### PR TITLE
Fix Reactivity

### DIFF
--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -1,3 +1,4 @@
+import { reactive } from 'vue';
 import { std } from '../std.ts';
 import { bbox } from '@turf/bbox'
 import { isEqual } from '@react-hookz/deep-equal';
@@ -108,7 +109,13 @@ export default class COT {
         if (!opts || (opts && opts.skipSave !== true)) {
             this.save();
         }
+    }
 
+    /**
+     * Begin listening for remote updates
+     * This is a seperate function due to the issues outlined in: https://stackoverflow.com/q/70184129
+     */
+    remote() {
         if (this._remote) {
             // The sync BroadcastChannel will post a message anytime the underlying
             // Atlas database has a COT update, resulting in a sync with the frontend
@@ -121,6 +128,8 @@ export default class COT {
                     Object.assign(this._geometry, ev.data.geometry);
                 }
             };
+        } else {
+            throw new Error('Only Remote instances can listen for updates');
         }
     }
 

--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -1,4 +1,3 @@
-import { reactive } from 'vue';
 import { std } from '../std.ts';
 import { bbox } from '@turf/bbox'
 import { isEqual } from '@react-hookz/deep-equal';

--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -115,7 +115,7 @@ export default class COT {
      * Begin listening for remote updates
      * This is a seperate function due to the issues outlined in: https://stackoverflow.com/q/70184129
      */
-    remote() {
+    reactivity() {
         if (this._remote) {
             // The sync BroadcastChannel will post a message anytime the underlying
             // Atlas database has a COT update, resulting in a sync with the frontend

--- a/api/web/src/components/CloudTAK/CoTView.vue
+++ b/api/web/src/components/CloudTAK/CoTView.vue
@@ -868,6 +868,8 @@ async function load_cot() {
     if (baseCOT) {
         cot.value = baseCOT
 
+        cot.value.remote();
+
         if (cot.value.is_skittle) {
             username.value = await cot.value.username()
         } else {

--- a/api/web/src/components/CloudTAK/CoTView.vue
+++ b/api/web/src/components/CloudTAK/CoTView.vue
@@ -868,7 +868,7 @@ async function load_cot() {
     if (baseCOT) {
         cot.value = baseCOT
 
-        cot.value.remote();
+        cot.value.reactivity();
 
         if (cot.value.is_skittle) {
             username.value = await cot.value.username()


### PR DESCRIPTION
### Context

Vue3 uses a proxy when wrapped by `ref` or `reactive` to handle updating state in the DOM when underlying updates are made to the wrapped object. Since this wrapping takes place AFTER class construction, internal updates were not properly triggering DOM updates.

This PR makes underlying updates a manual but necessary function call to ensure that the class is wrapped by Proxy 