### PR TITLE
Schema support for numeric types

### DIFF
--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -3910,9 +3910,9 @@
             }
         },
         "node_modules/@tak-ps/vue-tabler": {
-            "version": "3.68.5",
-            "resolved": "https://registry.npmjs.org/@tak-ps/vue-tabler/-/vue-tabler-3.68.5.tgz",
-            "integrity": "sha512-vvNzEbnHVpIU40nLv3KFxxcULszFT7e2EbjsL1HPEcurq77MFbY/aiuAR9+bNw5es1yaiEqSWjYGsoMfKk0RWw==",
+            "version": "3.69.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/vue-tabler/-/vue-tabler-3.69.0.tgz",
+            "integrity": "sha512-+sADjp3G/7xQTK3F0AAWTFZcTs6lyyFQ2ewnyeT0ZsQxO2rFciZnuVHWwd7c5IxvChKoLm5C1IWnRkVX2W+lmg==",
             "license": "ISC",
             "dependencies": {
                 "@tabler/icons-vue": "^3.0.0",

--- a/api/web/src/components/Layer/utils/Schema.vue
+++ b/api/web/src/components/Layer/utils/Schema.vue
@@ -29,6 +29,18 @@
                     :description='schema.properties[key].description'
                 />
             </template>
+            <template v-else-if='schema.properties[key].type === "number" || schema.properties[key].type === "integer"'>
+                <TablerInput
+                    v-model='data[key]'
+                    type='number'
+                    :label='key'
+                    :step='schema.properties[key].type === "integer" ? 1 : "any"'
+                    :disabled='disabled'
+                    :default='schema.properties[key].default'
+                    :required='schema.required.includes(key)'
+                    :description='schema.properties[key].description'
+                />
+            </template>
             <template v-else-if='schema.properties[key].type === "boolean"'>
                 <TablerToggle
                     v-model='data[key]'
@@ -271,6 +283,10 @@ export default {
                     this.data[key] = this.schema.properties[key].default || false;
                 } else if (!this.data[key] && this.schema.properties[key].type === 'string') {
                     this.data[key] = this.schema.properties[key].default || '';
+                } else if (!this.data[key] && this.schema.properties[key].type === 'integer') {
+                    this.data[key] = this.schema.properties[key].default;
+                } else if (!this.data[key] && this.schema.properties[key].type === 'number') {
+                    this.data[key] = this.schema.properties[key].default;
                 }
             }
         }
@@ -283,7 +299,7 @@ export default {
         },
         importCSV: function(csv) {
             this.upload.shown = false;
-            
+
             // Auto-detect delimiter: prefer comma, fallback to tab for backward compatibility
             const firstLine = csv.split('\n')[0];
             const delimiter = firstLine.includes(',') ? ',' : '\t';


### PR DESCRIPTION
### Context

Adds the following support to the Layer Environment Editor
- Apply defaults to `integer` type if available
- Apply defaults to `number` type if available
- Treat number as a numeric input type
- Treat integer as a numeric input type with `step: 1`