### PR TITLE
Human Readable Delete Errors

### DIFF
--- a/api/routes/connection.ts
+++ b/api/routes/connection.ts
@@ -258,7 +258,19 @@ export default async function router(schema: Schema, config: Config) {
         try {
             await Auth.is_auth(config, req);
 
+            if (await config.models.Layer.count({
+                where: sql`connection = ${req.params.connectionid}`
+            }) > 0) throw new Err(400, null, 'Connection has active Layers - Delete layers before deleting Connection');
+
+            if (await config.models.ConnectionSink.count({
+                where: sql`connection = ${req.params.connectionid}`
+            }) > 0) throw new Err(400, null, 'Connection has active Sinks - Delete Sinks before deleting Connection');
+
             await config.models.Connection.delete(req.params.connectionid);
+
+            await config.models.ConnectionToken.delete(sql`
+                connection = ${req.params.connectionid}
+            `);
 
             config.conns.delete(req.params.connectionid);
 

--- a/api/routes/connection.ts
+++ b/api/routes/connection.ts
@@ -1,5 +1,5 @@
 import Err from '@openaddresses/batch-error';
-import { sql, ilike, and, inArray } from 'drizzle-orm';
+import { sql, and, inArray } from 'drizzle-orm';
 import Config from '../lib/config.js';
 import CW from '../lib/aws/metric.js';
 import Auth, { AuthResourceAccess } from '../lib/auth.js';

--- a/api/routes/data.ts
+++ b/api/routes/data.ts
@@ -293,6 +293,10 @@ export default async function router(schema: Schema, config: Config) {
 
             const data = await config.models.Data.from(req.params.dataid);
 
+            if (await config.models.Layer.count({
+                where: sql`data = ${req.params.dataid}`
+            }) > 0) throw new Err(400, null, 'Data has active Layers - Delete layers before deleting Data Sync');
+
             await S3.del(`data-${String(req.params.dataid)}/`, { recurse: true });
 
             try {


### PR DESCRIPTION
### Context

If a database integrity rule is violated during deletion, a 5xx error is issued. This PR adds checks before deletion of common types that will generate a 4xx error with a human readable description of how to rectify the error

