### PR TITLE
Login page fixes

### DIFF
--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -69,7 +69,7 @@
                             </div>
                         </div>
                         <div class='text-center text-muted mt-3'>
-                            Don't have account yet? <a href='mailto:nicholas.ingalls@state.co.us'>Contact Us</a>
+                            Don't have an account yet? <a href='https://cotak.gov/pages/sign-up'>Sign Up</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Grammar fix and pointer to sign-up page
- Added missing "an" in "Don't have an account yet?"
- Pointed to existing sign-up page instead of dev e-mail