### PR TITLE
Update connection-channels.ts

### DIFF
--- a/api/routes/connection-channels.ts
+++ b/api/routes/connection-channels.ts
@@ -22,10 +22,14 @@ export default async function router(schema: Schema, config: Config) {
             }, req.params.connectionid);
 
             const api = await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(connection.auth.cert, connection.auth.key));
-
+            
             const list = await api.Group.list({
                 useCache: true
             });
+
+            if (list.data && list.data.length > 1) {
+                list.warning = 'Warning: Multiple channels selected. Please confirm this is your intended action.';
+            }
 
             res.json(list);
         } catch (err) {


### PR DESCRIPTION
added a warning check in the /connection/:connectionid/channel GET endpoint that monitors when users select multiple channels for data sync. Specifically, we added a simple condition that checks if list.data.length > 1 and if true, adds a warning message to the response object. This fulfills issue #387's requirement to warn users when they select more than one channel in their Data Sync channel list.