### PR TITLE
BreadCrumb Fix

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -629,9 +629,9 @@
             }
         },
         "node_modules/@aws-sdk/client-ec2": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.734.0.tgz",
-            "integrity": "sha512-bMl8RdzVGFIDBUXPuTacsm0thTe8Y+PaTjeIPMlUfzSVFXrRqwLxiSM3vWeEvQhD74mn3FYhIiCt9wkjy1GiQw==",
+            "version": "3.737.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.737.0.tgz",
+            "integrity": "sha512-KgOPESCfVpkCkuFuXw4/x1lIdgNsiHcc8CSqmaX3p9y9lNfFehU5dv2hSE3vJlIktfpEellPSOWN1Lkcv6Yw5Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -4792,9 +4792,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "12.19.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-12.19.0.tgz",
-            "integrity": "sha512-SaOgZm3IdtTmqRi/My0IdGxETT4gB3mfqtmLVCqGLvTq5II3lB21Ll4hG0fxJHWQ4X+nYnYR+n94fdF2nUqEQA==",
+            "version": "12.20.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-12.20.0.tgz",
+            "integrity": "sha512-vSc7qGqm9hhFzaEAhmRpZQ9ppP/8lkKAt7j/33MA/raLIGntR/JiHoERWZ8XYefm0k0SnyPc3r2twLqAIB9X0g==",
             "license": "MIT",
             "dependencies": {
                 "@openaddresses/batch-error": "^2.4.0",
@@ -5295,9 +5295,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.5.tgz",
-            "integrity": "sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+            "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -5386,9 +5386,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.10.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-            "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+            "version": "22.12.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+            "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -11843,9 +11843,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.18.2",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
-            "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+            "version": "5.18.3",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.3.tgz",
+            "integrity": "sha512-G33HFW0iFNStfY2x6QXO2JYVMrFruc8AZRX0U/L71aA7WeWfX2E5Nm8E/tsipSZJeIZZbSjUDeynLK/wcuNWIw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "=1.4.0"


### PR DESCRIPTION
### Context

Some CoT markers coming in via the historic CoT API were missing a callsign and therefore failed the node-cot parsing

This PR makes the callsign field optional
