### PR TITLE
Direct Type Check

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -213,7 +213,7 @@ export default async function server(config: Config): Promise<ServerManager> {
                     const profile = await config.models.Profile.from(parsedParams.connection);
                     if (!profile.auth.cert || !profile.auth.key) throw new Error('No Cert Found on profile');
 
-                    client = await config.conns.add(new ProfileConnConfig(config, parsedParams.connection, profile.auth), true);
+                    client = await config.conns.add(new ProfileConnConfig(config, parsedParams.connection, profile.auth));
                 } else {
                     client = config.conns.get(parsedParams.connection);
                 }

--- a/api/routes/connection-layer.ts
+++ b/api/routes/connection-layer.ts
@@ -811,17 +811,15 @@ export default async function router(schema: Schema, config: Config) {
                 default: false,
                 description: 'Get Live Alarm state from CloudWatch'
             }),
-        }),
-        params: Type.Object({
-            connectionid: Type.Integer({ minimum: 1 }),
-            layerid: Type.Integer({ minimum: 1 }),
-        }),
-        query: Type.Object({
             token: Type.Optional(Type.String()),
             download: Type.Boolean({
                 default: false,
                 description: 'Download Layer as JSON file'
             })
+        }),
+        params: Type.Object({
+            connectionid: Type.Integer({ minimum: 1 }),
+            layerid: Type.Integer({ minimum: 1 }),
         }),
         res: LayerResponse
     }, async (req, res) => {


### PR DESCRIPTION
### Context

A bug was discovered where an upstream user of `Connections.cots` must supply `ephemeral=true` if injecting to a user profile
otherwise a Profile connection would be treated as a Machine Connection. Profile connections use the user's email/username
as a primary key where programatic machine connections use an integer ID. This resulted in user data attempting to enter
the machine Sink processor and failing as the Layer table with a serial ID could not be compared to the string.

### Solution

Instead of manually managing an `ephemeral` flag, we can check the `instanceof` the `Connection` to determine if it is a `ProfileConnection` or a `MachineConnection`.
