### PR TITLE
JSONata Query Fix

### DIFF
--- a/api/lib/control/tilejson.ts
+++ b/api/lib/control/tilejson.ts
@@ -13,7 +13,6 @@ import { Static, Type } from '@sinclair/typebox'
 import Err from '@openaddresses/batch-error';
 import { Basemap_FeatureAction } from '../enums.js';
 import { validateStyleMin } from '@maplibre/maplibre-gl-style-spec';
-import { Basemap } from '../schema.js';
 
 export const TileJSONActions = Type.Object({
     feature: Type.Array(Type.Enum(Basemap_FeatureAction))

--- a/api/lib/models/Layer.ts
+++ b/api/lib/models/Layer.ts
@@ -5,7 +5,7 @@ import { StyleContainer } from '../style.js';
 import { Layer_Priority } from '../enums.js';
 import { Static, Type } from '@sinclair/typebox'
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { Layer, LayerIncoming, LayerOutgoing } from '../schema.js';
+import { Connection, Layer, LayerIncoming, LayerOutgoing } from '../schema.js';
 import { sql, eq, asc, desc, is, SQL } from 'drizzle-orm';
 
 export const Layer_Config = Type.Object({
@@ -56,6 +56,12 @@ export const AugmentedLayer = Type.Object({
     memory: Type.Integer(),
     timeout: Type.Integer(),
     priority: Type.Enum(Layer_Priority),
+
+    parent: Type.Object({
+        id: Type.Integer(),
+        name: Type.String(),
+        enabled: Type.Boolean()
+    }),
 
     incoming: Type.Optional(AugmentedLayerIncoming),
     outgoing: Type.Optional(AugmentedLayerOutgoing)
@@ -145,6 +151,12 @@ export default class LayerModel extends Modeler<typeof Layer> {
                 memory: Layer.memory,
                 timeout: Layer.timeout,
 
+                parent: jsonBuildObject({
+                    id: Connection.id,
+                    name: Connection.name,
+                    enabled: Connection.enabled
+                }),
+
                 incoming: jsonBuildObject({
                     layer: LayerIncoming.layer,
                     created: LayerIncoming.created,
@@ -173,6 +185,7 @@ export default class LayerModel extends Modeler<typeof Layer> {
                 })
             })
             .from(Layer)
+            .innerJoin(Connection, eq(Layer.connection, Connection.id))
             .leftJoin(LayerIncoming, eq(LayerIncoming.layer, Layer.id))
             .leftJoin(LayerOutgoing, eq(LayerOutgoing.layer, Layer.id))
             .where(is(id, SQL)? id as SQL<unknown> : eq(this.requiredPrimaryKey(), id))
@@ -217,6 +230,12 @@ export default class LayerModel extends Modeler<typeof Layer> {
                 memory: Layer.memory,
                 timeout: Layer.timeout,
 
+                parent: jsonBuildObject({
+                    id: Connection.id,
+                    name: Connection.name,
+                    enabled: Connection.enabled
+                }),
+
                 incoming: jsonBuildObject({
                     layer: LayerIncoming.layer,
                     created: LayerIncoming.created,
@@ -245,6 +264,7 @@ export default class LayerModel extends Modeler<typeof Layer> {
                 })
             })
             .from(Layer)
+            .innerJoin(Connection, eq(Layer.connection, Connection.id))
             .leftJoin(LayerIncoming, eq(LayerIncoming.layer, Layer.id))
             .leftJoin(LayerOutgoing, eq(LayerOutgoing.layer, Layer.id))
             .where(query.where)

--- a/api/routes/basemap.ts
+++ b/api/routes/basemap.ts
@@ -18,7 +18,7 @@ import { StandardResponse, BasemapResponse, OptionalTileJSON, GeoJSONFeature } f
 import { BasemapCollection } from '../lib/models/Basemap.js';
 import { Basemap as BasemapParser } from '@tak-ps/node-cot';
 import { Basemap } from '../lib/schema.js';
-import { toEnum, Basemap_Format, Basemap_Scheme, Basemap_Type, Basemap_FeatureAction } from '../lib/enums.js';
+import { toEnum, Basemap_Format, Basemap_Scheme, Basemap_Type } from '../lib/enums.js';
 import { EsriBase, EsriProxyLayer } from '../lib/esri.js';
 import * as Default from '../lib/limits.js';
 

--- a/api/routes/connection-layer-cot.ts
+++ b/api/routes/connection-layer-cot.ts
@@ -45,20 +45,23 @@ export default async function router(schema: Schema, config: Config) {
 
             const style = new Style(layer.incoming);
 
+            const styled = [];
             for (let i = 0; i < req.body.features.length; i++) {
                 if (!req.body.features[i].properties) req.body.features[i].properties = {};
 
                 const styledFeat = await style.feat(req.body.features[i])
                 if (!styledFeat) continue;
-                req.body.features[i] = styledFeat;
 
-                if (req.body.features[i].properties.flow === undefined) {
-                    req.body.features[i].properties.flow = {};
+                if (styledFeat.properties.flow === undefined) {
+                    styledFeat.properties.flow = {};
                 }
 
-                // @ts-expect-error TS claims this could be undefined
-                req.body.features[i].properties.flow[`CloudTAK-Layer-${req.params.layerid}`] = new Date().toISOString();
+                styledFeat.properties.flow[`CloudTAK-Layer-${req.params.layerid}`] = new Date().toISOString();
+
+                styled.push(styledFeat);
             }
+
+            req.body.features = styled;
 
             let pooledClient;
             let data;

--- a/api/routes/connection-layer.ts
+++ b/api/routes/connection-layer.ts
@@ -106,7 +106,7 @@ export default async function router(schema: Schema, config: Config) {
                 order: req.query.order,
                 sort: req.query.sort,
                 where: sql`
-                    name ~* ${req.query.filter}
+                    layers.name ~* ${req.query.filter}
                     AND connection = ${req.params.connectionid}
                     AND (${Param(req.query.data)}::BIGINT IS NULL OR ${Param(req.query.data)}::BIGINT = layers_incoming.data)
                 `

--- a/api/routes/connection-layer.ts
+++ b/api/routes/connection-layer.ts
@@ -37,7 +37,7 @@ export default async function router(schema: Schema, config: Config) {
             let page = 0;
             let list;
             do {
-                list = await config.models.Layer.list({ page, limit: 25 });
+                list = await config.models.Layer.augmented_list({ page, limit: 25 });
                 ++page;
 
                 for (const layer of list.items) {

--- a/api/routes/internal.ts
+++ b/api/routes/internal.ts
@@ -53,7 +53,7 @@ export default async function router(schema: Schema, config: Config) {
                 order: req.query.order,
                 sort: req.query.sort,
                 where: sql`
-                    name ~* ${req.query.filter}
+                    layers.name ~* ${req.query.filter}
                     AND (${Param(req.query.connection)}::BIGINT IS NULL OR ${Param(req.query.connection)}::BIGINT = layers.connection)
                     AND (${Param(req.query.data)}::BIGINT IS NULL OR ${Param(req.query.data)}::BIGINT = layers_incoming.data)
                     AND (${Param(req.query.task)}::TEXT IS NULL OR Starts_With(layers.task, ${Param(req.query.task)}::TEXT))

--- a/api/routes/profile-overlays.ts
+++ b/api/routes/profile-overlays.ts
@@ -79,7 +79,7 @@ export default async function router(schema: Schema, config: Config) {
                 } else if (item.mode === 'basemap') {
                     try {
                         const basemap = await config.models.Basemap.from(item.mode_id);
-                        items.push({ ...item, opacity: Number(item.opacity), actions: TileJSON.actions() });
+                        items.push({ ...item, opacity: Number(item.opacity), actions: TileJSON.actions(basemap.url) });
                     } catch (err) {
                         console.error('Could not find basemap', err);
                         await config.models.ProfileOverlay.delete(item.id);
@@ -95,7 +95,7 @@ export default async function router(schema: Schema, config: Config) {
                 ) {
                     await config.models.ProfileOverlay.delete(item.id);
                     removed.push(...overlays.items.splice(i, 1).map((o) => {
-                        return { ...item, opacity: Number(item.opacity) }
+                        return { ...item, opacity: Number(o.opacity) }
                     }));
                     total--;
                 } else {

--- a/api/web/src/components/Admin/AdminLayers.vue
+++ b/api/web/src/components/Admin/AdminLayers.vue
@@ -6,13 +6,15 @@
             </h1>
 
             <div class='ms-auto btn-list'>
-                <IconCloudUpload
-                    v-tooltip='"Redeploy"'
-                    :size='32'
-                    stroke='1'
-                    class='cursor-pointer'
+                <TablerIconButton
+                    title='Redeploy'
                     @click='redeploy'
-                />
+                >
+                    <IconCloudUpload
+                        :size='32'
+                        stroke='1'
+                    />
+                </TablerIconButton>
 
                 <TablerRefreshButton
                     :loading='loading'
@@ -147,6 +149,7 @@ import {
     TablerEnum,
     TablerLoading,
     TablerAlert,
+    TablerIconButton,
     TablerRefreshButton
 } from '@tak-ps/vue-tabler';
 import {

--- a/api/web/src/components/Admin/AdminLayers.vue
+++ b/api/web/src/components/Admin/AdminLayers.vue
@@ -14,11 +14,8 @@
                     @click='redeploy'
                 />
 
-                <IconRefresh
-                    v-tooltip='"Refresh"'
-                    :size='32'
-                    stroke='1'
-                    class='cursor-pointer'
+                <TablerRefreshButton
+                    :loading='loading'
                     @click='fetchList'
                 />
             </div>
@@ -45,6 +42,10 @@
                 v-if='loading'
                 desc='Loading Layers'
             />
+            <TablerAlert
+                v-else-if='error'
+                :err='error'
+            />
             <TablerNone
                 v-else-if='!list.items.length'
                 label='Layers'
@@ -65,16 +66,47 @@
                             v-for='layer in list.items'
                             :key='layer.id'
                             class='cursor-pointer'
-                            @click='stdclick($router, $event, `/connection/${layer.connection}/layer/${layer.id}`)'
+                            @click='stdclick(router, $event, `/connection/${layer.connection}/layer/${layer.id}`)'
                         >
                             <template v-for='h in header'>
                                 <template v-if='h.display && h.name === "name"'>
                                     <td>
                                         <div class='d-flex align-items-center'>
-                                            <Status :layer='layer' /><span
-                                                class='mx-2'
-                                                v-text='layer[h.name]'
-                                            />
+                                            <Status :layer='layer' />
+                                            <div class='mx-2 row'>
+                                                <div
+                                                    class='subheader'
+                                                    v-text='layer.parent.name'
+                                                />
+                                                <div v-text='layer[h.name]' />
+                                            </div>
+                                        </div>
+                                    </td>
+                                </template>
+                                <template v-else-if='h.display && h.name === "task"'>
+                                    <td>
+                                        <div class='d-flex align-items-center'>
+                                            <span v-text='layer.task' />
+                                            <div class='mx-2 ms-auto'>
+                                                <IconExchange
+                                                    v-if='layer.incoming && layer.outgoing'
+                                                    title='Outgoing/Incoming'
+                                                    size='32'
+                                                    :stroke='1'
+                                                />
+                                                <IconStackPop
+                                                    v-else-if='layer.outgoing'
+                                                    title='Outgoing'
+                                                    size='32'
+                                                    :stroke='1'
+                                                />
+                                                <IconStackPush
+                                                    v-else-if='layer.incoming'
+                                                    title='Incoming'
+                                                    size='32'
+                                                    :stroke='1'
+                                                />
+                                            </div>
                                         </div>
                                     </td>
                                 </template>
@@ -102,8 +134,10 @@
     </div>
 </template>
 
-<script>
-import { std, stdurl, stdclick } from '/src/std.ts';
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router';
+import { std, stdurl, stdclick } from '../../std.ts';
 import TableHeader from '../util/TableHeader.vue'
 import TableFooter from '../util/TableFooter.vue'
 import Status from '../Layer/utils/StatusDot.vue';
@@ -111,107 +145,97 @@ import {
     TablerNone,
     TablerInput,
     TablerEnum,
-    TablerLoading
+    TablerLoading,
+    TablerAlert,
+    TablerRefreshButton
 } from '@tak-ps/vue-tabler';
 import {
-    IconRefresh,
+    IconExchange,
+    IconStackPop,
+    IconStackPush,
     IconCloudUpload,
 } from '@tabler/icons-vue'
 
-export default {
-    name: 'LayerAdmin',
-    components: {
-        Status,
-        TablerNone,
-        TablerEnum,
-        TablerInput,
-        TablerLoading,
-        IconRefresh,
-        IconCloudUpload,
-        TableHeader,
-        TableFooter,
-    },
-    data: function() {
+const router = useRouter();
+const error = ref(false);
+const loading = ref(true);
+const header = ref([]);
+const paging = ref({
+    filter: '',
+    task: 'All Types',
+    sort: 'name',
+    order: 'asc',
+    limit: 100,
+    page: 0
+});
+const list = ref({
+    total: 0,
+    tasks: [],
+    items: []
+});
+
+const taskTypes = computed(() => {
+    return ["All Types"].concat(list.value.tasks)
+});
+
+watch(paging.value, async () => {
+    await fetchList();
+});
+
+onMounted(async () => {
+    await listLayerSchema();
+    await fetchList();
+});
+
+async function redeploy() {
+    loading.value = true;
+    await std(`/api/layer/redeploy`, {
+        method: 'POST'
+    });
+    loading.value = false;
+}
+
+async function listLayerSchema() {
+    const schema = await std('/api/schema?method=GET&url=/layer');
+    header.value = ['id', 'name', 'task'].map((h) => {
+        return { name: h, display: true };
+    });
+
+    header.value.push(...schema.query.properties.sort.enum.map((h) => {
         return {
-            err: false,
-            loading: true,
-            header: [],
-            paging: {
-                filter: '',
-                task: 'All Types',
-                sort: 'name',
-                order: 'asc',
-                limit: 100,
-                page: 0
-            },
-            list: {
-                total: 0,
-                tasks: [],
-                items: []
-            }
+            name: h,
+            display: false
         }
-    },
-    computed: {
-        taskTypes: function() {
-            return ["All Types"].concat(this.list.tasks)
+    }).filter((h) => {
+        for (const hknown of header.value) {
+            if (hknown.name === h.name) return false;
         }
-    },
-    watch: {
-       paging: {
-            deep: true,
-            handler: async function() {
-                await this.fetchList();
-            }
-        }
-    },
-    mounted: async function() {
-        await this.listLayerSchema();
-        await this.fetchList();
-    },
-    methods: {
-        stdclick,
-        redeploy: async function() {
-            this.loading = true;
-            this.stack = await std(`/api/layer/redeploy`, {
-                method: 'POST'
-            });
-            this.loading = false;
-        },
-        listLayerSchema: async function() {
-            const schema = await std('/api/schema?method=GET&url=/layer');
-            this.header = ['id', 'name', 'cron', 'task'].map((h) => {
-                return { name: h, display: true };
-            });
+        return true;
+    }));
+}
 
-            this.header.push(...schema.query.properties.sort.enum.map((h) => {
-                return {
-                    name: h,
-                    display: false
-                }
-            }).filter((h) => {
-                for (const hknown of this.header) {
-                    if (hknown.name === h.name) return false;
-                }
-                return true;
-            }));
-        },
-        fetchList: async function() {
-            this.loading = true;
-            const url = stdurl('/api/layer');
-            url.searchParams.append('alarms', 'true');
-            url.searchParams.append('filter', this.paging.filter);
-            url.searchParams.append('limit', this.paging.limit);
-            url.searchParams.append('sort', this.paging.sort);
-            url.searchParams.append('order', this.paging.order);
-            url.searchParams.append('page', this.paging.page);
+async function fetchList() {
+    loading.value = true;
+    error.value = undefined;
 
-            if (this.paging.task !== 'All Types') {
-                url.searchParams.append('task', this.paging.task);
-            }
+    try {
+        const url = stdurl('/api/layer');
+        url.searchParams.append('alarms', 'true');
+        url.searchParams.append('filter', paging.value.filter);
+        url.searchParams.append('limit', paging.value.limit);
+        url.searchParams.append('sort', paging.value.sort);
+        url.searchParams.append('order', paging.value.order);
+        url.searchParams.append('page', paging.value.page);
 
-            this.list = await std(url);
-            this.loading = false;
+        if (paging.value.task !== 'All Types') {
+            url.searchParams.append('task', paging.value.task);
         }
+
+        list.value = await std(url);
+        loading.value = false;
+    } catch (err) {
+        loading.value = false;
+        error.value = err instanceof Error ? err : new Error(String(err));
     }
 }
 </script>

--- a/api/web/src/components/CloudTAK/Menu/MenuFiles.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuFiles.vue
@@ -7,7 +7,9 @@
             />
         </template>
         <template #default>
-            <TablerLoading v-if='loading' />
+            <TablerLoading
+                v-if='loading'
+            />
             <TablerAlert
                 v-else-if='error'
                 :err='error'

--- a/api/web/src/components/Layer/LayerIncomingStyles.vue
+++ b/api/web/src/components/Layer/LayerIncomingStyles.vue
@@ -286,7 +286,7 @@ const error_query = computed(() => {
     if (!query.value) return '';
 
     try {
-        jsonata(query.value.query)
+        jsonata(queries.value[query.value].query)
         return '';
     } catch (err) {
         return err.message;

--- a/api/web/src/components/Layer/utils/StatusDot.vue
+++ b/api/web/src/components/Layer/utils/StatusDot.vue
@@ -26,18 +26,13 @@
     </div>
 </template>
 
-<script>
+<script setup lang='ts'>
+import type { ETLLayer } from '../../../types.ts';
 import {
     IconPlayerPause
 } from '@tabler/icons-vue';
 
-export default {
-    name: 'LayerStatus',
-    components: {
-        IconPlayerPause
-    },
-    props: {
-        layer: Object
-    }
-}
+const props = defineProps<{
+    layer: ETLLayer
+}>()
 </script>

--- a/api/web/src/components/Layer/utils/StatusDot.vue
+++ b/api/web/src/components/Layer/utils/StatusDot.vue
@@ -3,7 +3,7 @@
         class='d-flex justify-content-center align-items-center'
         style='width: 36px;'
     >
-        <template v-if='!layer.enabled'>
+        <template v-if='!props.layer.enabled'>
             <IconPlayerPause
                 :size='32'
                 stroke='1'
@@ -13,9 +13,9 @@
             <span
                 class='status-indicator status-indicator-animated'
                 :class='{
-                    "status-green": layer.status === "healthy",
-                    "status-red": layer.status === "alarm",
-                    "status-dark": layer.status === "unknown",
+                    "status-green": props.layer.status === "healthy",
+                    "status-red": props.layer.status === "alarm",
+                    "status-dark": props.layer.status === "unknown",
                 }'
             >
                 <span class='status-indicator-circle' />

--- a/api/web/src/derived-types.d.ts
+++ b/api/web/src/derived-types.d.ts
@@ -302,7 +302,7 @@ export interface paths {
                     /** @description No Description */
                     type?: "raster" | "raster-dem" | "vector";
                     /** @description No Description */
-                    sort: "id" | "created" | "updated" | "name" | "title" | "url" | "overlay" | "username" | "bounds" | "center" | "minzoom" | "maxzoom" | "collection" | "format" | "style" | "styles" | "type" | "enableRLS";
+                    sort: "id" | "created" | "updated" | "name" | "title" | "url" | "overlay" | "username" | "bounds" | "center" | "minzoom" | "maxzoom" | "collection" | "format" | "scheme" | "styles" | "type" | "enableRLS";
                     /** @description Filter results by a human readable name field */
                     filter: string;
                     /** @description Only show Basemaps belonging to a given collection */
@@ -340,7 +340,7 @@ export interface paths {
                                 maxzoom: number;
                                 collection: (null | string) | null;
                                 format: string;
-                                style: string;
+                                scheme: string;
                                 styles: unknown[];
                                 type: string;
                                 bounds?: number[];
@@ -384,7 +384,7 @@ export interface paths {
                             minzoom?: number;
                             maxzoom?: number;
                             /** @constant */
-                            style?: "zxy";
+                            style?: "xyz";
                             format?: "png" | "jpeg" | "mvt";
                         };
                     };
@@ -417,7 +417,7 @@ export interface paths {
                         maxzoom?: number;
                         format?: "png" | "jpeg" | "mvt";
                         /** @constant */
-                        style?: "zxy";
+                        style?: "xyz";
                         type?: "raster" | "raster-dem" | "vector";
                         bounds?: number[];
                         center?: number[];
@@ -445,7 +445,7 @@ export interface paths {
                             maxzoom: number;
                             collection: (null | string) | null;
                             format: string;
-                            style: string;
+                            scheme: string;
                             styles: unknown[];
                             type: string;
                             bounds?: number[];
@@ -507,7 +507,7 @@ export interface paths {
                             maxzoom: number;
                             collection: (null | string) | null;
                             format: string;
-                            style: string;
+                            scheme: string;
                             styles: unknown[];
                             type: string;
                             bounds?: number[];
@@ -565,6 +565,7 @@ export interface paths {
                         /** @description Human readable name */
                         name?: string;
                         collection?: null | string;
+                        overlay?: boolean;
                         /** @default user */
                         scope: "server" | "user";
                         url?: string;
@@ -572,7 +573,7 @@ export interface paths {
                         maxzoom?: number;
                         format?: "png" | "jpeg" | "mvt";
                         /** @constant */
-                        style?: "zxy";
+                        style?: "xyz";
                         type?: "raster" | "raster-dem" | "vector";
                         bounds?: number[];
                         center?: number[];
@@ -600,7 +601,7 @@ export interface paths {
                             maxzoom: number;
                             collection: (null | string) | null;
                             format: string;
-                            style: string;
+                            scheme: string;
                             styles: unknown[];
                             type: string;
                             bounds?: number[];
@@ -642,17 +643,27 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            tilejson: string;
+                            /** @constant */
+                            tilejson: "3.0.0";
                             version: string;
+                            /** @constant */
+                            scheme: "xyz";
                             name: string;
+                            description: string;
+                            attribution?: string;
                             minzoom: number;
                             maxzoom: number;
                             tiles: string[];
                             bounds: number[];
                             center: number[];
                             type: string;
-                            layers: unknown[];
                             format?: string;
+                            vector_layers: {
+                                id: string;
+                                minzoom: number;
+                                maxzoom: number;
+                                fields: Record<string, never>;
+                            }[];
                         };
                     };
                 };
@@ -692,6 +703,60 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/basemap/{:basemapid}/feature/{:featureid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a basemap feature */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @constant */
+                            type: "Feature";
+                            properties: Record<string, never>;
+                            geometry: {
+                                /** @constant */
+                                type: "Point";
+                                coordinates: number[];
+                            } | {
+                                /** @constant */
+                                type: "LineString";
+                                coordinates: number[][];
+                            } | {
+                                /** @constant */
+                                type: "Polygon";
+                                coordinates: number[][][];
+                            };
+                        };
+                    };
                 };
             };
         };
@@ -2949,6 +3014,11 @@ export interface paths {
                                 memory: number;
                                 timeout: number;
                                 priority: "high" | "low" | "off";
+                                parent: {
+                                    id: number;
+                                    name: string;
+                                    enabled: boolean;
+                                };
                                 incoming?: {
                                     layer: number;
                                     created: string;
@@ -3016,14 +3086,8 @@ export interface paths {
                                         }[];
                                         queries?: {
                                             query: string;
-                                            id?: string;
-                                            remarks?: string;
-                                            callsign?: string;
-                                            links?: {
-                                                remarks: string;
-                                                url: string;
-                                            }[];
-                                            styles: {
+                                            delete?: boolean;
+                                            styles?: {
                                                 id?: string;
                                                 remarks?: string;
                                                 callsign?: string;
@@ -3144,6 +3208,11 @@ export interface paths {
                             memory: number;
                             timeout: number;
                             priority: "high" | "low" | "off";
+                            parent: {
+                                id: number;
+                                name: string;
+                                enabled: boolean;
+                            };
                             incoming?: {
                                 layer: number;
                                 created: string;
@@ -3211,14 +3280,8 @@ export interface paths {
                                     }[];
                                     queries?: {
                                         query: string;
-                                        id?: string;
-                                        remarks?: string;
-                                        callsign?: string;
-                                        links?: {
-                                            remarks: string;
-                                            url: string;
-                                        }[];
-                                        styles: {
+                                        delete?: boolean;
+                                        styles?: {
                                             id?: string;
                                             remarks?: string;
                                             callsign?: string;
@@ -3369,14 +3432,8 @@ export interface paths {
                             }[];
                             queries?: {
                                 query: string;
-                                id?: string;
-                                remarks?: string;
-                                callsign?: string;
-                                links?: {
-                                    remarks: string;
-                                    url: string;
-                                }[];
-                                styles: {
+                                delete?: boolean;
+                                styles?: {
                                     id?: string;
                                     remarks?: string;
                                     callsign?: string;
@@ -3514,14 +3571,8 @@ export interface paths {
                                 }[];
                                 queries?: {
                                     query: string;
-                                    id?: string;
-                                    remarks?: string;
-                                    callsign?: string;
-                                    links?: {
-                                        remarks: string;
-                                        url: string;
-                                    }[];
-                                    styles: {
+                                    delete?: boolean;
+                                    styles?: {
                                         id?: string;
                                         remarks?: string;
                                         callsign?: string;
@@ -3673,14 +3724,8 @@ export interface paths {
                             }[];
                             queries?: {
                                 query: string;
-                                id?: string;
-                                remarks?: string;
-                                callsign?: string;
-                                links?: {
-                                    remarks: string;
-                                    url: string;
-                                }[];
-                                styles: {
+                                delete?: boolean;
+                                styles?: {
                                     id?: string;
                                     remarks?: string;
                                     callsign?: string;
@@ -3821,14 +3866,8 @@ export interface paths {
                                 }[];
                                 queries?: {
                                     query: string;
-                                    id?: string;
-                                    remarks?: string;
-                                    callsign?: string;
-                                    links?: {
-                                        remarks: string;
-                                        url: string;
-                                    }[];
-                                    styles: {
+                                    delete?: boolean;
+                                    styles?: {
                                         id?: string;
                                         remarks?: string;
                                         callsign?: string;
@@ -4033,6 +4072,11 @@ export interface paths {
                             memory: number;
                             timeout: number;
                             priority: "high" | "low" | "off";
+                            parent: {
+                                id: number;
+                                name: string;
+                                enabled: boolean;
+                            };
                             incoming?: {
                                 layer: number;
                                 created: string;
@@ -4100,14 +4144,8 @@ export interface paths {
                                     }[];
                                     queries?: {
                                         query: string;
-                                        id?: string;
-                                        remarks?: string;
-                                        callsign?: string;
-                                        links?: {
-                                            remarks: string;
-                                            url: string;
-                                        }[];
-                                        styles: {
+                                        delete?: boolean;
+                                        styles?: {
                                             id?: string;
                                             remarks?: string;
                                             callsign?: string;
@@ -4253,6 +4291,11 @@ export interface paths {
                             memory: number;
                             timeout: number;
                             priority: "high" | "low" | "off";
+                            parent: {
+                                id: number;
+                                name: string;
+                                enabled: boolean;
+                            };
                             incoming?: {
                                 layer: number;
                                 created: string;
@@ -4320,14 +4363,8 @@ export interface paths {
                                     }[];
                                     queries?: {
                                         query: string;
-                                        id?: string;
-                                        remarks?: string;
-                                        callsign?: string;
-                                        links?: {
-                                            remarks: string;
-                                            url: string;
-                                        }[];
-                                        styles: {
+                                        delete?: boolean;
+                                        styles?: {
                                             id?: string;
                                             remarks?: string;
                                             callsign?: string;
@@ -6960,6 +6997,11 @@ export interface paths {
                                 memory: number;
                                 timeout: number;
                                 priority: "high" | "low" | "off";
+                                parent: {
+                                    id: number;
+                                    name: string;
+                                    enabled: boolean;
+                                };
                                 incoming?: {
                                     layer: number;
                                     created: string;
@@ -7027,14 +7069,8 @@ export interface paths {
                                         }[];
                                         queries?: {
                                             query: string;
-                                            id?: string;
-                                            remarks?: string;
-                                            callsign?: string;
-                                            links?: {
-                                                remarks: string;
-                                                url: string;
-                                            }[];
-                                            styles: {
+                                            delete?: boolean;
+                                            styles?: {
                                                 id?: string;
                                                 remarks?: string;
                                                 callsign?: string;
@@ -7157,6 +7193,11 @@ export interface paths {
                             memory: number;
                             timeout: number;
                             priority: "high" | "low" | "off";
+                            parent: {
+                                id: number;
+                                name: string;
+                                enabled: boolean;
+                            };
                             incoming?: {
                                 layer: number;
                                 created: string;
@@ -7224,14 +7265,8 @@ export interface paths {
                                     }[];
                                     queries?: {
                                         query: string;
-                                        id?: string;
-                                        remarks?: string;
-                                        callsign?: string;
-                                        links?: {
-                                            remarks: string;
-                                            url: string;
-                                        }[];
-                                        styles: {
+                                        delete?: boolean;
+                                        styles?: {
                                             id?: string;
                                             remarks?: string;
                                             callsign?: string;
@@ -12640,6 +12675,9 @@ export interface paths {
                                 mode: string;
                                 mode_id: string | null;
                                 url: string;
+                                actions: {
+                                    feature: ("query" | "fetch" | "create" | "update" | "delete")[];
+                                };
                             }[];
                         };
                     };
@@ -12693,6 +12731,9 @@ export interface paths {
                             mode: string;
                             mode_id: string | null;
                             url: string;
+                            actions: {
+                                feature: ("query" | "fetch" | "create" | "update" | "delete")[];
+                            };
                         };
                     };
                 };
@@ -12768,6 +12809,9 @@ export interface paths {
                             mode: string;
                             mode_id: string | null;
                             url: string;
+                            actions: {
+                                feature: ("query" | "fetch" | "create" | "update" | "delete")[];
+                            };
                         };
                     };
                 };
@@ -12821,6 +12865,9 @@ export interface paths {
                             mode: string;
                             mode_id: string | null;
                             url: string;
+                            actions: {
+                                feature: ("query" | "fetch" | "create" | "update" | "delete")[];
+                            };
                         };
                     };
                 };


### PR DESCRIPTION
### Context

- :rocket: Show Connection name in Admin Layer List
- :rocket: Show incoming/outgoing/bidirectional status in Admin Layer List
- :rocket: Remove `cron` header by default in Admin Layer List as that is specific to incoming layers
- :bug: Fix filtering bug when JSONata query is set to delete data
- :rocket: Migrate AdminConnection Component to `setup`
- - :rocket: Migrate AdminLayer Component to `setup`