### PR TITLE
Move Invoke to incoming

### DIFF
--- a/api/web/src/components/CloudTAK/util/FloatingVideo.vue
+++ b/api/web/src/components/CloudTAK/util/FloatingVideo.vue
@@ -294,12 +294,12 @@ async function createPlayer(): Promise<void> {
         player.value.attachMedia(videoTag.value!);
 
         player.value.on(Hls.Events.MEDIA_ATTACHED, async () => {
-            player.value.loadSource(url.toString());
+            if (player.value) player.value.loadSource(url.toString());
         });
 
         player.value.on(Hls.Events.MANIFEST_PARSED, async () => {
             try {
-                await videoTag.value.play();
+                if (videoTag.value) await videoTag.value.play();
             } catch (err) {
                 console.error("Error playing video:", err);
                 error.value = new Error('Failed to play video');
@@ -319,7 +319,9 @@ async function createPlayer(): Promise<void> {
                         break;
                     case Hls.ErrorTypes.MEDIA_ERROR:
                         console.log("Fatal media error encountered", data);
-                        player.value.recoverMediaError();
+                        if (player.value) {
+                            player.value.recoverMediaError();
+                        }
                         break;
                     default:
                         if (player.value) player.value.destroy();

--- a/api/web/src/components/Layer/LayerDeployment.vue
+++ b/api/web/src/components/Layer/LayerDeployment.vue
@@ -7,16 +7,6 @@
             <div class='ms-auto'>
                 <div class='btn-list'>
                     <TablerIconButton
-                        title='Manual Run'
-                        @click='invoke'
-                    >
-                        <IconPlayerPlay
-                            :size='24'
-                            stroke='1'
-                        />
-                    </TablerIconButton>
-
-                    <TablerIconButton
                         title='Redeploy'
                         @click='redeploy'
                     >
@@ -245,7 +235,6 @@ import {
     TablerLoading
 } from '@tak-ps/vue-tabler';
 import {
-    IconPlayerPlay,
     IconPencil,
     IconRefresh,
     IconSettings,
@@ -304,14 +293,6 @@ async function refresh() {
     disabled.value = true;
 
     await fetchLogs();
-}
-
-async function invoke() {
-    loading.value.full = true;
-    await std(`/api/connection/${route.params.connectionid}/layer/${route.params.layerid}/task/invoke`, {
-        method: 'POST'
-    });
-    loading.value.full = false;
 }
 
 async function redeploy(showLoading=true) {

--- a/api/web/src/components/Layer/LayerIncomingConfig.vue
+++ b/api/web/src/components/Layer/LayerIncomingConfig.vue
@@ -346,11 +346,17 @@ function reload() {
 }
 
 async function invoke() {
-    loading.value.full = true;
-    await std(`/api/connection/${route.params.connectionid}/layer/${route.params.layerid}/task/invoke`, {
-        method: 'POST'
-    });
-    loading.value.full = false;
+    loading.value.init = true;
+    try {
+        await std(`/api/connection/${route.params.connectionid}/layer/${route.params.layerid}/task/invoke`, {
+            method: 'POST'
+        });
+
+        loading.value.init = false;
+    } catch (err) {
+        loading.value.init = false;
+        throw err;
+    }
 }
 
 

--- a/api/web/src/components/Layer/LayerIncomingConfig.vue
+++ b/api/web/src/components/Layer/LayerIncomingConfig.vue
@@ -6,6 +6,17 @@
             </h3>
             <div class='ms-auto btn-list'>
                 <TablerIconButton
+                    v-if='disabled && cronEnabled'
+                    title='Manual Run'
+                    @click='invoke'
+                >
+                    <IconPlayerPlay
+                        :size='32'
+                        stroke='1'
+                    />
+                </TablerIconButton>
+
+                <TablerIconButton
                     v-if='disabled'
                     title='Edit Layer Config'
                     @click='disabled = false'
@@ -35,7 +46,7 @@
                     v-if='props.capabilities ? props.capabilities.incoming.invocation.includes("schedule") : true'
                     class='col-md-12'
                 >
-                    <div class='d-flex'>
+                    <div class='d-flex align-items-center'>
                         <IconCalendarClock
                             :size='20'
                             stroke='1'
@@ -112,7 +123,7 @@
                     v-if='props.capabilities ? props.capabilities.incoming.invocation.includes("webhook") : true'
                     class='col-md-12'
                 >
-                    <div class='d-flex'>
+                    <div class='d-flex align-items-center'>
                         <IconWebhook
                             :size='20'
                             stroke='1'
@@ -279,6 +290,7 @@ import {
     IconSquareChevronRight,
     IconCalendarClock,
     IconChevronDown,
+    IconPlayerPlay,
     IconWebhook,
     IconPencil,
     IconSettings,
@@ -332,6 +344,15 @@ function reload() {
     cronEnabled.value = !!incoming.value.cron
     disabled.value = true;
 }
+
+async function invoke() {
+    loading.value.full = true;
+    await std(`/api/connection/${route.params.connectionid}/layer/${route.params.layerid}/task/invoke`, {
+        method: 'POST'
+    });
+    loading.value.full = false;
+}
+
 
 function cronstr(cron?: string) {
     if (!cron) return;


### PR DESCRIPTION
### Context

The "Play" button for a layer ETL only invokes the function that handles scheduled runs on incoming ETLs. As such it no longer makes sense to show this on the top level deployment card which can support unsupported ETLS ie: webhooks or outgoing where the "play" button would perform no action.

This PR moves the play button to the Incoming Config page and only shows it if incoming schedules are configured.

Closes: https://github.com/dfpc-coe/CloudTAK/issues/646