### PR TITLE
Add Layer Create

### DIFF
--- a/api/web/src/components/Connection/ConnectionLayer.vue
+++ b/api/web/src/components/Connection/ConnectionLayer.vue
@@ -4,7 +4,7 @@
         <h2 class='card-title'>Layers</h2>
 
         <div class='ms-auto btn-list'>
-            <IconPlus v-tooltip='"Create Layer"' @click='$router.push("/layer/new")' size='32' class='cursor-pointer'/>
+            <IconPlus v-tooltip='"Create Layer"' @click='$router.push(`/connection/${this.$route.params.connectionid}/layer/new`)' size='32' class='cursor-pointer'/>
         </div>
     </div>
 

--- a/api/web/src/components/Data/DataLayer.vue
+++ b/api/web/src/components/Data/DataLayer.vue
@@ -4,7 +4,14 @@
         <h2 class='card-title'>Layers</h2>
 
         <div class='ms-auto btn-list'>
-            <IconPlus v-tooltip='"Create Layer"' @click='$router.push("/layer/new")' size='32' class='cursor-pointer'/>
+            <IconPlus
+                v-tooltip='"Create Layer"'
+                @click='$router.push(
+                    `/connection/${$route.params.connectionid}/data/${$route.params.dataid}/layer/new`
+                )'
+                size='32'
+                class='cursor-pointer'
+            />
         </div>
     </div>
 

--- a/api/web/src/components/LayerEdit.vue
+++ b/api/web/src/components/LayerEdit.vue
@@ -121,8 +121,6 @@
 import { std, stdurl } from '/src/std.ts';
 import PageFooter from './PageFooter.vue';
 import cronstrue from 'cronstrue';
-import ConnectionSelect from './util/ConnectionSelect.vue';
-import DataSelect from './util/DataSelect.vue';
 import {
     TablerBreadCrumb,
     TablerDelete,
@@ -131,8 +129,6 @@ import {
 } from '@tak-ps/vue-tabler';
 import {
     IconSettings,
-    IconBuildingBroadcastTower,
-    IconDatabase,
 } from '@tabler/icons-vue';
 import TaskModal from './Layer/utils/TaskModal.vue';
 
@@ -246,15 +242,11 @@ export default {
     },
     components: {
         PageFooter,
-        ConnectionSelect,
-        DataSelect,
         TablerBreadCrumb,
         TablerInput,
         TablerDelete,
         TablerLoading,
         IconSettings,
-        IconBuildingBroadcastTower,
-        IconDatabase,
         TaskModal,
     }
 }

--- a/api/web/src/components/LayerEdit.vue
+++ b/api/web/src/components/LayerEdit.vue
@@ -59,7 +59,12 @@
                                 </div>
                                 <template v-if='!$route.params.layerid'>
                                     <div class="col-md-6">
-                                        <TablerInput v-model='layer.cron' :error='errors.cron' placeholder='Cron Expression'>
+                                        <TablerInput
+                                            v-model='layer.cron'
+                                            :error='errors.cron'
+                                            label='Cron Expression'
+                                            placeholder='Cron Expression'
+                                        >
                                             <div class='dropdown'>
                                                 <div class="dropdown-toggle" type="button" id="dropdownCron" data-bs-toggle="dropdown" aria-expanded="false">
                                                     <IconSettings size='16' class='cursor-pointer dropdown-toggle'/>
@@ -77,39 +82,16 @@
                                     <div class="col-md-6">
                                         <div class='d-flex'>
                                         </div>
-                                        <TablerInput v-model='layer.task' :error='errors.task' placeholder='Schedule Task'>
+                                        <TablerInput
+                                            v-model='layer.task'
+                                            :error='errors.task'
+                                            label='Schedule Task'
+                                            placeholder='Schedule Task'
+                                        >
                                             <div class='ms-auto btn-list'>
                                                 <IconSettings @click='taskmodal = true' size='16' class='cursor-pointer'/>
                                             </div>
                                         </TablerInput>
-                                    </div>
-                                    <div class="col-md-12">
-                                        <div class='row'>
-                                            <div class='col-12'>
-                                                <label>Data Destination</label>
-                                            </div>
-                                            <div class='col-12 d-flex'>
-                                                <div class='btn-group' role="group">
-                                                    <input :disabled='disabled' v-model='destination' value='connection' type="radio" class="btn-check" name="connection-toolbar" id="connection-toolbar-connection" autocomplete="off">
-                                                    <label for="connection-toolbar-connection" class="btn btn-icon"><IconBuildingBroadcastTower size='32'/></label>
-
-                                                    <input :disabled='disabled' v-model='destination' value='data' type="radio" class="btn-check" name="connection-toolbar" id="connection-toolbar-data" autocomplete="off">
-                                                    <label for="connection-toolbar-data" class="btn btn-icon"><IconDatabase size='32'/></label>
-                                                </div>
-                                                <ConnectionSelect
-                                                    v-if='destination === "connection"'
-                                                    class='mx-2'
-                                                    :disabled='disabled'
-                                                    v-model='layer.connection'
-                                                />
-                                                <DataSelect
-                                                    v-else
-                                                    class='mx-2'
-                                                    :disabled='disabled'
-                                                    v-model='layer.data'
-                                                />
-                                            </div>
-                                        </div>
                                     </div>
                                 </template>
                                 <div class="col-lg-12 d-flex">
@@ -168,12 +150,11 @@ export default {
                 description: '',
             },
             taskmodal: false,
-            destination: 'connection',
             layer: {
                 name: '',
                 description: '',
-                data: null,
-                connection: null,
+                data: this.$route.params.dataid ? parseInt(this.$route.params.dataid) : undefined,
+                connection: this.$route.params.dataid ? undefined : parseInt(this.$route.params.connectionid),
                 cron: '',
                 task: '',
                 enabled: true,
@@ -216,10 +197,8 @@ export default {
             this.$router.push('/layer');
         },
         create: async function() {
-            let fields =  ['name', 'description']
-            if (!this.$route.params.connectionid) fields.push('task', 'cron');
-
-            for (const field of ['name', 'description']) {
+            let fields =  ['name', 'description', 'task', 'cron']
+            for (const field of fields) {
                 this.errors[field] = !this.layer[field] ? 'Cannot be empty' : '';
             }
             for (const e in this.errors) if (this.errors[e]) return;

--- a/api/web/src/main.js
+++ b/api/web/src/main.js
@@ -83,7 +83,9 @@ const router = new VueRouter.createRouter({
         },
 
         { path: '/layer', name: 'layers', component: () => import('./components/Layers.vue') },
-        { path: '/layer/new', name: 'layer-new', component: () => import('./components/LayerEdit.vue') },
+
+        { path: '/connection/:connectionid/layer/new', name: 'connection-layer-new', component: () => import('./components/LayerEdit.vue') },
+        { path: '/connection/:connectionid/data/:dataid/layer/new', name: 'connection-data-layer-new', component: () => import('./components/LayerEdit.vue') },
 
         {
             path: '/layer/:layerid',

--- a/api/web/src/stores/cots.ts
+++ b/api/web/src/stores/cots.ts
@@ -60,10 +60,9 @@ export const useCOTStore = defineStore('cots', {
                     type: 'FeatureCollection',
                     features:  Array.from(this.cots.values()).filter((cot) => {
                         if (profileStore.profile.display_stale === 'Immediate' && now.isAfter(cot.properties.stale)) {
-                            console.error('AFTER', cot.properties.stale);
                             return false;
                         } else if (!['Never', 'Immediate'].includes(profileStore.profile.display_stale)) {
-                            return now.isAfter(moment(cot.properties.stale).add(...profileStore.profile.display_stale.split(' ')))
+                            return now.isBefore(moment(cot.properties.stale).add(...profileStore.profile.display_stale.split(' ')))
                         }
 
                         return true;


### PR DESCRIPTION
### Context

When we create a layer we formerly had a dropdown list to allow the user to select a connection or data ID. We're getting enough layers and data sources that they don't fit in a single list. As everything is migrating to live under a single connection associated to an agency, they PR removes the Data/ConnectionID Selection and infers it automatically from the URL