### PR TITLE
LogStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Pending Release
 
+- :rocket: `API` Improve behavior if underlying LogStream isn't created or is missing
+- :rocket: `UI` Remove Create Layer buttons from non-connection page
+
 ### v1.11.0 - 2024-04-18
 
 - :rocket: `API` Add support for parsing `ackrequest` in CoT messages

--- a/api/lib/aws/lambda-logs.ts
+++ b/api/lib/aws/lambda-logs.ts
@@ -23,8 +23,9 @@ export default class LogGroup {
     }> {
         const cwl = new CloudWatchLogs.CloudWatchLogsClient({ region: process.env.AWS_DEFAULT_REGION });
 
+        let streams;
         try {
-            const streams = await cwl.send(new CloudWatchLogs.DescribeLogStreamsCommand({
+            streams = await cwl.send(new CloudWatchLogs.DescribeLogStreamsCommand({
                 limit: 1,
                 descending: true,
                 logGroupName: `/aws/lambda/${config.StackName}-layer-${layer.id}`,

--- a/api/lib/aws/lambda-logs.ts
+++ b/api/lib/aws/lambda-logs.ts
@@ -1,4 +1,5 @@
 import CloudWatchLogs from '@aws-sdk/client-cloudwatch-logs';
+import Err from '@openaddresses/batch-error';
 import Config from '../config.js';
 import process from 'node:process';
 
@@ -22,12 +23,20 @@ export default class LogGroup {
     }> {
         const cwl = new CloudWatchLogs.CloudWatchLogsClient({ region: process.env.AWS_DEFAULT_REGION });
 
-        const streams = await cwl.send(new CloudWatchLogs.DescribeLogStreamsCommand({
-            limit: 1,
-            descending: true,
-            logGroupName: `/aws/lambda/${config.StackName}-layer-${layer.id}`,
-            orderBy: 'LastEventTime'
-        }));
+        try {
+            const streams = await cwl.send(new CloudWatchLogs.DescribeLogStreamsCommand({
+                limit: 1,
+                descending: true,
+                logGroupName: `/aws/lambda/${config.StackName}-layer-${layer.id}`,
+                orderBy: 'LastEventTime'
+            }));
+        } catch (err) {
+            if (String(err).includes('ResourceNotFoundException')) {
+                return { logs: [] }
+            } else {
+                throw new Err(500, new Error(err instanceof Error ? err.message : String(err)), 'Failed to list lambda logs');
+            }
+        }
 
         if (!streams.logStreams || !streams.logStreams.length) {
             return { logs: [] }

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -170,7 +170,7 @@ export default {
                                 'sns:publish'
                             ],
                             Resource: [
-                                cf.join(['arn:', cf.partition, ':sns:', cf.region, ':', cf.accountId, ':coe-etl-prod-stack-events'])
+                                cf.join(['arn:', cf.partition, ':sns:', cf.region, ':', cf.accountId, ':', cf.stackName, '-*'])
                             ]
                         },{
                             Effect: 'Allow',


### PR DESCRIPTION
### Context

If AWS throws an error and doesn't create the LogStream for the Layer, the Stack currently locks up.
This PR introduces fault tolerance if the LogStream isn't created (or is deleted via the console) for any reason.