### PR TITLE
Fix blurry basemap rendering by setting correct tile size for raster sources

### DIFF
--- a/api/web/src/base/overlay.ts
+++ b/api/web/src/base/overlay.ts
@@ -206,7 +206,8 @@ export default class Overlay {
 
             mapStore.map.addSource(String(this.id), {
                 type: 'raster',
-                url: String(url)
+                url: String(url),
+                tileSize: 256
             });
         } else if (this.type === 'vector' && this.url) {
             const url = stdurl(this.url);


### PR DESCRIPTION
## Problem
Basemaps (especially Google Maps and other 256px tile sources) appear blurry due to MapLibre's default assumption that raster tiles are 512px, causing upscaling artifacts.

## Solution
Set `tileSize: 256` explicitly in raster source configuration to match the actual tile dimensions used by most tile servers.

## Changes
- Added `tileSize: 256` to raster source configuration in `overlay.ts`
- Prevents MapLibre from upscaling 256px tiles to 512px display size

## Testing
- Tested with Google Maps tiles (`https://mts1.google.com/vt/lyrs=m&hl=en&x={$x}&y={$y}&z={$z}&s=Gal&apistyle=s.t:2|s.e:l|p.v:off`)
- Basemaps now render crisp at all zoom levels
- No impact on vector tiles or other source types

Fixes blurry basemap rendering issue.
