### PR TITLE
Cache Invalidation

### DIFF
--- a/api/routes/connection-layer-ephemeral.ts
+++ b/api/routes/connection-layer-ephemeral.ts
@@ -7,7 +7,7 @@ import { sql } from 'drizzle-orm';
 
 export default async function router(schema: Schema, config: Config) {
     await schema.put('/connection/:connectionid/layer/:layerid/incoming/ephemeral', {
-        name: 'Put Ephemeral',
+        name: 'Incoming Ephemeral',
         group: 'LayerEphemeral',
         description: 'Store ephemeral values',
         params: Type.Object({
@@ -41,6 +41,46 @@ export default async function router(schema: Schema, config: Config) {
             await config.cacher.del(`layer-${req.params.layerid}`);
 
             res.json(incoming.ephemeral)
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.put('/connection/:connectionid/layer/:layerid/outgoing/ephemeral', {
+        name: 'Outgoing Ephemeral',
+        group: 'LayerEphemeral',
+        description: 'Store ephemeral values',
+        params: Type.Object({
+            connectionid: Type.Integer({ minimum: 1 }),
+            layerid: Type.Integer({ minimum: 1 }),
+        }),
+        body: Type.Record(Type.String(), Type.String()),
+        res: Type.Record(Type.String(), Type.String())
+    }, async (req, res) => {
+        try {
+            const { connection } = await Auth.is_connection(config, req, {
+                resources: [
+                    { access: AuthResourceAccess.CONNECTION, id: req.params.connectionid },
+                    { access: AuthResourceAccess.LAYER, id: req.params.layerid }
+                ]
+            }, req.params.connectionid);
+
+            const layer =  await config.models.Layer.augmented_from(req.params.layerid)
+
+            if (layer.connection !== connection.id) {
+                throw new Err(400, null, 'Layer does not belong to this connection');
+            } else if (!layer.outgoing) {
+                throw new Err(400, null, 'Layer does not have outgoing config');
+            }
+
+            const outgoing = await config.models.LayerOutgoing.commit(req.params.layerid, {
+                updated: sql`Now()`,
+                ephemeral: req.body
+            });
+
+            await config.cacher.del(`layer-${req.params.layerid}`);
+
+            res.json(outgoing.ephemeral)
         } catch (err) {
             Err.respond(err, res);
         }

--- a/api/test/fixtures/get_schema.json
+++ b/api/test/fixtures/get_schema.json
@@ -239,6 +239,11 @@
         "query": false,
         "res": true
     },
+    "PUT /connection/:connectionid/layer/:layerid/outgoing/ephemeral": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
     "POST /layer/redeploy": {
         "body": false,
         "query": false,
@@ -464,6 +469,51 @@
         "query": true,
         "res": true
     },
+    "POST /import": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "PUT /import/:import": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "PUT /import": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "GET /import/:import": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "PATCH /import/:import": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "DELETE /import/:import": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "GET /import": {
+        "body": false,
+        "query": true,
+        "res": true
+    },
+    "POST /import/:import/batch": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "GET /import/:import/batch": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
     "GET /iconset": {
         "body": false,
         "query": true,
@@ -528,51 +578,6 @@
         "body": false,
         "query": true,
         "res": false
-    },
-    "POST /import": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "PUT /import/:import": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "PUT /import": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "GET /import/:import": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "PATCH /import/:import": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "DELETE /import/:import": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "GET /import": {
-        "body": false,
-        "query": true,
-        "res": true
-    },
-    "POST /import/:import/batch": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "GET /import/:import/batch": {
-        "body": false,
-        "query": false,
-        "res": true
     },
     "GET /layer": {
         "body": false,


### PR DESCRIPTION
### Context

In the case of an Environment change in the layer that changes the means of authentication, the ephemeral store can potentially have old but unexpired tokens that appear valid.

This reduces the chance of this problem by invalidating the ephemeral cache when an environment is changed.