### PR TITLE
Fix API GW mapping for tiles and clarified output language

### DIFF
--- a/cloudformation/CloudTAK.template.js
+++ b/cloudformation/CloudTAK.template.js
@@ -36,7 +36,7 @@ export default cf.merge(
                 Default: 'false'
             },
             HostedURL: {
-                Description: 'URL of domain/subdomain at which the API is hosted ie: "map.example.com"',
+                Description: 'Hostname at which the API is hosted ie: "map.example.com"',
                 Type: 'String'
             },
             SSLCertificateIdentifier: {

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -552,11 +552,11 @@ export default {
         }
     },
     Outputs: {
-        API: {
-            Description: 'API ELB',
-            Value: cf.join(['http://', cf.getAtt('ELB', 'DNSName')])
+        APIURLCNAME: {
+            Description: 'Hosted API CNAME target (API ELB)',
+            Value: cf.join([cf.getAtt('ELB', 'DNSName'), '.'])
         },
-        HostedURL: {
+        APIURL: {
             Description: 'Hosted API Location',
             Export: {
                 Name: cf.join([cf.stackName, '-hosted'])

--- a/cloudformation/lib/pmtiles.js
+++ b/cloudformation/lib/pmtiles.js
@@ -105,10 +105,11 @@ export default {
             }
         },
         PMTilesApiMap: {
-            Type: 'AWS::ApiGateway::BasePathMapping',
-            Properties: {
-                DomainName: cf.ref('PMTilesApiDomain'),
-                RestApiId: cf.ref('PMTilesLambdaAPI')
+           Type: 'AWS::ApiGatewayV2::ApiMapping',
+           Properties: {
+               DomainName: cf.ref('PMTilesApiDomain'),
+               ApiId: cf.ref('PMTilesLambdaAPI'),
+               Stage: cf.ref('PMtilesLambdaAPIStage')
             }
         },
         PMTilesLambdaAPI: {
@@ -198,6 +199,13 @@ export default {
             Value: cf.join(['https://tiles.', cf.ref('HostedURL')]),
             Export: {
                 Name: cf.join([cf.stackName, '-pmtiles-api'])
+            }
+        },
+        PMTilesAPICNAME: {
+            Description: 'PMTiles API CNAME target',
+            Value: cf.join([ cf.getAtt('PMTilesApiDomain', 'RegionalDomainName'), '.']),
+            Export: {
+                Name: cf.join([cf.stackName, '-pmtiles-api-cname-target'])
             }
         }
     }


### PR DESCRIPTION
- Corrected the API GW mapping for the customer cert (e.g. `tiles.map.example.com`) used for the pmtiles API GW. 
- Added an output of the regional API-GW endpoint, so that a DNS CNAME mapping from `tiles.map.example.com` can be easily configured. 
- Clarified the language for the ALB endpoint output, so that a DNS CNAME mapping from `map.example.com` to this ALB can be easily configured. 
- Clarified input parameter language which asks for a URL but expects a hostname. 