### PR TITLE
Set the creatorUid to `ANDROID-CloudTAK-${user.email}` when creating missions

### DIFF
--- a/api/routes/marti-mission.ts
+++ b/api/routes/marti-mission.ts
@@ -172,7 +172,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const mission = await api.Mission.create(req.params.name, {
                 ...req.body,
-                creatorUid: user.email
+                creatorUid: `ANDROID-CloudTAK-${user.email}`
             });
 
             res.json(mission);


### PR DESCRIPTION
Changes the creatorUid when creating missions to match the UID used elsewhere in CloudTAK. This solves an error I was getting while updating OpenTAKServer to work with CloudTAK.