### PR TITLE
Add Null Loc allowance

### DIFF
--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -36,10 +36,10 @@ export default async function router(schema: Schema, config: Config) {
             tak_callsign: Type.Optional(Type.String()),
             tak_group: Type.Optional(Type.Enum(TAKGroup)),
             tak_role: Type.Optional(Type.Enum(TAKRole)),
-            tak_loc: Type.Optional(Type.Object({
+            tak_loc: Type.Optional([Type.Null(), Type.Object({
                 type: Type.String(),
                 coordinates: Type.Array(Type.Number())
-            }))
+            })])
         }),
         res: ProfileResponse
     }, async (req, res) => {

--- a/api/routes/search.ts
+++ b/api/routes/search.ts
@@ -17,7 +17,7 @@ export default async function router(schema: Schema, config: Config) {
             longitude: Type.Number()
         }),
         res: Type.Object({
-            weather: FetchHourly
+            weather: Type.Union([FetchHourly, Type.Null()])
         })
     }, async (req, res) => {
         try {
@@ -26,7 +26,12 @@ export default async function router(schema: Schema, config: Config) {
                 weather: null
             };
 
-            response.weather = await weather.get(req.params.longitude, req.params.latitude);
+            try {
+                response.weather = await weather.get(req.params.longitude, req.params.latitude);
+            } catch (err) {
+                console.error('Weather Fetch Error', err)
+                response.weather = null;
+            }
     
             return res.json(response);
         } catch (err) {


### PR DESCRIPTION
### Context

If a user hasn't yet set a TAK Profile Location and attempts to update profile settings, the update fails as `tak_loc: null` is not allowed by the API.

This PR allows for `tak_loc` to be set to null