### PR TITLE
Allow Editing Server Settings

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -102,15 +102,6 @@
                 "typescript-eslint": "^7.6.0"
             }
         },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@aws-crypto/crc32": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
@@ -237,15 +228,14 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/client-batch": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.556.0.tgz",
-            "integrity": "sha512-79Vw78+E+7DgA/VZ6fyA7rSbAu+tpdB8Hkq7mBq7DeIBl0o2PHT/YQLseNwaNvUlQLGnL1fmkDoDBuXJniki2w==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.564.0.tgz",
+            "integrity": "sha512-nzaIbkaStohvdo1HBFIRijjY4ToU2xn8hTuAyZmbt6gt5Ip0Wc8ir/IJQTTednl/zqA5tXnSvsHwPhmZP+qMAw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -287,15 +277,14 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.556.0.tgz",
-            "integrity": "sha512-qsqAZVFg1QQdS0lINII9xpZo6p5VcNqupnugxkqZ7BlzBGQaNuovlcLkWjBNM7rufRTxWThqPpRqc7/CAD4kvQ==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.564.0.tgz",
+            "integrity": "sha512-yO2Ac78rkMgTpF3OboHWklX9Ju4ut2EFEOOQqPb8DAgg5unhkh7063x6GPHPNJrmRWkJTr0HbVb8tdK5nExmJQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -339,15 +328,14 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.556.0.tgz",
-            "integrity": "sha512-ZaOzvfiskGMdeUglzvjvddXfl37NpzV5kGbn+C8mkM8HD4wg1hJoDw14pelz+j2JOfEaK/iwRirMxIv/z+OWgw==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.564.0.tgz",
+            "integrity": "sha512-mYvwsRPhk8UYqltFEB4WFtCpzXDbfpSTVn2igT934o7ZdwBTLOdmbHessQVCYVO3ME3FIl3ELodZ9h0VOl6sqg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -391,15 +379,14 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.556.0.tgz",
-            "integrity": "sha512-Z0glTNYh+KkjMFOwXhia2Q1IoyljcBA8O0vP0QGiqXBNliFHFoYYYWsMstkJt4fd15WdFG6+J7mhBw8OCGyLhA==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.564.0.tgz",
+            "integrity": "sha512-saG1GHILeu9rX3XMcZXuKG8Kmk9MkYXRb5AGwjpaZkF8jAAVHmW2mhHPtA+pwVHMucFueaTQiSNla8UxOOMUZQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -445,15 +432,14 @@
             }
         },
         "node_modules/@aws-sdk/client-dynamodb": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.556.0.tgz",
-            "integrity": "sha512-Msb/LxTbboX/v5HlR5zcMJ9JI61X83yI6pqsL85CcFrEuzAi+QqSmt84sT9sYU263RKkmo8Py4WazM7uIGs+mw==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.564.0.tgz",
+            "integrity": "sha512-2jz7nDEXvdHofxYQ16V2yFxKTeYwM+7o0RmM6KP2HCghTlRpS5L/TUw2fptqpxj+kx+nf2M7o85guJwLDbQu/g==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-endpoint-discovery": "3.535.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
@@ -498,15 +484,14 @@
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.556.0.tgz",
-            "integrity": "sha512-AGE2O77qwM6RPl3Szr0bqVRDYjsB+tT2NIvjRlVKtgBx9EVd2LoyqBSjYs3zjCS6w4NqI3KzRQYcm0U4YmnE9Q==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.564.0.tgz",
+            "integrity": "sha512-ljflgsamqGwG/c+OHU5lvsivq8FSLUrKTFJRexnAar6HJ+xj3Ju94eqG4rooBQReiH4FMFzY//bxd3tlg89rxQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -549,15 +534,14 @@
             }
         },
         "node_modules/@aws-sdk/client-eventbridge": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.556.0.tgz",
-            "integrity": "sha512-Rx3NaRpsMcUdNIOerb8yrmeMKkLOEuK80TYtr/uBWnCUgnwfl69yf7Z5unwvO/7ZswGy7HCN4L/JOtQAWWTQpw==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.564.0.tgz",
+            "integrity": "sha512-GAZIISWmMBHuWB7akHAy5E3+VsCTjCFVSEQq4kQAyBn8dSCb0XeNJCenar9LLp3tuvT+a5+ML/iMMnkx1S5MlQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -599,15 +583,14 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.556.0.tgz",
-            "integrity": "sha512-HrsdCySeoHA1WTxzOT42ct+Se71ncwRv+vJ3Le6NmUV9oRQ6h7Bw7OYliB5wadP8GHWV7egbbvR+Dy8SwuENvw==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.564.0.tgz",
+            "integrity": "sha512-2n7fNWrQroIRXoN0VucijYieM7bLMq8/l1pWkrYKdd8DG1lLPTKK57axRe6DEqaCguWOR63pHPEzNUgTf5CU+w==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -654,16 +637,15 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.556.0.tgz",
-            "integrity": "sha512-6WF9Kuzz1/8zqX8hKBpqj9+FYwQ5uTsVcOKpTW94AMX2qtIeVRlwlnNnYyywWo61yqD3g59CMNHcqSsaqAwglg==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.564.0.tgz",
+            "integrity": "sha512-QvTjjQWC7LB18X7BRvYK6Rc1oK1nToht4KOBR+zXmz4R1TEtMpyC9xgZzzVzp2aocXV1/WuDlg8Mvssx8UmUuQ==",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-bucket-endpoint": "3.535.0",
                 "@aws-sdk/middleware-expect-continue": "3.535.0",
                 "@aws-sdk/middleware-flexible-checksums": "3.535.0",
@@ -721,15 +703,14 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.556.0.tgz",
-            "integrity": "sha512-mTnoP3xAMb/uKVqomCr+Gvsu2UsT3cQr2ehpjiZwy/afaWxuF16dN76OBJAp3iK9/xf24i6smajzwS4z6rs+MA==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.564.0.tgz",
+            "integrity": "sha512-zkzi1cnGH6KGsjWaS45VITwnAHgrSuAjxsIHuu/zjR0Ikx5nr/Z9oFnOQKfwB68hLYxArV2CxPNlVyA8iYNAZA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -772,15 +753,14 @@
             }
         },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.556.0.tgz",
-            "integrity": "sha512-Lz6IsuznAkFgU2SYKAb0r0PxkvzQv53/IeqOi/k58jC0rWzOit362519lqJHJ9MNt28NeWrD8CYwYoGB1J4N+Q==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.564.0.tgz",
+            "integrity": "sha512-597lRdhqkS4xIwKnvrt7mB2cJzxBL7joJhLj0ZAo9MycK5MBhyaBsWU/1CGlZlWuuSRXtt6y/MBEJmdXSm5MPQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/credential-provider-node": "3.556.0",
+                "@aws-sdk/credential-provider-node": "3.564.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
                 "@aws-sdk/middleware-recursion-detection": "3.535.0",
@@ -872,13 +852,12 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.556.0.tgz",
-            "integrity": "sha512-AXKd2TB6nNrksu+OfmHl8uI07PdgzOo4o8AxoRO8SHlwoMAGvcT9optDGVSYoVfgOKTymCoE7h8/UoUfPc11wQ==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.564.0.tgz",
+            "integrity": "sha512-LWBXiwA0qlGhpJx3fbFQagVEyVPoecGtJh3+5hoc+CTVnT00J7T0jLe3kgemvEI9kjhIyDW+MFkq1jCttrGNJw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/core": "3.556.0",
                 "@aws-sdk/middleware-host-header": "3.535.0",
                 "@aws-sdk/middleware-logger": "3.535.0",
@@ -920,7 +899,7 @@
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/credential-provider-node": "^3.556.0"
+                "@aws-sdk/credential-provider-node": "^3.564.0"
             }
         },
         "node_modules/@aws-sdk/client-sts": {
@@ -1046,14 +1025,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.556.0.tgz",
-            "integrity": "sha512-0Nz4ErOlXhe3muxWYMbPwRMgfKmVbBp36BAE2uv/z5wTbfdBkcgUwaflEvlKCLUTdHzuZsQk+BFS/gVyaUeOuA==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.564.0.tgz",
+            "integrity": "sha512-kiEfBoKRcbX7I/rjhVGJrTUQ0895ANhPu6KE1GRZW7wc1gIGgKGJ+0tvAqRtQjYX0U9pivEDb0dh16OF9PBFFw==",
             "dependencies": {
                 "@aws-sdk/client-sts": "3.556.0",
                 "@aws-sdk/credential-provider-env": "3.535.0",
                 "@aws-sdk/credential-provider-process": "3.535.0",
-                "@aws-sdk/credential-provider-sso": "3.556.0",
+                "@aws-sdk/credential-provider-sso": "3.564.0",
                 "@aws-sdk/credential-provider-web-identity": "3.556.0",
                 "@aws-sdk/types": "3.535.0",
                 "@smithy/credential-provider-imds": "^2.3.0",
@@ -1067,15 +1046,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.556.0.tgz",
-            "integrity": "sha512-s1xVtKjyGc60O8qcNIzS1X3H+pWEwEfZ7TgNznVDNyuXvLrlNWiAcigPWGl2aAkc8tGcsSG0Qpyw2KYC939LFg==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.564.0.tgz",
+            "integrity": "sha512-HXD5ZCXzfcd6cJ/pW8frh8DuYlKaCd/JKmwzuCRUxgxZwbLEeNmyRYvF+D7osETJJZ4VIwgVbpEw1yLqRz1onw==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.535.0",
                 "@aws-sdk/credential-provider-http": "3.552.0",
-                "@aws-sdk/credential-provider-ini": "3.556.0",
+                "@aws-sdk/credential-provider-ini": "3.564.0",
                 "@aws-sdk/credential-provider-process": "3.535.0",
-                "@aws-sdk/credential-provider-sso": "3.556.0",
+                "@aws-sdk/credential-provider-sso": "3.564.0",
                 "@aws-sdk/credential-provider-web-identity": "3.556.0",
                 "@aws-sdk/types": "3.535.0",
                 "@smithy/credential-provider-imds": "^2.3.0",
@@ -1104,12 +1083,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.556.0.tgz",
-            "integrity": "sha512-ETuBgcnpfxqadEAqhQFWpKoV1C/NAgvs5CbBc5EJbelJ8f4prTdErIHjrRtVT8c02MXj92QwczsiNYd5IoOqyw==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.564.0.tgz",
+            "integrity": "sha512-Wv0NV8tDwtydEpsp/kVZ22Z+40bsSBDYgYZ1Uxx+KR8a1PvT6B5FnEtccWTJ371sQG/uqLum7dXSbJq1Qqze1w==",
             "dependencies": {
                 "@aws-sdk/client-sso": "3.556.0",
-                "@aws-sdk/token-providers": "3.556.0",
+                "@aws-sdk/token-providers": "3.564.0",
                 "@aws-sdk/types": "3.535.0",
                 "@smithy/property-provider": "^2.2.0",
                 "@smithy/shared-ini-file-loader": "^2.4.0",
@@ -1148,11 +1127,11 @@
             }
         },
         "node_modules/@aws-sdk/lib-dynamodb": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.556.0.tgz",
-            "integrity": "sha512-0CsNQyw7z5Fe4bj0oHnrZgz5grVLQI8OuMWUGxVgTeIL6a6kusWR4Ky7+RveAoiLCAYh3FIVvlqAiD4hJdIizQ==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.564.0.tgz",
+            "integrity": "sha512-GwsBb+jjeiFG5L7dwE2iFzE22+dC38Kd7BkfSxBZqi3pD5GFMzcKrel7gkETs5VZce3u1DPQmp31+xCweLZGZA==",
             "dependencies": {
-                "@aws-sdk/util-dynamodb": "3.556.0",
+                "@aws-sdk/util-dynamodb": "3.564.0",
                 "@smithy/smithy-client": "^2.5.1",
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
@@ -1165,9 +1144,9 @@
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.556.0.tgz",
-            "integrity": "sha512-55J1gQhl7Ovr39X1+K7EvS5230QA/JEFGOdK/BpMH54gXwnxwsgphngCMbpCz5fLQX0+u5QgJnC6GEHgFNKSAQ==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.564.0.tgz",
+            "integrity": "sha512-pn3WuzusrfXZw7i6U8y3Cr2TMPcL2C8GDF/VM8EwgXIWJr+jdLD2WNwEcOoMXndbEd9M9hMhEW5GKXucOTiPpw==",
             "dependencies": {
                 "@smithy/abort-controller": "^2.2.0",
                 "@smithy/middleware-endpoint": "^2.5.1",
@@ -1416,11 +1395,11 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.556.0.tgz",
-            "integrity": "sha512-tvIiugNF0/+2wfuImMrpKjXMx4nCnFWQjQvouObny+wrif/PGqqQYrybwxPJDvzbd965bu1I+QuSv85/ug7xsg==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.564.0.tgz",
+            "integrity": "sha512-Kk5ixcl9HjqwzfBJZGQAtsqwKa7Z8P7Mdug837BG8zCJbhf7wwNsmItzXTiAlpVrDZyT8P1yWIxsLOS1YUtmow==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.556.0",
+                "@aws-sdk/client-sso-oidc": "3.564.0",
                 "@aws-sdk/types": "3.535.0",
                 "@smithy/property-provider": "^2.2.0",
                 "@smithy/shared-ini-file-loader": "^2.4.0",
@@ -1455,9 +1434,9 @@
             }
         },
         "node_modules/@aws-sdk/util-dynamodb": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.556.0.tgz",
-            "integrity": "sha512-SF7bEPt8uCiklHkCvDQfGmAl6qADDd/sHHjcWS0zGYPesLkKSJDo/uKUjwuLxzkpHEp+xvB8BYrHFMIefb28AQ==",
+            "version": "3.564.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.564.0.tgz",
+            "integrity": "sha512-yJnIS+XZw84+R61T+4oRz8ojbAIoTSe62MsESketdq2n8DPiPsH1x4oUEJPA7tOst3eT4YfdAt2Cv67KWbUrNw==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -2445,9 +2424,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.11.0.tgz",
-            "integrity": "sha512-TLIJq9TMtD1NEG1mVoqNUn1Ita0qSaB5XboZErjFBcO/GJYXwWY4dVdTi9G0lbxtu0x+hJXDItcLaFHb7rlFTw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.11.1.tgz",
+            "integrity": "sha512-GW1Iomhmm1o4Z+X57xGby8A35Cu9UZLL7pSMdqDBkD99U5cywff8F+8hLk5aBTzNubnsFAvWQ/fZjNwPsEn9lA==",
             "engines": {
                 "node": ">=18.14.1"
             }
@@ -3111,17 +3090,17 @@
             }
         },
         "node_modules/@openaddresses/batch-error": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/@openaddresses/batch-error/-/batch-error-2.3.3.tgz",
-            "integrity": "sha512-eH5eMSRz08wdVr7iH89EzUpPuHe26CsmmuRy9vP4DK0dwtHYhErhwBtn3IhthbiCiW7KxuErXavSmHRxGMsVcw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@openaddresses/batch-error/-/batch-error-2.4.0.tgz",
+            "integrity": "sha512-RntQhHIRCQbS0U3g2K6Lbu3H6t+v6Cgv4eOtJ/JD5spNUpo+mdrlcDgWMr4+Ac6KEV42OLxACuDDn2kFZumzvQ==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@openaddresses/batch-generic": {
-            "version": "17.1.0",
-            "resolved": "https://registry.npmjs.org/@openaddresses/batch-generic/-/batch-generic-17.1.0.tgz",
-            "integrity": "sha512-/N5AmTyTKBvlpOumMHkweqf35zSgH3dh22RELfK1zPWaMQgy+9gsZS8haFco/UatVsvRzx2p26nZFDBZPNcmig==",
+            "version": "17.2.0",
+            "resolved": "https://registry.npmjs.org/@openaddresses/batch-generic/-/batch-generic-17.2.0.tgz",
+            "integrity": "sha512-0tw2BX+eGx/BGqA+hhd/5F3gKjzzsnXT7reDpjLh95VVEvh4CXVm7hfyLDMYur8psJgIYmo/M/i9pswXN3/+Fw==",
             "dependencies": {
                 "@openaddresses/batch-error": "^2.1.2",
                 "@turf/bbox": "^6.5.0",
@@ -3258,9 +3237,9 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.32.24",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.24.tgz",
-            "integrity": "sha512-2NhY+gf/fHvqYlWUAjuCI4+/esEVDicSIPLMFC98bZrqQ+YYpBc9YPOsAEosQNhu6AhVomlwn+yDe0UPzUYFTw=="
+            "version": "0.32.27",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.27.tgz",
+            "integrity": "sha512-JHRrubCKiXi6VKlbBTpTQnExkUFasPMIaXCJYJhqVBGLliQVt1yBZZgiZo3/uSmvAdXlIIdGoTAT6RB09L0QqA=="
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
@@ -8363,9 +8342,9 @@
             "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
         },
         "node_modules/hono": {
-            "version": "4.2.7",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.2.7.tgz",
-            "integrity": "sha512-k1xHi86tJnRIVvqhFMBDGFKJ8r5O+bEsT4P59ZK59r0F300Xd910/r237inVfuT/VmE86RQQffX4OYNda6dLXw==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.2.8.tgz",
+            "integrity": "sha512-re/zNrOWb7Sp9KhojlMEgcgvqsE8Rgk9IcmumqsbKa9ruPT5XuOcx1U+xuNaI4SUnwrPsiTQ72MiodtpJEVfjg==",
             "engines": {
                 "node": ">=16.0.0"
             }
@@ -9484,9 +9463,9 @@
             "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         },
         "node_modules/lru-cache": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
             "engines": {
                 "node": "14 || >=16.14"
             }
@@ -10246,17 +10225,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -12344,9 +12323,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.1.tgz",
-            "integrity": "sha512-6MNu1MYNALLFvcPpo2MJVJFIxz2rFkH+XoX+J72LBLdj4JLjVaP4lHmNHtJ/tXZUXHdsb2Iw9JhPlqspjkomQg=="
+            "version": "5.17.2",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.2.tgz",
+            "integrity": "sha512-V/NqUw6QoTrjSpctp2oLQvxrl3vW29UsUtZyq7B1CF0v870KOFbYGDQw8rpKaKm0JxTwHpWnW1SN9YuKZdiCyw=="
         },
         "node_modules/swagger-ui-express": {
             "version": "5.0.0",
@@ -13367,6 +13346,15 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -13483,9 +13471,9 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/ws": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+            "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/api/routes/config.ts
+++ b/api/routes/config.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import Schema from '@openaddresses/batch-schema';
+import { GenerateUpsert } from '@openaddresses/batch-generic';
 import Err from '@openaddresses/batch-error';
 import Auth from '../lib/auth.js';
 import Config from '../lib/config.js';
@@ -21,6 +22,38 @@ export default async function router(schema: Schema, config: Config) {
             (await Promise.allSettled((req.query.keys.split(',').map((key) => {
                 return config.models.Setting.from(key);
             })))).forEach((k) => {
+                if (k.status === 'rejected') return;
+                return final[k.value.key] = k.value.value;
+            });
+
+            return res.json(final);
+        } catch (err) {
+            return Err.respond(err, res);
+        }
+    });
+
+    await schema.put('/config', {
+        name: 'Update Config',
+        group: 'Config',
+        description: 'Update Config Key/Values',
+        body: Type.Object({
+            'agol::enabled': Type.Optional(Type.Boolean()),
+            'agol::token': Type.Optional(Type.String())
+        }),
+        res: Type.Any()
+    }, async (req, res) => {
+        try {
+            await Auth.as_user(config, req, { admin: true });
+
+            const final: Record<string, string> = {};
+            (await Promise.allSettled(Object.keys(req.body).map((key) => {
+                return config.models.Setting.generate({
+                    key: key,
+                    value: req.body[key]
+                },{
+                    upsert: GenerateUpsert.UPDATE
+                });
+            }))).forEach((k) => {
                 if (k.status === 'rejected') return;
                 return final[k.value.key] = k.value.value;
             });

--- a/api/web/src/components/Admin/AdminConfig.vue
+++ b/api/web/src/components/Admin/AdminConfig.vue
@@ -7,7 +7,7 @@
             <div class='ms-auto'>
                 <div class='btn-list'>
                     <IconSettings
-                        v-if='false'
+                        v-if='!edit'
                         v-tooltip='"Configure Server"'
                         size='32'
                         class='cursor-pointer'
@@ -18,14 +18,22 @@
         </div>
         <div class="card-body row">
             <div class='col-lg-12 py-2'>
-                <TablerInput
-                    v-model='config.esri_token'
+                <TablerToggle
+                    v-model='config["agol::enabled"]'
                     :disabled='!edit'
-                    label='ESRI AGOL Token'
+                    label='ArcGIS Online Enabled'
+                />
+                <TablerInput
+                    v-model='config["agol::token"]'
+                    :disabled='!edit'
+                    label='ArcGIS Online API Token'
                 />
             </div>
 
             <div v-if='edit' class='col-lg-12 d-flex py-2'>
+                <div @click='fetch' class='btn'>
+                    Cancel
+                </div>
                 <div class='ms-auto'>
                     <div @click='postConfig' class='btn btn-primary'>
                         Save Settings
@@ -41,6 +49,7 @@
 import { std, stdurl } from '/src/std.ts';
 import {
     TablerLoading,
+    TablerToggle,
     TablerInput
 } from '@tak-ps/vue-tabler';
 import {
@@ -57,8 +66,8 @@ export default {
             edit: false,
             loading: true,
             config: {
-                enabled_esri: false,
-                esri_token: ''
+                'agol::enabled': false,
+                'agol::token': ''
             }
         }
     },
@@ -70,6 +79,7 @@ export default {
             return timeDiff(updated);
         },
         fetch: async function() {
+            this.edit = false;
             this.loading = true;
             const url = stdurl('/api/config')
             url.searchParams.append('keys', Object.keys(this.config).join(','));
@@ -80,7 +90,7 @@ export default {
             }
             this.loading = false;
         },
-        postServer: async function() {
+        postConfig: async function() {
             this.loading = true;
             await std(`/api/config`, {
                 method: 'PUT',
@@ -94,6 +104,7 @@ export default {
     components: {
         IconSettings,
         TablerLoading,
+        TablerToggle,
         TablerInput,
         IconLock,
         IconPlus,


### PR DESCRIPTION
### Context

We need a fairly flexible location for non-critical settings in the ETL Server that aren't directly 1:1 related to the TAK Server

This builds upon the `settings` table by allowing `PUT` requests to updating pre-defined keys in the the table

Immediately: this will allow enabling & storing an AGOL token for a subsequent PR to enable a User Input box on the map interface for Geocoding

![image](https://github.com/dfpc-coe/CloudTAK/assets/1297009/90c509c4-a113-41c8-8dce-d9c7f968061a)
