### PR TITLE
Don't Double Zip DataPackages

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -634,9 +634,9 @@
             }
         },
         "node_modules/@aws-sdk/client-ec2": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.758.0.tgz",
-            "integrity": "sha512-bMH9s7/zebK92LvuLQshQEJ1Ar8016Ip/Aw0lRYf/+KSPNCAENX8fVwFt/O4o+UdYFLGqmPGGRwcO2JnL6nRMg==",
+            "version": "3.760.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.760.0.tgz",
+            "integrity": "sha512-84lwzkKmLhjYBTHUTUfNamsdYMOWtwZeLrTccps2TC8FcMXxQ/YRdpe+bqXE0MwO/tG7FAngjFPQ9dFOFlGZ+g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -4841,9 +4841,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "12.21.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-12.21.0.tgz",
-            "integrity": "sha512-s4fst/qnTKVALYm2U5JHmnkabxCbqRHEU8f5Ddxl2nxzsnieVCAh8TMX2pfMacFDJm7puzydNHfiGUxMtR+k7w==",
+            "version": "12.23.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-12.23.0.tgz",
+            "integrity": "sha512-j+dea7jDuuY82/cO24rJ5T3M/Q1y6aNKkH9jmdOMJ1y/DwG5l+fsQIVFfYJheoStIuV4yQjPmevIfde5H2go5g==",
             "license": "MIT",
             "dependencies": {
                 "@openaddresses/batch-error": "^2.4.0",
@@ -4854,11 +4854,10 @@
                 "@turf/sector": "^7.1.0",
                 "@turf/truncate": "^7.0.0",
                 "@types/archiver": "^6.0.2",
-                "@types/color": "^4.0.0",
                 "@types/geojson": "^7946.0.14",
                 "ajv": "^8.12.0",
                 "archiver": "^7.0.1",
-                "color": "^4.2.3",
+                "color": "^5.0.0",
                 "json-diff-ts": "^4.0.1",
                 "node-stream-zip": "^1.15.0",
                 "protobufjs": "^7.3.0",
@@ -5269,30 +5268,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/color": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/color/-/color-4.2.0.tgz",
-            "integrity": "sha512-6+xrIRImMtGAL2X3qYkd02Mgs+gFGs+WsK0b7VVMaO4mYRISwyTjcqNrO0mNSmYEoq++rSLDB2F5HDNmqfOe+A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/color-convert": "*"
-            }
-        },
-        "node_modules/@types/color-convert": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
-            "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/color-name": "^1.1.0"
-            }
-        },
-        "node_modules/@types/color-name": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
-            "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
-            "license": "MIT"
-        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5438,9 +5413,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.13.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-            "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+            "version": "22.13.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+            "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -5599,9 +5574,9 @@
             }
         },
         "node_modules/@types/ws": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
-            "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5619,17 +5594,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-            "integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
+            "integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.25.0",
-                "@typescript-eslint/type-utils": "8.25.0",
-                "@typescript-eslint/utils": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0",
+                "@typescript-eslint/scope-manager": "8.26.0",
+                "@typescript-eslint/type-utils": "8.26.0",
+                "@typescript-eslint/utils": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -5645,20 +5620,20 @@
             "peerDependencies": {
                 "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
-            "integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
+            "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.25.0",
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/typescript-estree": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0",
+                "@typescript-eslint/scope-manager": "8.26.0",
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/typescript-estree": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -5670,7 +5645,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/debug": {
@@ -5699,14 +5674,14 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
-            "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
+            "integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0"
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5717,14 +5692,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
-            "integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
+            "integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.25.0",
-                "@typescript-eslint/utils": "8.25.0",
+                "@typescript-eslint/typescript-estree": "8.26.0",
+                "@typescript-eslint/utils": "8.26.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -5737,7 +5712,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
@@ -5766,9 +5741,9 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
-            "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
+            "integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5780,14 +5755,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
-            "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
+            "integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0",
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -5803,7 +5778,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -5858,16 +5833,16 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
-            "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
+            "integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.25.0",
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/typescript-estree": "8.25.0"
+                "@typescript-eslint/scope-manager": "8.26.0",
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/typescript-estree": "8.26.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5878,17 +5853,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
-            "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
+            "integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.25.0",
+                "@typescript-eslint/types": "8.26.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -6015,6 +5990,24 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/ansi-styles/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ansi-styles/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
         },
         "node_modules/archiver": {
             "version": "7.0.1",
@@ -6163,9 +6156,9 @@
             "license": "MIT"
         },
         "node_modules/array-includes-with-glob": {
-            "version": "5.0.10",
-            "resolved": "https://registry.npmjs.org/array-includes-with-glob/-/array-includes-with-glob-5.0.10.tgz",
-            "integrity": "sha512-XjsXnFS7NzjJDpMYjmNktyumW9uFrWsbe9Xgl0fnmUjvmuKRAUaITYNu0A2mZWcsIpbfMtTBRzK2EfH+ySgjtw==",
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/array-includes-with-glob/-/array-includes-with-glob-5.0.12.tgz",
+            "integrity": "sha512-vnTzFmb4LpoNx51zr4s+V2RmVXEGXLE70fypGQy132QIMP7djRSOS5JU1O/o5mktEu9UTxjY52pDgP+dWRzOGg==",
             "license": "MIT",
             "dependencies": {
                 "matcher": "^5.0.0"
@@ -6491,13 +6484,13 @@
             }
         },
         "node_modules/call-bound": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "get-intrinsic": "^1.2.6"
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6576,44 +6569,49 @@
             "license": "MIT"
         },
         "node_modules/color": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
+            "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
             "license": "MIT",
             "dependencies": {
-                "color-convert": "^2.0.1",
-                "color-string": "^1.9.0"
+                "color-convert": "^3.0.1",
+                "color-string": "^2.0.0"
             },
             "engines": {
-                "node": ">=12.5.0"
+                "node": ">=18"
             }
         },
         "node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.0.1.tgz",
+            "integrity": "sha512-5kQah2eolfQV7HCrxtsBBArPfT5dwaKYMCXeMQsdRO7ihTO/cuNLGjd50ITCDn+ZU/YbS0Go64SjP9154eopxg==",
             "license": "MIT",
             "dependencies": {
-                "color-name": "~1.1.4"
+                "color-name": "^2.0.0"
             },
             "engines": {
-                "node": ">=7.0.0"
+                "node": ">=14.6"
             }
         },
         "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "license": "MIT"
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+            "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20"
+            }
         },
         "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
+            "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
             "license": "MIT",
             "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
+                "color-name": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/combined-stream": {
@@ -11470,6 +11468,47 @@
                 "@img/sharp-win32-x64": "0.33.5"
             }
         },
+        "node_modules/sharp/node_modules/color": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1",
+                "color-string": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=12.5.0"
+            }
+        },
+        "node_modules/sharp/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/sharp/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
+        },
+        "node_modules/sharp/node_modules/color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -12796,9 +12835,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -12810,15 +12849,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
-            "integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.0.tgz",
+            "integrity": "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.25.0",
-                "@typescript-eslint/parser": "8.25.0",
-                "@typescript-eslint/utils": "8.25.0"
+                "@typescript-eslint/eslint-plugin": "8.26.0",
+                "@typescript-eslint/parser": "8.26.0",
+                "@typescript-eslint/utils": "8.26.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12829,7 +12868,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/uglify-js": {

--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -20,7 +20,6 @@
                 "@turf/envelope": "^7.1.0",
                 "@turf/meta": "^7.2.0",
                 "@turf/point-on-feature": "^7.0.0",
-                "apexcharts": "^3.0.0",
                 "bootstrap": "^5.2.3",
                 "core-js": "^3.6.4",
                 "cronstrue": "^2.19.0",
@@ -45,7 +44,6 @@
                 "vue": "^3.2.31",
                 "vue-mention": "^2.0.0-alpha.3",
                 "vue-router": "^4.0.14",
-                "vue3-apexcharts": "1.7.0",
                 "ws": "^8.11.0"
             },
             "devDependencies": {
@@ -2830,21 +2828,21 @@
             "license": "MIT"
         },
         "node_modules/@redocly/config": {
-            "version": "0.20.3",
-            "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.3.tgz",
-            "integrity": "sha512-Nyyv1Bj7GgYwj/l46O0nkH1GTKWbO3Ixe7KFcn021aZipkZd+z8Vlu1BwkhqtVgivcKaClaExtWU/lDHkjBzag==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+            "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@redocly/openapi-core": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.31.1.tgz",
-            "integrity": "sha512-FoTmi+iA6NGXk6rZpX6QvmEqbApbJgYC6soLj3zfx0f/1M4vUff5GuOEC24GWj7rN0vNx5E6eUx59h0M4sjRnQ==",
+            "version": "1.32.2",
+            "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.32.2.tgz",
+            "integrity": "sha512-E1GvI1lPAX1rJSrgoFJewWoenoPrG4VTm91WPGkbFPC4r+qcdwZzlL9rxbkY0kB5BiFeUr+l0xZxb5wjL5Fv7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@redocly/ajv": "^8.11.2",
-                "@redocly/config": "^0.20.1",
+                "@redocly/config": "^0.22.0",
                 "colorette": "^1.2.0",
                 "https-proxy-agent": "^7.0.5",
                 "js-levenshtein": "^1.1.6",
@@ -2966,9 +2964,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-            "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
+            "integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
             "cpu": [
                 "arm"
             ],
@@ -2980,9 +2978,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-            "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
+            "integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
             "cpu": [
                 "arm64"
             ],
@@ -2994,9 +2992,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-            "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
+            "integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3008,9 +3006,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-            "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
+            "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
             "cpu": [
                 "x64"
             ],
@@ -3022,9 +3020,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-            "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
+            "integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
             "cpu": [
                 "arm64"
             ],
@@ -3036,9 +3034,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-            "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
+            "integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
             "cpu": [
                 "x64"
             ],
@@ -3050,9 +3048,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-            "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
+            "integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
             "cpu": [
                 "arm"
             ],
@@ -3064,9 +3062,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-            "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
+            "integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
             "cpu": [
                 "arm"
             ],
@@ -3078,9 +3076,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-            "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
+            "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
             "cpu": [
                 "arm64"
             ],
@@ -3092,9 +3090,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-            "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
+            "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
             "cpu": [
                 "arm64"
             ],
@@ -3106,9 +3104,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-            "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
+            "integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
             "cpu": [
                 "loong64"
             ],
@@ -3120,9 +3118,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-            "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
+            "integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
             "cpu": [
                 "ppc64"
             ],
@@ -3134,9 +3132,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-            "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
+            "integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
             "cpu": [
                 "riscv64"
             ],
@@ -3148,9 +3146,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-            "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
+            "integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
             "cpu": [
                 "s390x"
             ],
@@ -3162,9 +3160,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-            "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+            "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
             "cpu": [
                 "x64"
             ],
@@ -3176,9 +3174,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-            "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
+            "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
             "cpu": [
                 "x64"
             ],
@@ -3190,9 +3188,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-            "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
+            "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3204,9 +3202,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-            "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
+            "integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
             "cpu": [
                 "ia32"
             ],
@@ -3218,9 +3216,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-            "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
+            "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
             "cpu": [
                 "x64"
             ],
@@ -3776,17 +3774,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-            "integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
+            "integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.25.0",
-                "@typescript-eslint/type-utils": "8.25.0",
-                "@typescript-eslint/utils": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0",
+                "@typescript-eslint/scope-manager": "8.26.0",
+                "@typescript-eslint/type-utils": "8.26.0",
+                "@typescript-eslint/utils": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -3802,20 +3800,20 @@
             "peerDependencies": {
                 "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
-            "integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
+            "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.25.0",
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/typescript-estree": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0",
+                "@typescript-eslint/scope-manager": "8.26.0",
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/typescript-estree": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3827,18 +3825,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
-            "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
+            "integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0"
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3849,14 +3847,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
-            "integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
+            "integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.25.0",
-                "@typescript-eslint/utils": "8.25.0",
+                "@typescript-eslint/typescript-estree": "8.26.0",
+                "@typescript-eslint/utils": "8.26.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -3869,13 +3867,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
-            "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
+            "integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3887,14 +3885,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
-            "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
+            "integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/visitor-keys": "8.25.0",
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/visitor-keys": "8.26.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -3910,7 +3908,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -3940,16 +3938,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
-            "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
+            "integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.25.0",
-                "@typescript-eslint/types": "8.25.0",
-                "@typescript-eslint/typescript-estree": "8.25.0"
+                "@typescript-eslint/scope-manager": "8.26.0",
+                "@typescript-eslint/types": "8.26.0",
+                "@typescript-eslint/typescript-estree": "8.26.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3960,17 +3958,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
-            "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
+            "integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.25.0",
+                "@typescript-eslint/types": "8.26.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -4276,12 +4274,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/@yr/monotone-cubic-spline": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
-            "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
-            "license": "MIT"
-        },
         "node_modules/acorn": {
             "version": "8.14.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -4388,21 +4380,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/apexcharts": {
-            "version": "3.54.1",
-            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.54.1.tgz",
-            "integrity": "sha512-E4et0h/J1U3r3EwS/WlqJCQIbepKbp6wGUmaAwJOMjHUP4Ci0gxanLa7FR3okx6p9coi4st6J853/Cb1NP0vpA==",
-            "license": "MIT",
-            "dependencies": {
-                "@yr/monotone-cubic-spline": "^1.0.3",
-                "svg.draggable.js": "^2.2.2",
-                "svg.easing.js": "^2.0.0",
-                "svg.filter.js": "^2.0.2",
-                "svg.pathmorphing.js": "^0.1.3",
-                "svg.resize.js": "^1.4.3",
-                "svg.select.js": "^3.0.1"
             }
         },
         "node_modules/argparse": {
@@ -4730,13 +4707,13 @@
             }
         },
         "node_modules/call-bound": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "get-intrinsic": "^1.2.6"
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4756,9 +4733,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001700",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-            "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+            "version": "1.0.30001702",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+            "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
             "dev": true,
             "funding": [
                 {
@@ -4891,9 +4868,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-            "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
+            "version": "3.41.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
+            "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -4902,13 +4879,13 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
-            "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
+            "version": "3.41.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
+            "integrity": "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.3"
+                "browserslist": "^4.24.4"
             },
             "funding": {
                 "type": "opencollective",
@@ -4916,9 +4893,9 @@
             }
         },
         "node_modules/cronstrue": {
-            "version": "2.55.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.55.0.tgz",
-            "integrity": "sha512-ZsBZNtQWb0Rk6CNGJlzpPBYqNE7t93Aez5ZCExLihGwmIpE5qThSTDQzDV8Z1Nw6ksmLkwI98nPKyciZ5sH7dw==",
+            "version": "2.56.0",
+            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.56.0.tgz",
+            "integrity": "sha512-/YC3b4D/E/S8ToQ7f676A2fqoC3vVpXKjJ4SMsP0jYsvRYJdZ6h9+Fq/Y7FoFDEUFCqLTca+G2qTV227lyyFZg==",
             "license": "MIT",
             "bin": {
                 "cronstrue": "bin/cli.js"
@@ -5202,9 +5179,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.104",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.104.tgz",
-            "integrity": "sha512-Us9M2L4cO/zMBqVkJtnj353nQhMju9slHm62NprKTmdF3HH8wYOtNvDFq/JB2+ZRoGLzdvYDiATlMHs98XBM1g==",
+            "version": "1.5.112",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.112.tgz",
+            "integrity": "sha512-oen93kVyqSb3l+ziUgzIOlWt/oOuy4zRmpwestMn4rhFWAoFJeFuCVte9F2fASjeZZo7l/Cif9TiyrdW4CwEMA==",
             "dev": true,
             "license": "ISC"
         },
@@ -5722,9 +5699,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-            "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -7214,9 +7191,9 @@
             }
         },
         "node_modules/maplibre-gl": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.1.1.tgz",
-            "integrity": "sha512-0Z6ODzyFu/grwT6K1eIBpv6MZE4xnJD1AV+Yq1hPzOh/YCY36r9BlSaU7d7n2/HJOaoKOy0b2YF8cS4dD+iEVQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.2.0.tgz",
+            "integrity": "sha512-9zZKD0M80qtDsqBet+EDuAhoCeA/cnAuZAA0p3hcGKGbyjM/SH+R6wQvnBEgvJz9UhDynnkoKdUwhI+fUkHoXQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
@@ -8209,9 +8186,9 @@
             "license": "Unlicense"
         },
         "node_modules/rollup": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-            "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
+            "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8225,25 +8202,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.34.8",
-                "@rollup/rollup-android-arm64": "4.34.8",
-                "@rollup/rollup-darwin-arm64": "4.34.8",
-                "@rollup/rollup-darwin-x64": "4.34.8",
-                "@rollup/rollup-freebsd-arm64": "4.34.8",
-                "@rollup/rollup-freebsd-x64": "4.34.8",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-                "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-                "@rollup/rollup-linux-arm64-gnu": "4.34.8",
-                "@rollup/rollup-linux-arm64-musl": "4.34.8",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-                "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-                "@rollup/rollup-linux-s390x-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-musl": "4.34.8",
-                "@rollup/rollup-win32-arm64-msvc": "4.34.8",
-                "@rollup/rollup-win32-ia32-msvc": "4.34.8",
-                "@rollup/rollup-win32-x64-msvc": "4.34.8",
+                "@rollup/rollup-android-arm-eabi": "4.34.9",
+                "@rollup/rollup-android-arm64": "4.34.9",
+                "@rollup/rollup-darwin-arm64": "4.34.9",
+                "@rollup/rollup-darwin-x64": "4.34.9",
+                "@rollup/rollup-freebsd-arm64": "4.34.9",
+                "@rollup/rollup-freebsd-x64": "4.34.9",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
+                "@rollup/rollup-linux-arm-musleabihf": "4.34.9",
+                "@rollup/rollup-linux-arm64-gnu": "4.34.9",
+                "@rollup/rollup-linux-arm64-musl": "4.34.9",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
+                "@rollup/rollup-linux-riscv64-gnu": "4.34.9",
+                "@rollup/rollup-linux-s390x-gnu": "4.34.9",
+                "@rollup/rollup-linux-x64-gnu": "4.34.9",
+                "@rollup/rollup-linux-x64-musl": "4.34.9",
+                "@rollup/rollup-win32-arm64-msvc": "4.34.9",
+                "@rollup/rollup-win32-ia32-msvc": "4.34.9",
+                "@rollup/rollup-win32-x64-msvc": "4.34.9",
                 "fsevents": "~2.3.2"
             }
         },
@@ -9002,97 +8979,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/svg.draggable.js": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
-            "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/svg.easing.js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
-            "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": ">=2.3.x"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/svg.filter.js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
-            "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": "^2.2.5"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/svg.js": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
-            "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
-            "license": "MIT"
-        },
-        "node_modules/svg.pathmorphing.js": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
-            "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": "^2.4.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/svg.resize.js": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
-            "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": "^2.6.5",
-                "svg.select.js": "^2.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/svg.resize.js/node_modules/svg.select.js": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
-            "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": "^2.2.5"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/svg.select.js": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
-            "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
-            "license": "MIT",
-            "dependencies": {
-                "svg.js": "^2.6.5"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/temp-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -9290,9 +9176,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.35.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
-            "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
+            "version": "4.37.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+            "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -9388,9 +9274,9 @@
             "peer": true
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -9402,15 +9288,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
-            "integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.0.tgz",
+            "integrity": "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.25.0",
-                "@typescript-eslint/parser": "8.25.0",
-                "@typescript-eslint/utils": "8.25.0"
+                "@typescript-eslint/eslint-plugin": "8.26.0",
+                "@typescript-eslint/parser": "8.26.0",
+                "@typescript-eslint/utils": "8.26.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9421,7 +9307,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/unbox-primitive": {
@@ -9522,9 +9408,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-            "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
             "dev": true,
             "funding": [
                 {
@@ -9900,16 +9786,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
-            }
-        },
-        "node_modules/vue3-apexcharts": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/vue3-apexcharts/-/vue3-apexcharts-1.7.0.tgz",
-            "integrity": "sha512-BmWoS8+x5XLCtk2ml7rLVO+QU+fjgQUUCjUXSFW9cNQpCMa5Z0eRPvZjvYLt5aDKNREtuZoidlG9WRjZ/Af7lA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "apexcharts": "> 3.0.0",
-                "vue": "> 3.0.0"
             }
         },
         "node_modules/webidl-conversions": {

--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -99,8 +99,8 @@ const body = ref<Login_Create>({
     password: ''
 });
 
-function external(url: unknown) {
-    window.location = url as Location;
+function external(url: string) {
+    window.location.assign(url);
 }
 
 async function createLogin() {


### PR DESCRIPTION
### Context

- Implement a check when a file is uploaded via the DataPackage context to see if the upload is already in the DataPackage format and if so just pass it through instead of "double zipping" it
- If the upload is not a DataPackage, fall back to creating a new DataPackage in which this upload will be added as a file
- :bug: Fix proper closing of the Zip reader Node-COT Library
- :rocket: Automatically remove the source zip when the DataPackage is parsed.