### PR TITLE
Make ECR Repository and ECS Cluster Names Configurable

### DIFF
--- a/api/lib/aws/ecr.ts
+++ b/api/lib/aws/ecr.ts
@@ -2,6 +2,8 @@ import AWSECR, { ImageIdentifier, ListImagesCommandInput } from '@aws-sdk/client
 import Err from '@openaddresses/batch-error';
 import process from 'node:process';
 
+const ECR_TASKS_REPOSITORY = process.env.ECR_TASKS_REPOSITORY_NAME || 'coe-ecr-etl-tasks';
+
 /**
  * @class
  */
@@ -14,7 +16,7 @@ export default class ECR {
 
             let res;
             do {
-                const req: ListImagesCommandInput = { repositoryName: 'coe-ecr-etl-tasks' };
+                const req: ListImagesCommandInput = { repositoryName: ECR_TASKS_REPOSITORY };
                 if (res && res.nextToken) req.nextToken = res.nextToken;
                 res = await ecr.send(new AWSECR.ListImagesCommand(req));
                 imageIds.push(...(res.imageIds || []));
@@ -31,7 +33,7 @@ export default class ECR {
 
         try {
             await ecr.send(new AWSECR.BatchDeleteImageCommand({
-                repositoryName: 'coe-ecr-etl-tasks',
+                repositoryName: ECR_TASKS_REPOSITORY,
                 imageIds: [{ imageTag: `${task}-v${version}` }]
             }));
         } catch (err) {

--- a/api/lib/aws/ecs-video.ts
+++ b/api/lib/aws/ecs-video.ts
@@ -7,6 +7,8 @@ import Config from '../config.js';
 import Err from '@openaddresses/batch-error';
 import process from 'node:process';
 
+const ECS_CLUSTER_PREFIX = process.env.ECS_CLUSTER_PREFIX || 'coe-ecs';
+
 /**
  * @class
  */
@@ -54,7 +56,7 @@ export default class ECSVideo {
             const ecs = new AWSECS.ECSClient({ region: process.env.AWS_REGION });
 
             const descs = await ecs.send(new AWSECS.DescribeTasksCommand({
-                cluster: `coe-ecs-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
+                cluster: `${ECS_CLUSTER_PREFIX}-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
                 tasks: [task]
             }));
 
@@ -81,7 +83,7 @@ export default class ECSVideo {
             const ecs = new AWSECS.ECSClient({ region: process.env.AWS_REGION });
 
             await ecs.send(new AWSECS.StopTaskCommand({
-                cluster: `coe-ecs-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
+                cluster: `${ECS_CLUSTER_PREFIX}-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
                 task: task,
                 reason: 'User Requested Termination from CloudTAK'
             }));
@@ -101,7 +103,7 @@ export default class ECSVideo {
             let res;
             do {
                 const req: ListTasksCommandInput = {
-                    cluster: `coe-ecs-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
+                    cluster: `${ECS_CLUSTER_PREFIX}-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
                     family: `coe-media-${this.config.StackName.replace(/^tak-cloudtak-/, '')}-task`
                 };
 
@@ -113,7 +115,7 @@ export default class ECSVideo {
             if (!taskArns.length) return [];
 
             const descs = await ecs.send(new AWSECS.DescribeTasksCommand({
-                cluster: `coe-ecs-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
+                cluster: `${ECS_CLUSTER_PREFIX}-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
                 tasks: taskArns
             }));
 
@@ -138,7 +140,7 @@ export default class ECSVideo {
             if (!this.config.MediaSecurityGroup) throw new Err(400, null, 'Media Security Group is not configured - Contact your administrator');
 
             const res = await ecs.send(new AWSECS.RunTaskCommand({
-                cluster: `coe-ecs-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
+                cluster: `${ECS_CLUSTER_PREFIX}-${this.config.StackName.replace(/^tak-cloudtak-/, '')}`,
                 count: 1,
                 enableECSManagedTags: true,
                 launchType: 'FARGATE',

--- a/api/lib/aws/lambda.ts
+++ b/api/lib/aws/lambda.ts
@@ -10,6 +10,8 @@ import { Static } from '@sinclair/typebox'
 import { StackFrame } from './cloudformation.js';
 import { Capabilities } from '@tak-ps/etl'
 
+const ECR_TASKS_REPOSITORY = process.env.ECR_TASKS_REPOSITORY_NAME || 'coe-ecr-etl-tasks';
+
 /**
  * @class
  */
@@ -93,7 +95,7 @@ export default class Lambda {
                         },
                         Role: cf.importValue(config.StackName + '-etl-role'),
                         Code: {
-                            ImageUri: cf.join([cf.accountId, '.dkr.ecr.', cf.region, `.amazonaws.com/coe-ecr-etl-tasks:`, cf.ref('Task')])
+                            ImageUri: cf.join([cf.accountId, '.dkr.ecr.', cf.region, `.amazonaws.com/${ECR_TASKS_REPOSITORY}:`, cf.ref('Task')])
                         }
                     }
                 }

--- a/api/test/task.srv.test.ts
+++ b/api/test/task.srv.test.ts
@@ -5,6 +5,8 @@ import {
     ECRClient
 } from '@aws-sdk/client-ecr';
 
+const ECR_TASKS_REPOSITORY = process.env.ECR_TASKS_REPOSITORY_NAME || 'coe-ecr-etl-tasks';
+
 const flight = new Flight();
 
 flight.init();
@@ -15,7 +17,7 @@ test('GET: api/task - empty', async (t) => {
     try {
         Sinon.stub(ECRClient.prototype, 'send').callsFake((command) => {
             t.deepEquals(command.input, {
-                repositoryName: 'coe-ecr-etl-tasks'
+                repositoryName: ECR_TASKS_REPOSITORY
             });
             return Promise.resolve({ imageIds: [] });
         });
@@ -43,7 +45,7 @@ test('GET: api/task - empty', async (t) => {
     try {
         Sinon.stub(ECRClient.prototype, 'send').callsFake((command) => {
             t.deepEquals(command.input, {
-                repositoryName: 'coe-ecr-etl-tasks'
+                repositoryName: ECR_TASKS_REPOSITORY
             });
 
             return Promise.resolve({


### PR DESCRIPTION
# Make ECR Repository and ECS Cluster Names Configurable

Fixes #707

## Problem
CloudTAK API contains hardcoded ECR repository names that prevent deployment in environments with different naming conventions, blocking CDK-based deployments.

## Solution
Added environment variable configuration with backward compatibility:

- `ECR_TASKS_REPOSITORY_NAME` - Configures ECR repository name (default: `coe-ecr-etl-tasks`)
- `ECS_CLUSTER_PREFIX` - Configures ECS cluster prefix (default: `coe-ecs`)

## Changes
- **api/lib/aws/ecr.ts** - 2 hardcoded references replaced
- **api/lib/aws/ecs-video.ts** - 5 hardcoded references replaced  
- **api/lib/aws/lambda.ts** - 1 hardcoded reference replaced
- **api/test/task.srv.test.ts** - 2 test assertions updated

## Benefits
- ✅ Enables CDK deployments with custom naming
- ✅ Maintains full backward compatibility
- ✅ Minimal code changes (10 lines total)
- ✅ Separates deployment config from application code
