### PR TITLE
Draw Tool Components

### DIFF
--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -20,6 +20,7 @@
                 "@turf/boolean-within": "^7.1.0",
                 "@turf/destination": "^7.2.0",
                 "@turf/distance": "^7.2.0",
+                "@turf/ellipse": "^7.2.0",
                 "@turf/envelope": "^7.1.0",
                 "@turf/length": "^7.2.0",
                 "@turf/meta": "^7.2.0",

--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.web",
-    "version": "10.16.0",
+    "version": "10.18.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.web",
-            "version": "10.16.0",
+            "version": "10.18.0",
             "dependencies": {
                 "@react-hookz/deep-equal": "^3.0.3",
                 "@tabler/core": "1.0.0",
@@ -3878,9 +3878,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "13.3.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-13.3.0.tgz",
-            "integrity": "sha512-YACf2TQ9H8tTrY8bQ0Nv1H09N39+xheIjFEiSfMB8sdf0fVwJFYYJWHZImXL1JAWD+Ib5ADShnJgY43FlX5KEA==",
+            "version": "13.4.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-13.4.0.tgz",
+            "integrity": "sha512-OstvRK6nQ6BXRtrhR+yqizcH8JLFKKSDHdhu8IOGdY31rGog9L/6NHQoC6dcx4et8bnBzpg0LKToQxney2TP5w==",
             "license": "MIT",
             "dependencies": {
                 "@openaddresses/batch-error": "^2.4.0",

--- a/api/web/package.json
+++ b/api/web/package.json
@@ -27,6 +27,7 @@
         "@turf/boolean-within": "^7.1.0",
         "@turf/destination": "^7.2.0",
         "@turf/distance": "^7.2.0",
+        "@turf/ellipse": "^7.2.0",
         "@turf/envelope": "^7.1.0",
         "@turf/length": "^7.2.0",
         "@turf/meta": "^7.2.0",

--- a/api/web/src/App.vue
+++ b/api/web/src/App.vue
@@ -32,10 +32,10 @@
                 >
                     <div class='btn-list'>
                         <a
-                            @click='externalDocs'
                             class='btn btn-dark'
                             target='_blank'
                             rel='noreferrer'
+                            @click='externalDocs'
                         >
                             <IconCode
                                 size='32'

--- a/api/web/src/base/utils/styles.ts
+++ b/api/web/src/base/utils/styles.ts
@@ -22,7 +22,11 @@ export default function styles(id: string, opts: {
         id: `${id}-poly`,
         type: 'fill',
         source: id,
-        filter: ["==", "$type", "Polygon"],
+        filter: [
+            'all',
+            ['==', '$type', 'Polygon'],
+            ['!=', 'fill-opacity', 0],
+        ],
         layout: {},
         paint: {
             'fill-opacity': ["number", ["get", "fill-opacity"], 1],
@@ -271,7 +275,13 @@ export default function styles(id: string, opts: {
             id: `${id}-text-line`,
             type: 'symbol',
             source: id,
-            filter: [ 'all', ['==', '$type', 'LineString'], ],
+            filter: [ 'any',
+                ['==', '$type', 'LineString'],
+                ['all',
+                    ['==', '$type', 'Polygon'],
+                    ['==', 'fill-opacity', 0]
+                ]
+            ],
             minzoom: MIN_LABEL_ZOOM,
             paint: {
                 'text-color': '#ffffff',
@@ -307,7 +317,11 @@ export default function styles(id: string, opts: {
             id: `${id}-text-poly`,
             type: 'symbol',
             source: id,
-            filter: [ 'all', ['==', '$type', 'Polygon'], ],
+            filter: [
+                'all',
+                ['==', '$type', 'Polygon'],
+                ['!=', 'fill-opacity', 0],
+            ],
             minzoom: MIN_LABEL_ZOOM,
             paint: {
                 'text-color': '#ffffff',

--- a/api/web/src/components/CloudTAK/DrawTools.vue
+++ b/api/web/src/components/CloudTAK/DrawTools.vue
@@ -1,0 +1,145 @@
+<template>
+    <TablerDropdown>
+        <template #default>
+            <TablerIconButton
+                title='Geometry Editing'
+                class='mx-2 cursor-pointer hover-button'
+                @click='closeAllMenu'
+            >
+                <IconPencil
+                    :size='40'
+                    stroke='1'
+                />
+            </TablerIconButton>
+        </template>
+        <template #dropdown>
+            <div
+                class='card py-1'
+                style='min-width: 300px;'
+            >
+                <div class='card-body'>
+                    <div class='card-title'>
+                        Drawing Tools
+                    </div>
+                </div>
+                <div class='card-body'>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='pointInput = true'
+                    >
+                        <IconCursorText
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Coordinate Input</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='rangeInput = true'
+                    >
+                        <IconCompass
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Range &amp; Bearing</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.POINT)'
+                    >
+                        <IconPoint
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Draw Point</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.LINESTRING)'
+                    >
+                        <IconLine
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Draw Line</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.POLYGON)'
+                    >
+                        <IconPolygon
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Draw Polygon</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.RECTANGLE)'
+                    >
+                        <IconVector
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Draw Rectangle</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.CIRCLE)'
+                    >
+                        <IconCircle
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Draw Circle</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.SECTOR)'
+                    >
+                        <IconCone
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Draw Sector</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='mapStore.draw.start(DrawToolMode.FREEHAND)'
+                    >
+                        <IconLasso
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Lasso Select</span>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </TablerDropdown>
+</template>
+
+<script setup lang='ts'>
+import { useRouter } from 'vue-router';
+import {
+    IconLasso,
+    IconCone,
+    IconCircle,
+    IconVector,
+    IconPolygon,
+    IconLine,
+    IconPoint,
+    IconCompass,
+    IconCursorText,
+    IconPencil,
+} from '@tabler/icons-vue';
+import { useMapStore } from '../../stores/map';
+import {
+    TablerIconButton,
+    TablerDropdown,
+} from '@tak-ps/vue-tabler';
+
+const mapStore = useMapStore();
+
+const router = useRouter();
+</script>

--- a/api/web/src/components/CloudTAK/DrawTools.vue
+++ b/api/web/src/components/CloudTAK/DrawTools.vue
@@ -4,7 +4,6 @@
             <TablerIconButton
                 title='Geometry Editing'
                 class='mx-2 cursor-pointer hover-button'
-                @click='closeAllMenu'
             >
                 <IconPencil
                     :size='40'
@@ -25,7 +24,7 @@
                 <div class='card-body'>
                     <div
                         class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                        @click='pointInput = true'
+                        @click='modal = ModalInputType.POINT'
                     >
                         <IconCursorText
                             :size='25'
@@ -35,7 +34,7 @@
                     </div>
                     <div
                         class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                        @click='rangeInput = true'
+                        @click='modal = ModalInputType.RANGE'
                     >
                         <IconCompass
                             :size='25'
@@ -105,6 +104,16 @@
                     </div>
                     <div
                         class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
+                        @click='modal = ModalInputType.LOST_PERSON_BEHAVIOR'
+                    >
+                        <IconWalk
+                            :size='25'
+                            stroke='1'
+                        />
+                        <span class='ps-2'>Lost Person Behavior</span>
+                    </div>
+                    <div
+                        class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
                         @click='mapStore.draw.start(DrawToolMode.FREEHAND)'
                     >
                         <IconLasso
@@ -117,11 +126,32 @@
             </div>
         </template>
     </TablerDropdown>
+
+    <CoordInput
+        v-if='modal === ModalInputType.POINT'
+        @close='modal = ModalInputType.NONE'
+    />
+
+    <LostPersonBehaviorInput
+        v-if='modal === ModalInputType.LOST_PERSON_BEHAVIOR'
+        @close='modal = ModalInputType.NONE'
+    />
+
+    <RangeInput
+        v-if='modal === ModalInputType.RANGE'
+        @close='modal = ModalInputType.NONE'
+    />
+
 </template>
 
 <script setup lang='ts'>
-import { useRouter } from 'vue-router';
+import { ref } from 'vue';
+import { DrawToolMode } from '../../stores/modules/draw.ts';
+import CoordInput from './CoordInput.vue';
+import LostPersonBehaviorInput from './LostPersonBehaviorInput.vue';
+import RangeInput from './RangeInput.vue';
 import {
+    IconWalk,
     IconLasso,
     IconCone,
     IconCircle,
@@ -139,7 +169,14 @@ import {
     TablerDropdown,
 } from '@tak-ps/vue-tabler';
 
-const mapStore = useMapStore();
+enum ModalInputType {
+    NONE = 'none',
+    RANGE = 'range',
+    POINT = 'point',
+    LOST_PERSON_BEHAVIOR = 'lost_person_behavior',
+}
 
-const router = useRouter();
+const modal = ref<ModalInputType>(ModalInputType.NONE);
+
+const mapStore = useMapStore();
 </script>

--- a/api/web/src/components/CloudTAK/LostPersonBehaviorInput.vue
+++ b/api/web/src/components/CloudTAK/LostPersonBehaviorInput.vue
@@ -1,0 +1,181 @@
+<template>
+    <TablerModal size='md'>
+        <div class='modal-status bg-blue' />
+        <button
+            type='button'
+            class='btn-close'
+            aria-label='Close'
+            @click='emit("close")'
+        />
+        <div class='modal-header text-white'>
+            <div class='modal-title d-flex align-items-center'>
+                <IconWalk
+                    :size='32'
+                    stroke='1'
+                />
+                <span class='mx-2'>Lost Person Behavior Input</span>
+            </div>
+        </div>
+        <div class='modal-body text-white'>
+            <div class='mx-2 my-2'>
+                <TablerInput
+                    v-model='config.name'
+                    label='Name'
+                    @submit='submitRings'
+                />
+            </div>
+
+            <Coordinate
+                label='Origin'
+                v-model='config.coordinates'
+                :edit='true'
+                :hover='true'
+                :modes='["dd"]'
+                @submit='submitRings'
+            />
+
+            <PropertyDistance
+                label='25% Containment Radius'
+                :edit='true'
+                :hover='true'
+                v-model='config.rings["25%"]'
+            />
+
+            <PropertyDistance
+                label='50% Containment Radius'
+                :edit='true'
+                :hover='true'
+                v-model='config.rings["50%"]'
+            />
+
+            <PropertyDistance
+                label='75% Containment Radius'
+                :edit='true'
+                :hover='true'
+                v-model='config.rings["75%"]'
+            />
+
+            <button
+                class='btn btn-primary w-100 mt-3'
+                @click='submitRings'
+            >
+                Save
+            </button>
+        </div>
+    </TablerModal>
+</template>
+
+<script setup lang='ts'>
+import { ref, toRaw } from 'vue'
+import Coordinate from './util/Coordinate.vue';
+import PropertyDistance from './util/PropertyDistance.vue';
+import Ellipse from '@turf/ellipse'
+import {
+    IconWalk,
+} from '@tabler/icons-vue';
+import {
+    TablerInput,
+    TablerModal,
+} from '@tak-ps/vue-tabler';
+import type { LngLatLike } from 'maplibre-gl'
+import { useMapStore } from '../../stores/map.ts';
+const mapStore = useMapStore();
+
+const emit = defineEmits([ 'close' ]);
+
+const center = mapStore.map.getCenter();
+
+const config = ref({
+    name: '',
+    type: 'u-d-p',
+    rings: {
+        '25%': 0,
+        '50%': 0,
+        '75%': 0
+    },
+    coordinates: [
+        Math.round(center.lng * 1000000) / 1000000,
+        Math.round(center.lat * 1000000) / 1000000,
+    ]
+});
+
+async function submitRings() {
+    const id = crypto.randomUUID();
+
+    await mapStore.worker.db.add({
+        id,
+        type: 'Feature',
+        path: '/',
+        properties: {
+            id,
+            type: toRaw(config.value.type),
+            how: 'h-g-i-g-o',
+            color: '#00FF00',
+            archived: true,
+            time: new Date().toISOString(),
+            start: new Date().toISOString(),
+            stale: new Date().toISOString(),
+            center: toRaw(config.value.coordinates),
+            callsign: toRaw((config.value.name || '') + " Origin"),
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: toRaw(config.value.coordinates)
+        }
+    }, {
+        authored: true
+    });
+
+    const keys = Object.keys(config.value.rings) as (keyof typeof config.value.rings)[];
+    for (const ring of keys) {
+        if (config.value.rings[ring] === 0) continue;
+
+        const ringid = crypto.randomUUID();
+
+        await mapStore.worker.db.add({
+            id: ringid,
+            type: 'Feature',
+            path: '/',
+            properties: {
+                id: ringid,
+                type: 'u-d-c-c',
+                how: 'h-g-i-g-o',
+                color: '#00FF00',
+                archived: true,
+                shape: {
+                    ellipse: {
+                        major: config.value.rings[ring] * 1000,
+                        minor: config.value.rings[ring] * 1000,
+                        angle: 360
+                    }
+                },
+                'fill-opacity': 0,
+                time: new Date().toISOString(),
+                start: new Date().toISOString(),
+                stale: new Date().toISOString(),
+                center: toRaw(config.value.coordinates),
+                callsign: toRaw((config.value.name || '') + " " + ring),
+            },
+            geometry: Ellipse(
+                config.value.coordinates,
+                config.value.rings[ring],
+                config.value.rings[ring],
+                {
+                    angle: 360
+                }
+            ).geometry
+        }, {
+            authored: true
+        });
+    }
+
+    if (mapStore.map) {
+        mapStore.map.flyTo({
+            center: config.value.coordinates as LngLatLike,
+            zoom: 14
+        });
+    }
+
+    emit('close');
+}
+</script>

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -312,125 +312,7 @@
                     style='width: 10px;'
                 />
 
-
-                <TablerDropdown>
-                    <template #default>
-                        <TablerIconButton
-                            title='Geometry Editing'
-                            class='mx-2 cursor-pointer hover-button'
-                            @click='closeAllMenu'
-                        >
-                            <IconPencil
-                                :size='40'
-                                stroke='1'
-                            />
-                        </TablerIconButton>
-                    </template>
-                    <template #dropdown>
-                        <div
-                            class='card py-1'
-                            style='min-width: 300px;'
-                        >
-                            <div class='card-body'>
-                                <div class='card-title'>
-                                    Drawing Tools
-                                </div>
-                            </div>
-                            <div class='card-body'>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='pointInput = true'
-                                >
-                                    <IconCursorText
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Coordinate Input</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='rangeInput = true'
-                                >
-                                    <IconCompass
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Range &amp; Bearing</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.POINT)'
-                                >
-                                    <IconPoint
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Draw Point</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.LINESTRING)'
-                                >
-                                    <IconLine
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Draw Line</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.POLYGON)'
-                                >
-                                    <IconPolygon
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Draw Polygon</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.RECTANGLE)'
-                                >
-                                    <IconVector
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Draw Rectangle</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.CIRCLE)'
-                                >
-                                    <IconCircle
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Draw Circle</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.SECTOR)'
-                                >
-                                    <IconCone
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Draw Sector</span>
-                                </div>
-                                <div
-                                    class='col-12 py-1 px-2 hover-button cursor-pointer user-select-none'
-                                    @click='mapStore.draw.start(DrawToolMode.FREEHAND)'
-                                >
-                                    <IconLasso
-                                        :size='25'
-                                        stroke='1'
-                                    />
-                                    <span class='ps-2'>Lasso Select</span>
-                                </div>
-                            </div>
-                        </div>
-                    </template>
-                </TablerDropdown>
+                <DrawTools />
             </div>
 
             <div
@@ -544,12 +426,12 @@ import SearchBox from './util/SearchBox.vue';
 import WarnConfiguration from './util/WarnConfiguration.vue';
 import CoordInput from './CoordInput.vue';
 import RangeInput from './RangeInput.vue';
+import DrawTools from './DrawTools.vue';
 import type { MapGeoJSONFeature, LngLatLike } from 'maplibre-gl';
 import type { Feature } from '../../types.ts';
 import CloudTAKFeatView from './FeatView.vue';
 import {
     IconSearch,
-    IconCompass,
     IconLocationOff,
     IconLocationPin,
     IconLocation,
@@ -558,17 +440,8 @@ import {
     IconMinus,
     IconLockAccess,
     IconAmbulance,
-    IconPencil,
-    IconLasso,
     IconMap,
     IconX,
-    IconPoint,
-    IconLine,
-    IconCone,
-    IconCircle,
-    IconPolygon,
-    IconCursorText,
-    IconVector,
     IconBell,
     IconAngle,
     IconCircleArrowUp,

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -256,16 +256,6 @@
                 </div>
             </div>
 
-            <CoordInput
-                v-if='pointInput'
-                @close='pointInput = false'
-            />
-
-            <RangeInput
-                v-if='rangeInput'
-                @close='rangeInput = false'
-            />
-
             <SearchBox
                 v-if='searchBoxShown'
                 style='
@@ -348,8 +338,6 @@
             <SideMenu
                 v-if='
                     mapStore.isLoaded
-                        && !pointInput
-                        && !rangeInput
                         && (
                             (noMenuShown && !mobileDetected)
                             || (!noMenuShown)
@@ -424,8 +412,6 @@ import WarnChannels from './util/WarnChannels.vue';
 import Notifications from './Notifications.vue';
 import SearchBox from './util/SearchBox.vue';
 import WarnConfiguration from './util/WarnConfiguration.vue';
-import CoordInput from './CoordInput.vue';
-import RangeInput from './RangeInput.vue';
 import DrawTools from './DrawTools.vue';
 import type { MapGeoJSONFeature, LngLatLike } from 'maplibre-gl';
 import type { Feature } from '../../types.ts';
@@ -481,8 +467,6 @@ const warnChannels = ref<boolean>(false)
 const warnConfiguration = ref<boolean>(false);
 
 const searchBoxShown = ref(false);
-const pointInput = ref<boolean>(false);
-const rangeInput = ref<boolean>(false);
 const feat = ref()        // Show the Feat Viewer sidebar
 
 const upload = ref({
@@ -529,8 +513,6 @@ const mapRef = useTemplateRef<HTMLElement>('map');
 
 const noMenuShown = computed<boolean>(() => {
     return !feat.value
-        && !pointInput.value
-        && !rangeInput.value
         && (!route.name || !String(route.name).startsWith('home-menu'))
 });
 
@@ -621,8 +603,6 @@ function selectFeat(selectedFeat: MapGeoJSONFeature) {
 function closeAllMenu() {
     feat.value = false;
     router.push("/");
-    pointInput.value = false;
-    rangeInput.value = false;
 }
 
 function closeRadial() {

--- a/api/web/src/components/CloudTAK/util/FloatingVideo.vue
+++ b/api/web/src/components/CloudTAK/util/FloatingVideo.vue
@@ -283,6 +283,7 @@ async function createPlayer(): Promise<void> {
 
         player.value = new Hls({
             enableWorker: true,
+            lowLatencyMode: false,
             debug: true,
             maxBufferSize: 3000000,
             maxMaxBufferLength: 300,

--- a/api/web/src/pages/docs/App.vue
+++ b/api/web/src/pages/docs/App.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div id='swagger'/>
+        <div id='swagger' />
     </div>
 </template>
 


### PR DESCRIPTION
### Context

This pull request introduces several updates to the project, including dependency upgrades, new features for drawing tools, and improvements to filtering logic in styles. The most significant changes are the addition of new drawing tools, the refactoring of the `Map.vue` component to use a dedicated `DrawTools` component, and updates to filtering logic for map layers.

### Dependency Updates:
* Upgraded the project version in `package-lock.json` from `10.16.0` to `10.18.0`.
* Added `@turf/ellipse` as a new dependency in `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-60823d2f4576e1ac0c836baf2c06398d8645fe7a0511c4bdb74a0970c5588c3fR30) [[2]](diffhunk://#diff-e57688cc8ba1f7393d198a2ffc1dfb2bf81fb847c855aa3ec6fd395b1f8589b2R23)
* Updated `@tak-ps/node-cot` dependency from version `13.3.0` to `13.4.0` in `package-lock.json`.

### Drawing Tools Feature:
* Added a new `DrawTools.vue` component to provide a dropdown menu for geometry editing, including tools for drawing points, lines, polygons, rectangles, circles, sectors, and freehand shapes. This also includes inputs for coordinate and range-based drawing.
* Added a `LostPersonBehaviorInput.vue` component to allow users to input and save lost person behavior data with configurable containment radii.

### Filtering Logic Enhancements:
* Improved filtering logic in `styles.ts` for better handling of map layers:
  - Updated polygon filters to exclude polygons with zero `fill-opacity`. [[1]](diffhunk://#diff-0e2b88e0375e28fba8c17e9157c788ea55c83705ead8c372e9b91c6620ff4ab9L25-R29) [[2]](diffhunk://#diff-0e2b88e0375e28fba8c17e9157c788ea55c83705ead8c372e9b91c6620ff4ab9L310-R324)
  - Enhanced line filters to include polygons with zero `fill-opacity` for text labels.

### Minor Fixes:
* Fixed the placement of the `@click` directive in `App.vue` for better readability.