### PR TITLE
Lambda Invocaion Type

### DIFF
--- a/api/routes/connection-layer.ts
+++ b/api/routes/connection-layer.ts
@@ -439,6 +439,10 @@ export default async function router(schema: Schema, config: Config) {
 
             await config.cacher.del(`layer-${req.params.layerid}`);
 
+            if (req.body.environment) {
+                await Lambda.invoke(config, layer.id, 'environment:incoming')
+            }
+
             res.json(incoming);
         } catch (err) {
             Err.respond(err, res);
@@ -592,6 +596,10 @@ export default async function router(schema: Schema, config: Config) {
             const outgoing = await config.models.LayerOutgoing.commit(layer.id, updated);
 
             await config.cacher.del(`layer-${req.params.layerid}`);
+
+            if (req.body.environment) {
+                await Lambda.invoke(config, layer.id, 'environment:outgoing')
+            }
 
             res.json(outgoing);
         } catch (err) {


### PR DESCRIPTION
### Context

This PR introduces a new Lambda ETL Event of either `environment:incoming` OR `environment:outgoing` that will be fired any time a Layer's Incoming or Outgoing environment is changed.

This will directly support the ability to dynamically specify new columns in AGOL sources and have the ETL dynamically provision them on the ESRI Server.

ETLs will need to update to the simultaneously release: https://github.com/dfpc-coe/etl-base/releases/tag/v9.9.0

cc/ @adrienhoff @bs-in-co 