### PR TITLE
Corrected typo in the footer

### DIFF
--- a/api/web/src/components/PageFooter.vue
+++ b/api/web/src/components/PageFooter.vue
@@ -25,10 +25,13 @@
                         <li class='list-inline-item'>
                             Copyright © 2025
                             <a
-                                href='.'
+                                href='https://www.colorado.gov/'
                                 class='link-secondary'
                             >State of Colorado</a>
-                            - MIT License
+                            - <a 
+                                href='https://github.com/dfpc-coe/CloudTAK/blob/main/LICENSE'
+                                class='link-secondary'  
+                             >AGPL-3.0 license</a>
                         </li>
                     </ul>
                 </div>

--- a/api/web/src/components/PageFooter.vue
+++ b/api/web/src/components/PageFooter.vue
@@ -27,7 +27,7 @@
                             <a
                                 href='.'
                                 class='link-secondary'
-                            >Static of Colorado</a>
+                            >State of Colorado</a>
                             - MIT License
                         </li>
                     </ul>


### PR DESCRIPTION
- Now reads "State of Colorado" instead of "Static of Colorado". Also added a link to https://www.colorado.gov/

- Updated the licensing string displayed on the bottom of admin pages to reflect what's listed in the [Github repo](https://github.com/dfpc-coe/CloudTAK/blob/main/LICENSE). 

