### PR TITLE
Increase Throughput

### DIFF
--- a/api/lib/sinks.ts
+++ b/api/lib/sinks.ts
@@ -56,7 +56,7 @@ export default class Sinks extends Map<string, typeof SinkInterface> {
 
                             return {
                                 Id: (Math.random() + 1).toString(36).substring(7),
-                                MessageGroupId: String(conn.id),
+                                MessageGroupId: `${String(conn.id)}-${feat.id}`,
                                 MessageBody: JSON.stringify({
                                     id: sink.id,
                                     type: sink.type,


### PR DESCRIPTION
### Context

I'd originally set the MessageGroupId in the FiFo queue to be the Sink ID with the understanding that I wanted CoTs to be processed in order as the "latest" CoT needs to be the last processed out of a list. We've seen significant bottlenecks for large CoT submissions to the sink API which were alleviated significantly in a prior PR which introduces parallelism within the FiFo batch of 10 messages.

This should further reduce queue congesion by instead limiting processing by Sink ID and then secondarily by CoT UID. Thereforce each CoT UID has to be processed in order but CoTs within a given sink can be processed in parallel.