### PR TITLE
Fix CSV Import Delimiter Issue

### DIFF
--- a/api/web/src/components/Layer/utils/Schema.vue
+++ b/api/web/src/components/Layer/utils/Schema.vue
@@ -283,9 +283,13 @@ export default {
         },
         importCSV: function(csv) {
             this.upload.shown = false;
+            
+            // Auto-detect delimiter: prefer comma, fallback to tab for backward compatibility
+            const firstLine = csv.split('\n')[0];
+            const delimiter = firstLine.includes(',') ? ',' : '\t';
 
             for (const line of csv.split('\n')) {
-                const row = line.split('\t');
+                const row = line.split(delimiter);
                 const obj = {};
                 for (let i = 0; i < this.upload.headers.length; i++) {
                     obj[this.upload.headers[i]] = row[i]


### PR DESCRIPTION
Addresses #634

# Fix CSV Import Delimiter Issue

## Problem
The `importCSV` function was incorrectly splitting on tab characters (`\t`) instead of commas, which is misleading since CSV stands for "Comma Separated Values."

## Solution
- Added auto-detection logic that prioritizes comma delimiter (proper CSV standard)
- Falls back to tab delimiter only when no commas are found in the first line
- Maintains backward compatibility for existing users with tab-separated files

## Changes
- Modified `importCSV` method in `Schema.vue` to detect delimiter automatically
- Preserves existing functionality while fixing the core CSV parsing issue

## Testing
- [ ] Test with comma-separated CSV files
- [ ] Test with tab-separated files (backward compatibility)
- [ ] Verify import functionality works as expected

This is a minimal fix that addresses the standards violation while maintaining compatibility.
