### PR TITLE
Remove AuthGroup

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -122,12 +122,6 @@ export default async function server(config: Config) {
                 }, config.SigningSecret)
             });
         });
-
-        app.get('/Marti/api/groups/all', (req: Request, res: Response) => {
-            return res.json({
-                data: [{ name: config.AuthGroup}]
-            });
-        });
     }
 
     await schema.load(

--- a/api/lib/config.ts
+++ b/api/lib/config.ts
@@ -38,7 +38,6 @@ export default class Config {
     external: External;
     UnsafeSigningSecret: string;
     MartiAPI: string;
-    AuthGroup: string;
     API_URL: string;
     PMTILES_URL: string;
     TileBaseURL: URL;
@@ -73,7 +72,6 @@ export default class Config {
         pg: Pool<typeof pgtypes>;
         server: InferSelectModel<typeof Server>;
         MartiAPI: string;
-        AuthGroup: string;
         DynamoDB?: string;
         Bucket?: string;
         HookURL?: string;
@@ -95,7 +93,6 @@ export default class Config {
         this.wsClients = init.wsClients;
         this.pg = init.pg;
         this.MartiAPI = init.MartiAPI;
-        this.AuthGroup = init.AuthGroup;
         this.DynamoDB = init.DynamoDB;
         this.Bucket = init.Bucket;
         this.server = init.server;
@@ -165,7 +162,6 @@ export default class Config {
             TileBaseURL: process.env.TileBaseURL ? new URL(process.env.TileBaseURL) : new URL('./data-dev/zipcodes.tilebase', import.meta.url),
             PMTILES_URL: process.env.PMTILES_URL || 'http://localhost:5001',
             MartiAPI: process.env.MartiAPI,
-            AuthGroup: process.env.AuthGroup,
             StackName: process.env.StackName,
             wsClients: new Map(),
             server, SigningSecret, API_URL, DynamoDB, Bucket, pg, models, HookURL

--- a/api/lib/models.ts
+++ b/api/lib/models.ts
@@ -22,6 +22,7 @@ export default class Models {
 
     Profile: Modeler<typeof pgtypes.Profile>;
     ProfileChat: ProfileChat;
+    ProfileFeature: Modeler<typeof pgtypes.ProfileFeature>;
     ProfileOverlay: Modeler<typeof pgtypes.ProfileOverlay>;
     ProfileMission: Modeler<typeof pgtypes.ProfileMission>;
 
@@ -40,6 +41,7 @@ export default class Models {
         this.Overlay = new Modeler(pg, pgtypes.Overlay);
         this.Server = new Modeler(pg, pgtypes.Server);
         this.Profile = new Modeler(pg, pgtypes.Profile);
+        this.ProfileFeature = new Modeler(pg, pgtypes.ProfileFeature);
         this.ProfileOverlay = new Modeler(pg, pgtypes.ProfileOverlay);
         this.ProfileMission = new Modeler(pg, pgtypes.ProfileMission);
         this.Basemap = new Modeler(pg, pgtypes.Basemap);

--- a/api/lib/provider.ts
+++ b/api/lib/provider.ts
@@ -48,35 +48,6 @@ export default class AuthProvider {
             throw new Err(500, new Error(body.error_description), 'Unknown Login Error');
         }
 
-        if (this.config.AuthGroup) {
-            const url = new URL('/Marti/api/groups/all?useCache=true', this.config.local ? 'http://localhost:5001' : this.config.MartiAPI);
-
-            const groupres = await fetch(url, {
-                credentials: 'include',
-                dispatcher: agent
-            });
-
-            if (!groupres.ok) {
-                throw new Err(500, new Error(`Status: ${groupres.status}: ${await groupres.text()}`), 'Non-200 Response from Auth Server - Groups');
-            }
-
-            const gbody: {
-                data: Array<{
-                    name: string;
-                }>
-            } = await groupres.json() as any;
-
-            const groups = gbody.data.map((d: {
-                name: string
-            }) => {
-                return d.name
-            });
-
-            if (!groups.includes(this.config.AuthGroup)) {
-                throw new Err(403, null, 'Insufficient Group Privileges');
-            }
-        }
-
         const split = Buffer.from(body.access_token, 'base64').toString().split('}').map((ext) => { return ext + '}'});
         if (split.length < 2) throw new Err(500, null, 'Unexpected TAK JWT Format');
         const contents: { sub: string; aud: string; nbf: number; exp: number; iat: number; } = JSON.parse(split[1]);

--- a/api/lib/schema.ts
+++ b/api/lib/schema.ts
@@ -53,6 +53,7 @@ export const ProfileChat = pgTable('profile_chats', {
 
 export const ProfileFeature = pgTable('profile_features', {
     uid: text('id').primaryKey(),
+    username: text('username').notNull().references(() => Profile.username),
     properties: json('properties').notNull().default({}),
     geometry: geometry('geometry', { type: GeometryType.Geometry, srid: 4326 })
 });

--- a/api/lib/schema.ts
+++ b/api/lib/schema.ts
@@ -55,7 +55,7 @@ export const ProfileFeature = pgTable('profile_features', {
     uid: text('id').primaryKey(),
     username: text('username').notNull().references(() => Profile.username),
     properties: json('properties').notNull().default({}),
-    geometry: geometry('geometry', { type: GeometryType.Geometry, srid: 4326 })
+    geometry: geometry('geometry', { type: GeometryType.Geometry, srid: 4326 }).notNull()
 });
 
 export const Basemap = pgTable('basemaps', {

--- a/api/lib/schema.ts
+++ b/api/lib/schema.ts
@@ -51,6 +51,12 @@ export const ProfileChat = pgTable('profile_chats', {
     message: text('message').notNull()
 });
 
+export const ProfileFeature = pgTable('profile_features', {
+    uid: text('id').primaryKey(),
+    properties: json('properties').notNull().default({}),
+    geometry: geometry('geometry', { type: GeometryType.Geometry, srid: 4326 })
+});
+
 export const Basemap = pgTable('basemaps', {
     id: serial('id').primaryKey(),
     created: timestamp('created', { withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),

--- a/api/migrations/0038_tan_hiroim.sql
+++ b/api/migrations/0038_tan_hiroim.sql
@@ -1,12 +1,6 @@
 CREATE TABLE IF NOT EXISTS "profile_features" (
 	"id" text PRIMARY KEY NOT NULL,
-	"username" text NOT NULL,
+	"username" text NOT NULL REFERENCES profile(username),
 	"properties" json DEFAULT '{}'::json NOT NULL,
-	"geometry" "GEOMETRY(GEOMETRY, 4326)"
+	"geometry" GEOMETRY(GEOMETRY, 4326) NOT NULL
 );
---> statement-breakpoint
-DO $$ BEGIN
- ALTER TABLE "profile_features" ADD CONSTRAINT "profile_features_username_profile_username_fk" FOREIGN KEY ("username") REFERENCES "profile"("username") ON DELETE no action ON UPDATE no action;
-EXCEPTION
- WHEN duplicate_object THEN null;
-END $$;

--- a/api/migrations/0038_tan_hiroim.sql
+++ b/api/migrations/0038_tan_hiroim.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "profile_features" (
+	"id" text PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"properties" json DEFAULT '{}'::json NOT NULL,
+	"geometry" "GEOMETRY(GEOMETRY, 4326)"
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "profile_features" ADD CONSTRAINT "profile_features_username_profile_username_fk" FOREIGN KEY ("username") REFERENCES "profile"("username") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/api/migrations/meta/0038_snapshot.json
+++ b/api/migrations/meta/0038_snapshot.json
@@ -1,0 +1,1636 @@
+{
+  "id": "cf7c4442-abc5-46d9-86da-720eb03e4eb4",
+  "prevId": "1fd68060-15d8-4a54-9148-23c72a37a4dd",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "basemaps": {
+      "name": "basemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minzoom": {
+          "name": "minzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxzoom": {
+          "name": "maxzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 16
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'png'"
+        },
+        "style": {
+          "name": "style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zxy'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raster'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_username_profile_username_fk": {
+          "name": "basemaps_username_profile_username_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "connection_sinks": {
+      "name": "connection_sinks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "logging": {
+          "name": "logging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_sinks_connection_connections_id_fk": {
+          "name": "connection_sinks_connection_connections_id_fk",
+          "tableFrom": "connection_sinks",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "connection_tokens": {
+      "name": "connection_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_tokens_connection_connections_id_fk": {
+          "name": "connection_tokens_connection_connections_id_fk",
+          "tableFrom": "connection_tokens",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "data": {
+      "name": "data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "auto_transform": {
+          "name": "auto_transform",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_sync": {
+          "name": "mission_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_diff": {
+          "name": "mission_diff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_role": {
+          "name": "mission_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MISSION_SUBSCRIBER'"
+        },
+        "mission_token": {
+          "name": "mission_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission_groups": {
+          "name": "mission_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": []
+        },
+        "assets": {
+          "name": "assets",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::json"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "data_connection_connections_id_fk": {
+          "name": "data_connection_connections_id_fk",
+          "tableFrom": "data",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "icons": {
+      "name": "icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type2525b": {
+          "name": "type2525b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "icons_iconset_iconsets_uid_fk": {
+          "name": "icons_iconset_iconsets_uid_fk",
+          "tableFrom": "icons",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "iconsets": {
+      "name": "iconsets",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_friendly": {
+          "name": "default_friendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hostile": {
+          "name": "default_hostile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_neutral": {
+          "name": "default_neutral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_unknown": {
+          "name": "default_unknown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_resize": {
+          "name": "skip_resize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "iconsets_username_profile_username_fk": {
+          "name": "iconsets_username_profile_username_fk",
+          "tableFrom": "iconsets",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "imports": {
+      "name": "imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "imports_username_profile_username_fk": {
+          "name": "imports_username_profile_username_fk",
+          "tableFrom": "imports",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "layers": {
+      "name": "layers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enabled_styles": {
+          "name": "enabled_styles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "logging": {
+          "name": "logging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20000
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "memory": {
+          "name": "memory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 128
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 128
+        },
+        "data": {
+          "name": "data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_connection_connections_id_fk": {
+          "name": "layers_connection_connections_id_fk",
+          "tableFrom": "layers",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_data_data_id_fk": {
+          "name": "layers_data_data_id_fk",
+          "tableFrom": "layers",
+          "tableTo": "data",
+          "columnsFrom": [
+            "data"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "layer_alerts": {
+      "name": "layer_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alert-circle'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yellow'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Details Unknown'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layer_alerts_layer_layers_id_fk": {
+          "name": "layer_alerts_layer_layers_id_fk",
+          "tableFrom": "layer_alerts",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "overlays": {
+      "name": "overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vector'"
+        },
+        "styles": {
+          "name": "styles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Unknown'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tak_callsign": {
+          "name": "tak_callsign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CloudTAK User'"
+        },
+        "tak_group": {
+          "name": "tak_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Orange'"
+        },
+        "tak_role": {
+          "name": "tak_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Team Member'"
+        },
+        "tak_loc": {
+          "name": "tak_loc",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_stale": {
+          "name": "display_stale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'10 Minutes'"
+        },
+        "display_distance": {
+          "name": "display_distance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mile'"
+        },
+        "display_elevation": {
+          "name": "display_elevation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feet'"
+        },
+        "display_speed": {
+          "name": "display_speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mi/h'"
+        },
+        "system_admin": {
+          "name": "system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency_admin": {
+          "name": "agency_admin",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile_chats": {
+      "name": "profile_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatroom": {
+          "name": "chatroom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_callsign": {
+          "name": "sender_callsign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_uid": {
+          "name": "sender_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chats_username_profile_username_fk": {
+          "name": "profile_chats_username_profile_username_fk",
+          "tableFrom": "profile_chats",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile_features": {
+      "name": "profile_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRY, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_features_username_profile_username_fk": {
+          "name": "profile_features_username_profile_username_fk",
+          "tableFrom": "profile_features",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile_missions": {
+      "name": "profile_missions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "profile_overlays": {
+      "name": "profile_overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "pos": {
+          "name": "pos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "styles": {
+          "name": "styles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_overlays_username_profile_username_fk": {
+          "name": "profile_overlays_username_profile_username_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_overlays_username_url_unique": {
+          "name": "profile_overlays_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "url"
+          ]
+        }
+      }
+    },
+    "server": {
+      "name": "server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_secret": {
+          "name": "provider_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_client": {
+          "name": "provider_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "spatial_ref_sys": {
+      "name": "spatial_ref_sys",
+      "schema": "",
+      "columns": {
+        "srid": {
+          "name": "srid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_name": {
+          "name": "auth_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_srid": {
+          "name": "auth_srid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "srtext": {
+          "name": "srtext",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proj4text": {
+          "name": "proj4text",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1714786844578,
       "tag": "0037_great_longshot",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "5",
+      "when": 1714827806956,
+      "tag": "0038_tan_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -230,23 +230,25 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/client-batch": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.567.0.tgz",
-            "integrity": "sha512-eH+S8XcuM8Tps73DI/Mt2zm8hOTeAONZs3aKqIEsoE2AptR/b3s8eUXRqgUiTta9z0WqJICiIB4iutHRDMj9MA==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.569.0.tgz",
+            "integrity": "sha512-tk/E7qpwv9yoOxMZasoIhTtbQgwk/UKLjQ3pl4b50dI+mLIglPbDcu/NE0ajhIVMcZwO8SlTEFktPi9YAHGC2w==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -279,23 +281,25 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.567.0.tgz",
-            "integrity": "sha512-+Fk2Q3u5QxerslDsit2RgXO+KruWjwL23vm1WjqBW1tBR4Gj792GF2Ju0rOkGrB59azVOUriZouyzWhNJWoetw==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.569.0.tgz",
+            "integrity": "sha512-fO/CaiCZdvVCEWeBCa2EvefLveyFf/Cl3AT28vdpGh19ER9qqs4K63V2twgOGA7BKaVl/cX9zHz0tHoO4Fb83Q==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -330,23 +334,25 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.567.0.tgz",
-            "integrity": "sha512-GrQBt4uC+nY8uqm6Mk/q/j45W1z2N7kAkPzHrA7wUhoj1i9aPQJ+yfMsu16zvqGJ3eILQZMRAkb4IQ4NVUXfBw==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.569.0.tgz",
+            "integrity": "sha512-PwuOcIplW2hX5a8uAlwjQiISmn5MBiRH0fPeroWpE8xdLw/e20wPwVIC2xownvZL3/CeSbjDYfsOVFmfQZNJSQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -381,23 +387,25 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.567.0.tgz",
-            "integrity": "sha512-l4GzuVXlW0V4hdovN8+0vTnX/9zSLXqvPJVyGYH36m4hkANyzfrU6E2a3T4CZJO4i4y0T3+3gV/NjA99wV2B8g==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.569.0.tgz",
+            "integrity": "sha512-tYmDuLJCFvuYsVbao1EnGuLk7I2reFK4Wz1O8K7Pf72i2YB9uZoFE2h3OeKnniBKtHKEoCy0LDx7IjToqlX3Nw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/eventstream-serde-browser": "^2.2.0",
@@ -434,24 +442,26 @@
             }
         },
         "node_modules/@aws-sdk/client-dynamodb": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.567.0.tgz",
-            "integrity": "sha512-agIYp3G6gtRuxd1vT170C5rlUBhCNvxZ3rX1LZE0OYnbEVsMI297wWeZUF07zQ/B5sryPtrJ6NoDU8AKuADFGg==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.569.0.tgz",
+            "integrity": "sha512-o3Nh9826AzYgqGhKdII9ymMRxNJ1doIrvohv3wW1UjquVQLI3aquVRAU9SavVhwgRrv3LcG3nzEtlea5hKuppA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
-                "@aws-sdk/middleware-endpoint-discovery": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
+                "@aws-sdk/middleware-endpoint-discovery": "3.568.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -486,16 +496,18 @@
             }
         },
         "node_modules/@aws-sdk/client-ec2": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.567.0.tgz",
-            "integrity": "sha512-R1EoWKJZLRbtaUKzFjypaUPOV18lzl0Yjxmxi1wgNKgsDO8zKBI05MU5lqwoYy68aCvQ8qvzGudGsBULYCkzsg==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.569.0.tgz",
+            "integrity": "sha512-DpMCfXvvsLXCb1EWBpB66hEvJri5Zyux5cpkQAvw8R//xSLWdwMGALFWNrw2Z+/sXPBwvQrxhv1RQq+6CuFocw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-sdk-ec2": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
@@ -503,7 +515,7 @@
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -538,23 +550,25 @@
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.567.0.tgz",
-            "integrity": "sha512-3LQDIwgbSkjwPwMDqo2Tay4FZ0Tg1U8duL33krCtsp1uln+OOSfOOZrypCOYVHVHKf+vK4Zir2ykr0IyfrzDJw==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.569.0.tgz",
+            "integrity": "sha512-dTvTyviHPNQwYe9K0Qf/J1Tym6lssoglZxdsgUp4Q9o519Huol6oI2RfspU7sEH/fsQSGBVUiustb38wOEoDCA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -588,24 +602,26 @@
             }
         },
         "node_modules/@aws-sdk/client-ecs": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.567.0.tgz",
-            "integrity": "sha512-URX54y4vKIYEOfYKgNRcn3OGrVazSHFNFsgNkVZ5lTDySx4kOxOjKSSzAUmR7fmOxhfYiKB9leHARkojJ9jf2Q==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.569.0.tgz",
+            "integrity": "sha512-rq9U7BWuaMDIsen/6G5fvVM3CAob27HFbJ0iTrQ3U97/pMww0xI2gZPpKSSq+k0n3rHY9zvvj4Xc2y1KHGjdpg==",
             "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -640,25 +656,27 @@
             }
         },
         "node_modules/@aws-sdk/client-eventbridge": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.567.0.tgz",
-            "integrity": "sha512-DHKNkoNqoSBF6ccXu7zGo890kZOKN9biQ5XZ6qR9exMIe/2IKUnoGhhWF261NSZPG3fieNDW7C0aHR6VvLXhKA==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.569.0.tgz",
+            "integrity": "sha512-g3ViBZm4oSVO0UrhoT4dOMpkI7ne3J0U3EsQW8F0FqPbRhrAEPsW43MNZgrvoR45eMF5GqmbpXqC16hphTOhaw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-signing": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
-                "@aws-sdk/signature-v4-multi-region": "3.567.0",
+                "@aws-sdk/signature-v4-multi-region": "3.569.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/fetch-http-handler": "^2.5.0",
                 "@smithy/hash-node": "^2.2.0",
@@ -689,23 +707,25 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.567.0.tgz",
-            "integrity": "sha512-fFOcfFkTqxYXWuM1M+HC3f62WcFrrtThsXereNVr4tN1YoRDt/chX4J31wWIAajqWUnSkuCcCbSG+DaPSymkug==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.569.0.tgz",
+            "integrity": "sha512-yevp+Wfppt9tgDgbIp8r4jp4EjUaEL8Tb0p//wwwNV/nKET2e0sIKgFSht/4Zy/sn3xIlY341yEvrI8OQjb9BQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/eventstream-serde-browser": "^2.2.0",
@@ -743,32 +763,34 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.567.0.tgz",
-            "integrity": "sha512-P1KIhubdsv44A8mACYwBzNlBjW/WRpkZMGCDhwapV18Xo/v97hsLdg8FU2KiSIGN5/O4DXJcev8v4baGhjk5nw==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.569.0.tgz",
+            "integrity": "sha512-J+iE1t++9RsqKUidGL/9sOS/NhO7SZBJQGDZq2MilO7pHqo6l2tPUv+hNnIPmmO2D+jfktj/s2Uugxs6xQmv2A==",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.568.0",
                 "@aws-sdk/middleware-expect-continue": "3.567.0",
                 "@aws-sdk/middleware-flexible-checksums": "3.567.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
                 "@aws-sdk/middleware-location-constraint": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
-                "@aws-sdk/middleware-sdk-s3": "3.567.0",
+                "@aws-sdk/middleware-sdk-s3": "3.569.0",
                 "@aws-sdk/middleware-signing": "3.567.0",
                 "@aws-sdk/middleware-ssec": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
-                "@aws-sdk/signature-v4-multi-region": "3.567.0",
+                "@aws-sdk/signature-v4-multi-region": "3.569.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@aws-sdk/xml-builder": "3.567.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
@@ -809,23 +831,25 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.567.0.tgz",
-            "integrity": "sha512-2AfJJL7Lja9PU/PMZXkNJ8OkU2OiayUH68LMVvKoT/bImiGt2EYj+S61rveYML2sSKnoIevS+1hHo0SzzVcUlQ==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.569.0.tgz",
+            "integrity": "sha512-i3fNFKO+q1KguPcAQuqXCQccb941oyMHR8K53RtoFhPZNqe3TLhdjYNACI5i80zRX+SejiITIKrtmDaQt2XYRA==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -859,24 +883,26 @@
             }
         },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.567.0.tgz",
-            "integrity": "sha512-0S8LcsMYDm4At8CGL+KbzH8411J0zaoMJ9+bvYsN43BMrAt5/90KmmnSzwnCAqjQgpYW6N/5ZIhgR3+TvFHq/g==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.569.0.tgz",
+            "integrity": "sha512-9w2vIFm91J1M9iAcdmvXJ1h2XN+7sCekNvLol3RF8ZG9+kiS9vivFLZ2vSYVSRWlj2oh+BQ9f1Pir32uD3W7CQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
-                "@aws-sdk/middleware-sdk-sqs": "3.567.0",
+                "@aws-sdk/middleware-sdk-sqs": "3.569.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -910,22 +936,22 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.567.0.tgz",
-            "integrity": "sha512-jcnT1m+altt9Xm2QErZBnETh+4ioeCb/p9bo0adLb9JCAuI/VcnIui5+CykvCzOAxQ8c8Soa19qycqCuUcjiCw==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.568.0.tgz",
+            "integrity": "sha512-LSD7k0ZBQNWouTN5dYpUkeestoQ+r5u6cp6o+FATKeiFQET85RNA3xJ4WPnOI5rBC1PETKhQXvF44863P3hCaQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
                 "@aws-sdk/core": "3.567.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -958,24 +984,24 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.567.0.tgz",
-            "integrity": "sha512-evLQINTzVbjWCaVTMIkn9FqCkAusjA65kDWkHgGdrwMeqEneqhuWl9uZMhl8x6AJ/fV4H3td8MBM2QRWB4Ttng==",
-            "peer": true,
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.569.0.tgz",
+            "integrity": "sha512-u5DEjNEvRvlKKh1QLCDuQ8GIrx+OFvJFLfhorsp4oCxDylvORs+KfyKKnJAw4wYEEHyxyz9GzHD7p6a8+HLVHw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -1008,23 +1034,24 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.567.0.tgz",
-            "integrity": "sha512-Hsbj/iJJZbajdYRja4MiqK7chaXim+cltaIslqjhTFCHlOct88qQRUAz2GHzNkyIH9glubLdwHqQZ+QmCf+4Vw==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.569.0.tgz",
+            "integrity": "sha512-3AyipQ2zHszkcTr8n1Sp7CiMUi28aMf1vOhEo0KKi0DWGo1Z1qJEpWeRP363KG0n9/8U3p1IkXGz5FRbpXZxIw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.569.0",
                 "@aws-sdk/core": "3.567.0",
-                "@aws-sdk/credential-provider-node": "3.567.0",
+                "@aws-sdk/credential-provider-node": "3.569.0",
                 "@aws-sdk/middleware-host-header": "3.567.0",
-                "@aws-sdk/middleware-logger": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
                 "@aws-sdk/middleware-recursion-detection": "3.567.0",
                 "@aws-sdk/middleware-user-agent": "3.567.0",
                 "@aws-sdk/region-config-resolver": "3.567.0",
                 "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-endpoints": "3.567.0",
                 "@aws-sdk/util-user-agent-browser": "3.567.0",
-                "@aws-sdk/util-user-agent-node": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/core": "^1.4.2",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -1095,9 +1122,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.567.0.tgz",
-            "integrity": "sha512-2V9O9m/hrWtIBKfg+nYHTYUHSKOZdSWL53JRaN28zYoX4dPDWwP1GacP/Mq6LJhKRnByfmqh3W3ZBsKizauSug==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+            "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
@@ -1109,9 +1136,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.567.0.tgz",
-            "integrity": "sha512-MVSFmKo9ukxNyMYOk/u6gupGqktsbTZWh2uyULp0KLhuHPDTvWLmk96+6h6V2+GAp/J2QRK72l0EtjnHmcn3kg==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.568.0.tgz",
+            "integrity": "sha512-gL0NlyI2eW17hnCrh45hZV+qjtBquB+Bckiip9R6DIVRKqYcoILyiFhuOgf2bXeF23gVh6j18pvUvIoTaFWs5w==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/fetch-http-handler": "^2.5.0",
@@ -1128,14 +1155,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.567.0.tgz",
-            "integrity": "sha512-azbZ3jYZmSD3oCzbjPOrI+pilRDV6H9qtJ3J4MCnbRYQxR8eu80l4Y0tXl0+GfHZCpdOJ9+uEhqU+yTiVrrOXg==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.568.0.tgz",
+            "integrity": "sha512-m5DUN9mpto5DhEvo6w3+8SS6q932ja37rTNvpPqWJIaWhj7OorAwVirSaJQAQB/M8+XCUIrUonxytphZB28qGQ==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.567.0",
-                "@aws-sdk/credential-provider-process": "3.567.0",
-                "@aws-sdk/credential-provider-sso": "3.567.0",
-                "@aws-sdk/credential-provider-web-identity": "3.567.0",
+                "@aws-sdk/credential-provider-env": "3.568.0",
+                "@aws-sdk/credential-provider-process": "3.568.0",
+                "@aws-sdk/credential-provider-sso": "3.568.0",
+                "@aws-sdk/credential-provider-web-identity": "3.568.0",
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/credential-provider-imds": "^2.3.0",
                 "@smithy/property-provider": "^2.2.0",
@@ -1147,20 +1174,20 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.567.0"
+                "@aws-sdk/client-sts": "^3.568.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.567.0.tgz",
-            "integrity": "sha512-/kwYs2URdcXjKCPClUYrvdhhh7oRh1PWC0mehzy92c0I8hMdhIIpOmwJj8IoRIWdsCnPRatWBJBuE553y+HaUQ==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.569.0.tgz",
+            "integrity": "sha512-7jH4X2qlPU3PszZP1zvHJorhLARbU1tXvp8ngBe8ArXBrkFpl/dQ2Y/IRAICPm/pyC1IEt8L/CvKp+dz7v/eRw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.567.0",
-                "@aws-sdk/credential-provider-http": "3.567.0",
-                "@aws-sdk/credential-provider-ini": "3.567.0",
-                "@aws-sdk/credential-provider-process": "3.567.0",
-                "@aws-sdk/credential-provider-sso": "3.567.0",
-                "@aws-sdk/credential-provider-web-identity": "3.567.0",
+                "@aws-sdk/credential-provider-env": "3.568.0",
+                "@aws-sdk/credential-provider-http": "3.568.0",
+                "@aws-sdk/credential-provider-ini": "3.568.0",
+                "@aws-sdk/credential-provider-process": "3.568.0",
+                "@aws-sdk/credential-provider-sso": "3.568.0",
+                "@aws-sdk/credential-provider-web-identity": "3.568.0",
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/credential-provider-imds": "^2.3.0",
                 "@smithy/property-provider": "^2.2.0",
@@ -1173,9 +1200,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.567.0.tgz",
-            "integrity": "sha512-Bsp1bj8bnsvdLec9aXpBsHMlwCmO9TmRrZYyji7ZEUB003ZkxIgbqhe6TEKByrJd53KHfgeF+U4mWZAgBHDXfQ==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.568.0.tgz",
+            "integrity": "sha512-r01zbXbanP17D+bQUb7mD8Iu2SuayrrYZ0Slgvx32qgz47msocV9EPCSwI4Hkw2ZtEPCeLQR4XCqFJB1D9P50w==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
@@ -1188,12 +1215,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.567.0.tgz",
-            "integrity": "sha512-7TjvMiMsyYANNBiWBArEe7SvqSkZH0FleGUzp+AgT8/CDyGDRdLk7ve2n9f1+iH28av5J0Nw8+TfscHCImrDrQ==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.568.0.tgz",
+            "integrity": "sha512-+TA77NWOEXMUcfLoOuim6xiyXFg1GqHj55ggI1goTKGVvdHYZ+rhxZbwjI29+ewzPt/qcItDJcvhrjOrg9lCag==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.567.0",
-                "@aws-sdk/token-providers": "3.567.0",
+                "@aws-sdk/client-sso": "3.568.0",
+                "@aws-sdk/token-providers": "3.568.0",
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
                 "@smithy/shared-ini-file-loader": "^2.4.0",
@@ -1205,9 +1232,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.567.0.tgz",
-            "integrity": "sha512-0J7LgR7ll0glMFBz0d4ijCBB61G7ZNucbEKsCGpFk2csytXNPCZYobjzXpJO8QxxgQUGnb68CRB0bo+GQq8nPg==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+            "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
@@ -1218,13 +1245,13 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.567.0"
+                "@aws-sdk/client-sts": "^3.568.0"
             }
         },
         "node_modules/@aws-sdk/endpoint-cache": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.567.0.tgz",
-            "integrity": "sha512-+HV7cxdz+v+ppjpL8Nbu0jXW8Wsnwd3EClCEaT+Z9FA8eUFcFoX/uxketSiw/+xWAwO4iHtVAzzxr87E8WH78g==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.568.0.tgz",
+            "integrity": "sha512-y0CssKgOwwF+SRUkqlDQfwVCyOT5QzWARildFG4hHyRLasGEspE42ZjIDwv/OrqbAGWSoNsgIuxHrSScJ3yB+A==",
             "dependencies": {
                 "mnemonist": "0.38.3",
                 "tslib": "^2.6.2"
@@ -1234,11 +1261,11 @@
             }
         },
         "node_modules/@aws-sdk/lib-dynamodb": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.567.0.tgz",
-            "integrity": "sha512-oU57LT1tV0QkLkf4o9wqi6PI3w3yWlc4+g73agS5yNfidIbggbPocRVIOTju2tBWilI/gQV1o3JjfwbC2YEC7w==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.569.0.tgz",
+            "integrity": "sha512-Ew+G1XokoZ+SJrQtHifFUD6e7Kmvb3N8rTsUxoGOsV730Yx2uRCZ1VSo9R+rW75wLVBSO9PBTE4aEXcelnqTfQ==",
             "dependencies": {
-                "@aws-sdk/util-dynamodb": "3.567.0",
+                "@aws-sdk/util-dynamodb": "3.569.0",
                 "@smithy/smithy-client": "^2.5.1",
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
@@ -1247,13 +1274,13 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-dynamodb": "^3.567.0"
+                "@aws-sdk/client-dynamodb": "^3.569.0"
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.567.0.tgz",
-            "integrity": "sha512-pltRwwU7i+u8UFGcwhy/ohFEW9KT8BizplLxL4+9Wt3okQzZ91DxlFJng+aDOhxLF8VhY8lUG/qPK4sXZAA7PQ==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.569.0.tgz",
+            "integrity": "sha512-ipYMo1DQVSxfgWP3nRnk/bR+zAq3alt0+0fAMepdLUD3/HwnI6ztFRpI9FnZ4U3ZpBl9MvbBzRgsg+oecTNXeQ==",
             "dependencies": {
                 "@smithy/abort-controller": "^2.2.0",
                 "@smithy/middleware-endpoint": "^2.5.1",
@@ -1267,16 +1294,16 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.567.0"
+                "@aws-sdk/client-s3": "^3.569.0"
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.567.0.tgz",
-            "integrity": "sha512-arbfRcmTswGO9LUf94gIwthn6NHATq6TSQe7uZppvp0wCzxBbvIPuJ5H3yYxyJVa7AdOmQLU+IEkCXnhe6Pl6w==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.568.0.tgz",
+            "integrity": "sha512-uc/nbSpXv64ct/wV3Ksz0/bXAsEtXuoZu5J9FTcFnM7c2MSofa0YQrtrJ8cG65uGbdeiFoJwPA048BTG/ilhCA==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
-                "@aws-sdk/util-arn-parser": "3.567.0",
+                "@aws-sdk/util-arn-parser": "3.568.0",
                 "@smithy/node-config-provider": "^2.3.0",
                 "@smithy/protocol-http": "^3.3.0",
                 "@smithy/types": "^2.12.0",
@@ -1288,11 +1315,11 @@
             }
         },
         "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.567.0.tgz",
-            "integrity": "sha512-Of8rckjYuodGLpbrWJ7w8quoY5tOVNJbX8NThf8Pgme9ZIxMJzDfQ5ZNLx5U3hhZSkkHmGGr2bQvK1cyoSZvlw==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.568.0.tgz",
+            "integrity": "sha512-l6rK86SA9Dyw+SV1nrJtIYQT0pcRfXdrRqPIuNSwxyeUVuFba5ir8RnShkvrsG4hbnQtHASdCmaMLqHvjcqMgw==",
             "dependencies": {
-                "@aws-sdk/endpoint-cache": "3.567.0",
+                "@aws-sdk/endpoint-cache": "3.568.0",
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/node-config-provider": "^2.3.0",
                 "@smithy/protocol-http": "^3.3.0",
@@ -1363,9 +1390,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.567.0.tgz",
-            "integrity": "sha512-12oUmPfSqzaTxO29TXJ9GnJ5qI6ed8iOvHvRLOoqI/TrFqLJnFwCka8E9tpP/sftMchd7wfefbhHhZK4J3ek8Q==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+            "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/types": "^2.12.0",
@@ -1408,12 +1435,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.567.0.tgz",
-            "integrity": "sha512-isJJt3sdQ3V+kBk2gZvG6wVx/PYHSixGs2ahzQT5OOQfmUBBjm4O7bQKmCkfGYEU16vRl38BLiQokS/YSKIGVw==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.569.0.tgz",
+            "integrity": "sha512-qCmeG3qSq0Tv2sXJmtmEYHUFikRLa8OAkcGW/OXVUHf5XY06YFRPRCL5NFMayXusTEHb0Gb1ek3awZ4gix9gnQ==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
-                "@aws-sdk/util-arn-parser": "3.567.0",
+                "@aws-sdk/util-arn-parser": "3.568.0",
                 "@smithy/node-config-provider": "^2.3.0",
                 "@smithy/protocol-http": "^3.3.0",
                 "@smithy/signature-v4": "^2.3.0",
@@ -1427,9 +1454,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.567.0.tgz",
-            "integrity": "sha512-jQnno42ERijEKj9r0ZFZHchPw2NYPFYj8ekGKZAAACXz61EpxbTzPQSbbUh9Xsm00E7xHCJ7eM/wSLhUIRLOdQ==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.569.0.tgz",
+            "integrity": "sha512-KT3KlMmOApfOiMM0CdlO9RYCsjw7CmCpA3Fg2Jbe/+ywQNROMNthfgILqKq3ri7uTmWgo4yR4iaaTiRlrBfpAg==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/smithy-client": "^2.5.1",
@@ -1504,11 +1531,11 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.567.0.tgz",
-            "integrity": "sha512-LYoWyMSaI/tOhcyOFgUjsYKEab67D0Scu5JaFbjDV15UZYfpitlWq5TEuEJvSeyn3+y+yDEHT3sxu4RTd9ya7g==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.569.0.tgz",
+            "integrity": "sha512-uCf/7fDPcU3Q0hL+0jzoSodHJW+HZJTMP51egY3W+otMbr+6+JVfjlrKhHKsT3OtG5AUh+4cDU2k83oeGHxHVQ==",
             "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.567.0",
+                "@aws-sdk/middleware-sdk-s3": "3.569.0",
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/protocol-http": "^3.3.0",
                 "@smithy/signature-v4": "^2.3.0",
@@ -1520,9 +1547,9 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.567.0.tgz",
-            "integrity": "sha512-W9Zd7/504wGrNjHHbJeCms1j1M6/88cHtBhRTKOWa7mec1gCjrd0VB3JE1cRodc6OrbJZ9TmyarBg8er6X5aiA==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.568.0.tgz",
+            "integrity": "sha512-mCQElYzY5N2JlXB7LyjOoLvRN/JiSV+E9szLwhYN3dleTUCMbGqWb7RiAR2V3fO+mz8f9kR7DThTExKJbKogKw==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
@@ -1534,7 +1561,7 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.567.0"
+                "@aws-sdk/client-sso-oidc": "^3.568.0"
             }
         },
         "node_modules/@aws-sdk/types": {
@@ -1550,9 +1577,9 @@
             }
         },
         "node_modules/@aws-sdk/util-arn-parser": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.567.0.tgz",
-            "integrity": "sha512-d9WZWPrymGAFLVGe0qysH3cv576NsHDWP9F4ZIiJrM/71pB4/C9XXKfRVZXyexO6KMDEr2Lv0Jx1Lb+FF4ZsqQ==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+            "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -1561,9 +1588,9 @@
             }
         },
         "node_modules/@aws-sdk/util-dynamodb": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.567.0.tgz",
-            "integrity": "sha512-T6hBcLpUwESJyp50as4yUquyf0eitKGwi5Kw+zH3ELh/AwIrFLsVFHuBMRHUVctUZ9SXvnhXGXbJaT1Cf8Xvwg==",
+            "version": "3.569.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.569.0.tgz",
+            "integrity": "sha512-cTNwY1eSycZJhetaj0Xl0E65lHl65mwfe9bsq6cSRuMxUXYpuo5yEwiT5OMQiAC8QtlwpCHokFHI12TqqlZbFQ==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -1571,7 +1598,7 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-dynamodb": "^3.567.0"
+                "@aws-sdk/client-dynamodb": "^3.569.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
@@ -1603,9 +1630,9 @@
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.567.0.tgz",
-            "integrity": "sha512-o05vqq2+IdIHVqu2L28D1aVzZRkjheyQQE0kAIB+aS0fr4hYidsO2XqkXRRnhkaOxW3VN5/K/p2gxCaKt6A1XA==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+            "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -1625,9 +1652,9 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.567.0.tgz",
-            "integrity": "sha512-Fph602FBhLssed0x2GsRZyqJB8thcrKzbS53v57rQ6XHSQ6T8t2BUyrlXcBfDpoZQjnqobr0Uu2DG5UI3cgR6g==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+            "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/node-config-provider": "^2.3.0",
@@ -3378,9 +3405,9 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.32.27",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.27.tgz",
-            "integrity": "sha512-JHRrubCKiXi6VKlbBTpTQnExkUFasPMIaXCJYJhqVBGLliQVt1yBZZgiZo3/uSmvAdXlIIdGoTAT6RB09L0QqA=="
+            "version": "0.32.28",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.28.tgz",
+            "integrity": "sha512-wxng3UfKHYEVIy5xO4UK3s7AzSx755B4gDvpCwitgn2r/mAvDYAIA0A1FFfeI2zyQnMuF+66Ii5GplXAaw6wIA=="
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
@@ -4266,9 +4293,9 @@
             }
         },
         "node_modules/@types/busboy": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.3.tgz",
-            "integrity": "sha512-YMBLFN/xBD8bnqywIlGyYqsNFXu6bsiY7h3Ae0kO17qEuTjsqeyYMRPSUDacIKIquws2Y6KjmxAyNx8xB3xQbw==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+            "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -4379,9 +4406,9 @@
             }
         },
         "node_modules/@types/lodash": {
-            "version": "4.17.0",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-            "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.1.tgz",
+            "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q=="
         },
         "node_modules/@types/memjs": {
             "version": "1.3.3",
@@ -4422,9 +4449,9 @@
             }
         },
         "node_modules/@types/pg": {
-            "version": "8.11.5",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.5.tgz",
-            "integrity": "sha512-2xMjVviMxneZHDHX5p5S6tsRRs7TpDHeeK7kTTMe/kAC/mRRNjWHjZg0rkiY+e17jXSZV3zJYDxXV8Cy72/Vuw==",
+            "version": "8.11.6",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+            "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
             "devOptional": true,
             "dependencies": {
                 "@types/node": "*",
@@ -8484,17 +8511,17 @@
             "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
         },
         "node_modules/hono": {
-            "version": "4.2.9",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.2.9.tgz",
-            "integrity": "sha512-59FAv52UxDWUt/NlC0NzrRCjeVCThUnVlqlrKYm+k80XujBu6uJwBIa5gACKKZWobjA0MJ6Vds0I3URKf383Cw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.3.1.tgz",
+            "integrity": "sha512-yw/m4lZCuPpVJUQXyoeCy4uHXmq/osMxfEM8jMKGMr2V1OuL3vYybLrtoGj3GxC2wKIcMZO20i9nDMuZGkExNw==",
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/http-cookie-agent": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.3.tgz",
-            "integrity": "sha512-6JdymEgWgsg9VQ5VN9FGpRRcivyu4WdM0Ud3kW+Q0PB7knt0EFtlhNPU8wCuscXLfIEI5y6jEMdFTBODNsJR6g==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.5.tgz",
+            "integrity": "sha512-sfZ8fDgDP3B1YB+teqSnAK1aPgBu8reUUGxSsndP2XnYN6cM29EURXWXZqQQiaRdor3B4QjpkUNfv21syaO4DA==",
             "dependencies": {
                 "agent-base": "^7.1.1"
             },
@@ -8505,14 +8532,10 @@
                 "url": "https://github.com/sponsors/3846masa"
             },
             "peerDependencies": {
-                "deasync": "^0.1.26",
                 "tough-cookie": "^4.0.0",
                 "undici": "^5.11.0 || ^6.0.0"
             },
             "peerDependenciesMeta": {
-                "deasync": {
-                    "optional": true
-                },
                 "undici": {
                     "optional": true
                 }
@@ -9853,9 +9876,9 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-            "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+            "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -12763,9 +12786,9 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/tsx": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.8.2.tgz",
-            "integrity": "sha512-hmmzS4U4mdy1Cnzpl/NQiPUC2k34EcNSTZYVJThYKhdqTwuBeF+4cG9KUK/PFQ7KHaAaYwqlb7QfmsE2nuj+WA==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.9.0.tgz",
+            "integrity": "sha512-UY0UUhDPL6MkqkZU4xTEjEBOLfV+RIt4xeeJ1qwK73xai4/zveG+X6+tieILa7rjtegUW2LE4p7fw7gAoLuytA==",
             "dependencies": {
                 "esbuild": "~0.20.2",
                 "get-tsconfig": "^4.7.3"
@@ -14109,9 +14132,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.23.5",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.5.tgz",
-            "integrity": "sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==",
+            "version": "3.23.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.6.tgz",
+            "integrity": "sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/api/test/flight.ts
+++ b/api/test/flight.ts
@@ -1,6 +1,5 @@
 process.env.StackName = 'test';
 process.env.MartiAPI = 'https://example.com';
-process.env.AuthGroup = 'Admins';
 
 import assert from 'assert';
 import jwt from 'jsonwebtoken';

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -386,7 +386,6 @@ export default {
                         { Name: 'API_URL', Value: cf.ref('HostedURL') },
                         { Name: 'PMTILES_URL', Value: cf.join(['https://', cf.ref('PMTilesLambdaAPI'), '.execute-api.', cf.region, '.amazonaws.com']) },
                         { Name: 'MartiAPI', Value: cf.ref('MartiAPI') },
-                        { Name: 'AuthGroup', Value: cf.ref('AuthGroup') },
                         { Name: 'AWS_DEFAULT_REGION', Value: cf.region },
                         { Name: 'VpcId', Value: cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-vpc'])) },
                         { Name: 'SubnetPublicA', Value: cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-subnet-public-a'])) },


### PR DESCRIPTION
### Context

Now that we have System Admin, Agency Admin, & User distinctions implemented accross the API, this PR removes the AuthGroup requirement in favour of the TAK server determining ACL