### PR TITLE
Remove Layer Button

### DIFF
--- a/api/web/src/components/Layers.vue
+++ b/api/web/src/components/Layers.vue
@@ -15,12 +15,6 @@
                                     >
                                         <IconSearch size='32' />
                                     </a>
-                                    <a
-                                        class='cursor-pointer btn btn-primary'
-                                        @click='$router.push("/layer/new")'
-                                    >
-                                        New Layer
-                                    </a>
                                 </div>
                             </div>
                         </div>
@@ -61,7 +55,7 @@
                         <TablerNone
                             v-if='!list.items.length'
                             label='Layers'
-                            @create='$router.push("/layer/new")'
+                            :create='false'
                         />
                         <template v-else>
                             <div


### PR DESCRIPTION
![image](https://github.com/dfpc-coe/CloudTAK/assets/1297009/a2b24930-8477-4f3e-9046-eb2d3a187a5d)

Layers are now strictly created from within a connection, remove the New Layer button from the layers page