### PR TITLE
Add Handlebar Slice Function

### DIFF
--- a/api/lib/style.ts
+++ b/api/lib/style.ts
@@ -11,7 +11,19 @@ handlebars.registerHelper('fallback', (...params: Array<unknown>) => {
     return found;
 })
 
-handlebars.registerHelper('htmlstrip', function (text: string) {
+handlebars.registerHelper('slice', (text: string, start: number, end?: number) => {
+    if (text && !isNaN(start) && !isNaN(end)) {
+        return text.substring(start, end);
+    } else if (text && !isNaN(start)) {
+        return text.substring(start);
+    } else {
+        return '';
+    }
+});
+
+handlebars.registerHelper('htmlstrip', (text: string) => {
+    if (!text) return '';
+
     let addLine = false;
     let addSpace = false;
     const newLine = ['tr'];

--- a/api/test/style.test.ts
+++ b/api/test/style.test.ts
@@ -916,3 +916,42 @@ test('Style: Delete Feature by Style', async () => {
 
     assert.equal(feat, null);
 });
+
+test('Style: {{slice remarks}}', async () => {
+    const style = new Style({
+        stale: 123,
+        enabled_styles: true,
+        styles: {
+            remarks: '{{slice remarks 5}}'
+        }
+    });
+
+    assert.deepEqual(await style.feat({
+        type: 'Feature',
+        properties: {
+            metadata: {
+                remarks: 'DFPC Ingalls',
+            }
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+        }
+    }), {
+        type: 'Feature',
+        properties: {
+            remarks: 'Ingalls',
+            metadata: {
+                remarks: 'DFPC Ingalls',
+            },
+            stale: 123000
+        },
+        geometry: {
+            coordinates: [
+                0,
+                0
+            ],
+            type: 'Point'
+        },
+    });
+});


### PR DESCRIPTION
### Context

Adds a slice functionality to handlebar template used in ETL Styles

```
{{slice <fieldname> <start> <end?>}}
```
