### PR TITLE
Redirect State on Login

### DIFF
--- a/api/web/src/App.vue
+++ b/api/web/src/App.vue
@@ -162,9 +162,10 @@ export default {
     },
     errorCaptured: function(err) {
         if (err.message === '401') {
+            // Popup Modal if reauthenticating vs initial login
             this.login = true;
         } else if (String(err) === 'Error: Authentication Required') {
-            this.$router.push('/login');
+            this.routeLogin();
         } else {
             this.err = err;
         }
@@ -178,7 +179,7 @@ export default {
             await this.getLogin();
             await this.getServer();
         } else if (this.$route.name !== 'login') {
-            this.$router.push("/login");
+            this.routeLogin();
         }
 
         this.mounted = true;
@@ -189,6 +190,9 @@ export default {
             delete localStorage.token;
             this.$router.push("/login");
         },
+        routeLogin: function() {
+            this.$router.push(`/login?redirect=${encodeURIComponent(window.location.pathname)}`);
+        },
         getLogin: async function() {
             this.loading = true;
             try {
@@ -196,7 +200,9 @@ export default {
             } catch (err) {
                 this.user = null;
                 delete localStorage.token;
-                if (this.$route.name !== 'login') this.$router.push("/login");
+                if (this.$route.name !== 'login') {
+                    this.routeLogin();
+                }
                 this.loading = false;
             }
 

--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -116,7 +116,12 @@ export default {
                 localStorage.token = login.token;
 
                 this.$emit('login');
-                this.$router.push("/");
+
+                if (this.$route.query.redirect) {
+                    this.$router.push(this.$route.query.redirect);
+                } else {
+                    this.$router.push("/");
+                }
             } catch (err) {
                 this.loading = false;
                 throw err;


### PR DESCRIPTION
### Conext

If you click a link and haven't logged in, it loses the state of the link when you are redirect to the login page.

This PR introduces a `?redirect` which will be appended to the `/login` route and redirected to if successful
