### PR TITLE
Fix Default Groups

### DIFF
--- a/api/routes/config.ts
+++ b/api/routes/config.ts
@@ -125,7 +125,8 @@ export default async function router(schema: Schema, config: Config) {
                 return final[k.value.key.replace('group::', '')] = String(k.value.value);
             });
 
-            for (const group of keys) {
+            for (let group of keys) {
+                group = group.replace('group::', '')
                 if (!final[group]) final[group] = '';
             }
 


### PR DESCRIPTION
### Context

If a custom TAK Group name is not set the `group::` prefix is shown to the user when it shouldn't be and is correctly rejected if selected by the PATCH Profile API

This PR fixes the API response when getting the group list by automatically removing the `group::` prefix