### PR TITLE
Respect HTML Theme & Use Vue Teleport

### DIFF
--- a/api/web/index.html
+++ b/api/web/index.html
@@ -3,6 +3,9 @@
     class='h-full'
     lang="en"
     style='overflow: hidden;'
+    data-bs-theme='dark'
+    data-bs-theme-base='neutral'
+    data-bs-theme-primary='blue'
 >
     <head>
         <meta charset="utf-8">

--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.web",
-    "version": "10.30.0",
+    "version": "10.31.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.web",
-            "version": "10.30.0",
+            "version": "10.31.0",
             "dependencies": {
                 "@react-hookz/deep-equal": "^3.0.3",
                 "@tabler/core": "1.0.0",
@@ -3895,9 +3895,9 @@
             }
         },
         "node_modules/@tak-ps/vue-tabler": {
-            "version": "3.74.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/vue-tabler/-/vue-tabler-3.74.0.tgz",
-            "integrity": "sha512-o2bvPE6SiFWAqXB8gbq91Za/jefmNI5M2EPP+HwdECbFFTGSEsrmWTIwFcnJCmxOaRKrLKihg9bHVOGJWUl+lQ==",
+            "version": "3.75.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/vue-tabler/-/vue-tabler-3.75.0.tgz",
+            "integrity": "sha512-qJzauhIXojl8SjKkf04Gwg+SLZCalKgqKpc2NtViO5Iz6RPjGT/Qo0Cz5GzyU6ijz6LWVMd3jIr3iLvywXNdTA==",
             "license": "ISC",
             "dependencies": {
                 "@tabler/icons-vue": "^3.0.0",
@@ -4642,16 +4642,16 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.36.0.tgz",
-            "integrity": "sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.37.0.tgz",
+            "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/type-utils": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/type-utils": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -4665,7 +4665,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.36.0",
+                "@typescript-eslint/parser": "^8.37.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
             }
@@ -4680,15 +4680,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.36.0.tgz",
-            "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.37.0.tgz",
+            "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/typescript-estree": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4704,13 +4704,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.36.0.tgz",
-            "integrity": "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.37.0.tgz",
+            "integrity": "sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.36.0",
-                "@typescript-eslint/types": "^8.36.0",
+                "@typescript-eslint/tsconfig-utils": "^8.37.0",
+                "@typescript-eslint/types": "^8.37.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4725,13 +4725,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.36.0.tgz",
-            "integrity": "sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.37.0.tgz",
+            "integrity": "sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0"
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4742,9 +4742,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.36.0.tgz",
-            "integrity": "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.37.0.tgz",
+            "integrity": "sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4758,13 +4758,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.36.0.tgz",
-            "integrity": "sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.37.0.tgz",
+            "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -4781,9 +4782,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.36.0.tgz",
-            "integrity": "sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
+            "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4794,15 +4795,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.36.0.tgz",
-            "integrity": "sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.37.0.tgz",
+            "integrity": "sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.36.0",
-                "@typescript-eslint/tsconfig-utils": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/project-service": "8.37.0",
+                "@typescript-eslint/tsconfig-utils": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -4846,15 +4847,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.36.0.tgz",
-            "integrity": "sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.37.0.tgz",
+            "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/typescript-estree": "8.36.0"
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4869,12 +4870,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.36.0.tgz",
-            "integrity": "sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.37.0.tgz",
+            "integrity": "sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.36.0",
+                "@typescript-eslint/types": "8.37.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -5574,9 +5575,9 @@
             "license": "MIT"
         },
         "node_modules/birpc": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.4.0.tgz",
-            "integrity": "sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.5.0.tgz",
+            "integrity": "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -9384,9 +9385,9 @@
             }
         },
         "node_modules/potpack": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
-            "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+            "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
             "license": "ISC"
         },
         "node_modules/prelude-ls": {
@@ -11766,14 +11767,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.36.0.tgz",
-            "integrity": "sha512-fTCqxthY+h9QbEgSIBfL9iV6CvKDFuoxg6bHPNpJ9HIUzS+jy2lCEyCmGyZRWEBSaykqcDPf1SJ+BfCI8DRopA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.37.0.tgz",
+            "integrity": "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.36.0",
-                "@typescript-eslint/parser": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0"
+                "@typescript-eslint/eslint-plugin": "8.37.0",
+                "@typescript-eslint/parser": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/api/web/src/App.vue
+++ b/api/web/src/App.vue
@@ -3,9 +3,6 @@
         <header
             v-if='navShown'
             class='navbar navbar-expand-md d-print-none'
-            data-bs-theme='dark'
-            data-bs-theme-base='neutral'
-            data-bs-theme-primary='blue'
         >
             <div class='container-xl'>
                 <div class='col-auto'>
@@ -60,7 +57,7 @@
                                 aria-labelledby='userProfileButton'
                             >
                                 <div
-                                    class='d-flex dropdown-item cursor-pointer hover-dark'
+                                    class='d-flex dropdown-item cursor-pointer hover'
                                     @click='router.push("/connection")'
                                 >
                                     <IconNetwork
@@ -70,7 +67,7 @@
                                     <span class='mx-2'>Connections</span>
                                 </div>
                                 <div
-                                    class='d-flex dropdown-item cursor-pointer hover-dark'
+                                    class='d-flex dropdown-item cursor-pointer hover'
                                     @click='router.push("/admin")'
                                 >
                                     <IconSettings
@@ -81,7 +78,7 @@
                                     <span class='ms-auto badge border border-red bg-red text-white'>Admin</span>
                                 </div>
                                 <div
-                                    class='d-flex dropdown-item cursor-pointer hover-dark'
+                                    class='d-flex dropdown-item cursor-pointer hover'
                                     @click='logout'
                                 >
                                     <IconLogout
@@ -272,16 +269,20 @@ $cloudtak-blue: #07556D;
     background-color: $cloudtak-child !important;
 }
 
+html[data-bs-theme='dark'] .hover:hover {
+    background: #0f172a;
+}
+
+html[data-bs-theme='light'] .hover:hover {
+    background: #f5f5f5;
+}
+
 .hover-button-hidden {
     visibility: hidden;
 }
 
 .hover-button:hover .hover-button-hidden {
     visibility: visible;
-}
-
-.hover-light:hover {
-    background: #f5f5f5;
 }
 
 .border-light {
@@ -292,10 +293,6 @@ $cloudtak-blue: #07556D;
 .hover-button:hover {
     border-radius: 6px;
     background-color: rgba(0, 0, 0, 0.2);
-}
-
-.hover-dark:hover {
-    background: #0f172a;
 }
 
 .border-dark {

--- a/api/web/src/components/Admin/AdminConfig.vue
+++ b/api/web/src/components/Admin/AdminConfig.vue
@@ -23,7 +23,7 @@
             </div>
             <div class='card-body row'>
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("login") ? opened.delete("login") : opened.add("login")'
                 >
                     <IconChevronDown v-if='opened.has("login")' />
@@ -61,7 +61,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("agol") ? opened.delete("agol") : opened.add("agol")'
                 >
                     <IconChevronDown v-if='opened.has("agol")' />
@@ -92,7 +92,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("media") ? opened.delete("media") : opened.add("media")'
                 >
                     <IconChevronDown v-if='opened.has("media")' />
@@ -117,7 +117,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("display") ? opened.delete("display") : opened.add("display")'
                 >
                     <IconChevronDown v-if='opened.has("display")' />
@@ -152,7 +152,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("groups") ? opened.delete("groups") : opened.add("groups")'
                 >
                     <IconChevronDown v-if='opened.has("groups")' />
@@ -181,7 +181,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("map") ? opened.delete("map") : opened.add("map")'
                 >
                     <IconChevronDown v-if='opened.has("map")' />
@@ -227,7 +227,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 cursor-pointer'
                     @click='opened.has("provider") ? opened.delete("provider") : opened.add("provider")'
                 >
                     <IconChevronDown v-if='opened.has("provider")' />

--- a/api/web/src/components/Admin/AdminPalette.vue
+++ b/api/web/src/components/Admin/AdminPalette.vue
@@ -89,7 +89,7 @@
                     <div
                         v-for='feature of palette.features'
                         :key='feature.uuid'
-                        class='hover-light px-2 py-2 cursor-pointer d-flex align-items-center rounded'
+                        class='hover px-2 py-2 cursor-pointer d-flex align-items-center rounded'
                         @click='router.push(`/admin/palette/${route.params.palette}/feature/${feature.uuid}`)'
                     >
                         <IconPoint

--- a/api/web/src/components/Admin/AdminUser.vue
+++ b/api/web/src/components/Admin/AdminUser.vue
@@ -98,7 +98,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 mt-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 mt-2 cursor-pointer'
                     @click='opened.has("tak") ? opened.delete("tak") : opened.add("tak")'
                 >
                     <IconChevronDown v-if='opened.has("tak")' />
@@ -139,7 +139,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 mt-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 mt-2 cursor-pointer'
                     @click='opened.has("display") ? opened.delete("display") : opened.add("display")'
                 >
                     <IconChevronDown v-if='opened.has("display")' />
@@ -171,7 +171,7 @@
                 </div>
 
                 <div
-                    class='col-lg-12 hover-light py-2 mt-2 cursor-pointer'
+                    class='col-lg-12 hover py-2 mt-2 cursor-pointer'
                     @click='opened.has("fusion") ? opened.delete("fusion") : opened.add("fusion")'
                 >
                     <IconChevronDown v-if='opened.has("fusion")' />

--- a/api/web/src/components/Admin/Server/ServerInjectors.vue
+++ b/api/web/src/components/Admin/Server/ServerInjectors.vue
@@ -38,7 +38,7 @@
             <template v-else>
                 <template v-for='i in list.items'>
                     <div
-                        class='col-12 hover-light px-2 py-2 rounded cursor-pointer'
+                        class='col-12 hover px-2 py-2 rounded cursor-pointer'
                         @click='injector = i'
                     >
                         <div

--- a/api/web/src/components/Admin/Server/ServerRepeaters.vue
+++ b/api/web/src/components/Admin/Server/ServerRepeaters.vue
@@ -29,7 +29,7 @@
             />
             <template v-else>
                 <template v-for='repeater in list.items'>
-                    <div class='col-12 hover-light d-flex align-items-center px-2 py-2'>
+                    <div class='col-12 hover d-flex align-items-center px-2 py-2'>
                         <div class='row'>
                             <div class='col-12'>
                                 <span v-text='repeater.callsign' />

--- a/api/web/src/components/Admin/Videos/VideoConfig.vue
+++ b/api/web/src/components/Admin/Videos/VideoConfig.vue
@@ -198,7 +198,7 @@
                 <template v-else>
                     <div
                         v-for='path in service.paths'
-                        class='hover-light px-2 py-2 cursor-pointer d-flex align-items-center'
+                        class='hover px-2 py-2 cursor-pointer d-flex align-items-center'
                         @click='pathid = path.name'
                     >
                         <StatusDot

--- a/api/web/src/components/CloudTAK/CoTView.vue
+++ b/api/web/src/components/CloudTAK/CoTView.vue
@@ -162,7 +162,7 @@
                                         <div
                                             v-if='cot.properties.attachments === undefined'
                                             role='button'
-                                            class='hover-dark px-2 py-2 d-flex align-items-center'
+                                            class='hover px-2 py-2 d-flex align-items-center'
                                             @click='updateProperty("attachments", [])'
                                         >
                                             <IconPaperclip
@@ -175,7 +175,7 @@
                                         <div
                                             v-if='cot.properties.video === undefined'
                                             role='button'
-                                            class='hover-dark px-2 py-2 d-flex align-items-center'
+                                            class='hover px-2 py-2 d-flex align-items-center'
                                             @click='updateProperty("video", { url: "" })'
                                         >
                                             <IconMovie
@@ -188,7 +188,7 @@
                                         <div
                                             v-if='cot.properties.sensor === undefined'
                                             role='button'
-                                            class='hover-dark px-2 py-2 d-flex align-items-center'
+                                            class='hover px-2 py-2 d-flex align-items-center'
                                             @click='updateProperty("sensor", {})'
                                         >
                                             <IconCone
@@ -716,7 +716,7 @@
                 class='col-12 px-1 pb-2'
             >
                 <div
-                    class='col-12 py-2 d-flex align-items-center hover-dark cursor-pointer user-select-none'
+                    class='col-12 py-2 d-flex align-items-center hover cursor-pointer user-select-none'
                     @click='chevrons.has("metadata") ? chevrons.delete("metadata") : chevrons.add("metadata")'
                 >
                     <TablerIconButton

--- a/api/web/src/components/CloudTAK/MainMenu.vue
+++ b/api/web/src/components/CloudTAK/MainMenu.vue
@@ -22,7 +22,7 @@
         <div
             v-if='!compact'
             ref='resize'
-            class='resize hover-dark cursor-drag'
+            class='resize hover cursor-drag'
         />
         <div
             ref='menu'
@@ -59,7 +59,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/features")'
@@ -87,7 +87,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/overlays")'
@@ -115,7 +115,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/contacts")'
@@ -143,7 +143,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/basemaps")'
@@ -171,7 +171,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/missions")'
@@ -199,7 +199,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/packages")'
@@ -227,7 +227,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/channels")'
@@ -255,7 +255,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/videos")'
@@ -283,7 +283,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/chats")'
@@ -311,7 +311,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/routes")'
@@ -339,7 +339,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/files")'
@@ -367,7 +367,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/imports")'
@@ -395,7 +395,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/iconsets")'
@@ -425,7 +425,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/connections")'
@@ -460,7 +460,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/debugger")'
@@ -495,7 +495,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/admin")'
@@ -529,7 +529,7 @@
                         :tabindex='compact ? undefined : 0'
                         class='cursor-pointer col-12 d-flex align-items-center'
                         :class='{
-                            "py-2 px-3 hover-dark": !compact,
+                            "py-2 px-3 hover": !compact,
                             "py-1 px-2 hover-button": compact
                         }'
                         @click='router.push("/menu/settings")'
@@ -586,7 +586,7 @@
                     <div
                         role='button'
                         style='width: 40px;'
-                        class='py-2 px-2 ms-auto d-flex hover-dark cursor-pointer'
+                        class='py-2 px-2 ms-auto d-flex hover cursor-pointer'
                         @click.stop.prevent='logout'
                         @keyup.enter='logout'
                     >

--- a/api/web/src/components/CloudTAK/MapLoading.vue
+++ b/api/web/src/components/CloudTAK/MapLoading.vue
@@ -1,7 +1,7 @@
 <template>
     <TablerModal>
         <div
-            class='modal-body bg-white rounded user-select-none'
+            class='modal-body rounded user-select-none'
         >
             <div
                 class='text-center'

--- a/api/web/src/components/CloudTAK/Menu/Debugger.vue
+++ b/api/web/src/components/CloudTAK/Menu/Debugger.vue
@@ -40,7 +40,7 @@
                     key='fit'
                 >
                     <div
-                        class='row hover-dark px-2 py-2 cursor-pointer user-select-none'
+                        class='row hover px-2 py-2 cursor-pointer user-select-none'
                         @click='opened.has(fit) ? opened.delete(fit) : opened.add(fit)'
                     >
                         <div

--- a/api/web/src/components/CloudTAK/Menu/MenuBasemaps.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuBasemaps.vue
@@ -116,7 +116,7 @@
                                     <div clas='col-12'>
                                         <div
                                             v-if='(!basemap.username && isSystemAdmin) || basemap.username'
-                                            class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                                            class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                                             @click.stop.prevent='editModal = basemap'
                                         >
                                             <IconSettings
@@ -127,7 +127,7 @@
                                             <span class='mx-2'>Edit Basemap</span>
                                         </div>
                                         <div
-                                            class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                                            class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                                             @click.stop.prevent='download(basemap)'
                                         >
                                             <IconDownload
@@ -137,7 +137,7 @@
                                             <span class='mx-2'>Download XML</span>
                                         </div>
                                         <div
-                                            class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                                            class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                                             @click.stop.prevent='share = [basemap.id]'
                                         >
                                             <IconShare2

--- a/api/web/src/components/CloudTAK/Menu/MenuChannels.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuChannels.vue
@@ -57,9 +57,9 @@
                 <div
                     v-for='ch in processChannels'
                     :key='ch.name'
-                    class='col-lg-12 hover-dark'
+                    class='col-lg-12 hover'
                 >
-                    <div class='hover-dark'>
+                    <div class='hover'>
                         <div class='px-2'>
                             <div class='col-12 py-2 px-2 d-flex align-items-center'>
                                 <IconEye

--- a/api/web/src/components/CloudTAK/Menu/MenuChats.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuChats.vue
@@ -34,7 +34,7 @@
                         v-for='chat in chats.items'
                         role='menuitem'
                         tabindex='0'
-                        class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover-dark'
+                        class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover'
                         @click='$router.push(`/menu/chats/${chat.chatroom}`)'
                     >
                         <IconUser

--- a/api/web/src/components/CloudTAK/Menu/MenuConnections.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuConnections.vue
@@ -45,7 +45,7 @@
                         role='menuitem'
                         @click='router.push(`/connection/${conn.id}`)'
                     >
-                        <div class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover-dark'>
+                        <div class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover'>
                             <div class='col-auto'>
                                 <ConnectionStatus :connection='conn' />
                             </div>

--- a/api/web/src/components/CloudTAK/Menu/MenuContacts.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuContacts.vue
@@ -46,7 +46,7 @@
                         class='col-lg-12'
                     >
                         <div
-                            class='col-lg-12 d-flex align-items-center cursor-pointer hover-dark'
+                            class='col-lg-12 d-flex align-items-center cursor-pointer hover'
                             style='height: 40px'
                             @click='opened.has(team) ? opened.delete(team) : opened.add(team)'
                         >
@@ -93,7 +93,7 @@
                 </template>
 
                 <div
-                    class='col-lg-12 d-flex align-items-center cursor-pointer hover-dark'
+                    class='col-lg-12 d-flex align-items-center cursor-pointer hover'
                     style='height: 40px'
                     @click='showOffline = !showOffline'
                 >

--- a/api/web/src/components/CloudTAK/Menu/MenuFeatures.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuFeatures.vue
@@ -16,7 +16,7 @@
 
                 <template #dropdown>
                     <div
-                        class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                        class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                         @click.stop.prevent='download("geojson")'
                     >
                         <IconFile
@@ -26,7 +26,7 @@
                         <span class='mx-2'>GeoJSON</span>
                     </div>
                     <div
-                        class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                        class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                         @click.stop.prevent='download("kml")'
                     >
                         <IconFile

--- a/api/web/src/components/CloudTAK/Menu/MenuFiles.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuFiles.vue
@@ -49,7 +49,7 @@
                     :key='asset.name'
                 >
                     <div
-                        class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover-dark'
+                        class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover'
                         @click='opened.has(asset.name) ? opened.delete(asset.name) : opened.add(asset.name)'
                     >
                         <div class='col-auto'>
@@ -86,7 +86,7 @@
                         <div class='rounded bg-child'>
                             <div
                                 v-if='asset.visualized'
-                                class='cursor-pointer rounded-top col-12 hover-dark d-flex align-items-center px-2 py-2 user-select-none'
+                                class='cursor-pointer rounded-top col-12 hover d-flex align-items-center px-2 py-2 user-select-none'
                                 @click.stop.prevent='createOverlay(asset)'
                             >
                                 <IconMapPlus
@@ -97,7 +97,7 @@
                             </div>
                             <div
                                 v-else
-                                class='rounded-top col-12 hover-dark d-flex align-items-center px-2 py-2 user-select-none'
+                                class='rounded-top col-12 hover d-flex align-items-center px-2 py-2 user-select-none'
                             >
                                 <IconMapOff
                                     :size='32'
@@ -107,7 +107,7 @@
                             </div>
 
                             <div
-                                class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2 user-select-none'
+                                class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2 user-select-none'
                                 @click.stop.prevent='downloadAsset(asset)'
                             >
                                 <IconDownload
@@ -117,7 +117,7 @@
                                 <span class='mx-2'>Download Original</span>
                             </div>
                             <div
-                                class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2 user-select-none'
+                                class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2 user-select-none'
                                 @click.stop.prevent='shareToPackage = asset.name'
                             >
                                 <IconPackage
@@ -129,7 +129,7 @@
 
                             <TablerDelete
                                 displaytype='menu'
-                                class='hover-dark rounded-bottom'
+                                class='hover rounded-bottom'
                                 label='Delete File'
                                 @delete='deleteAsset(asset)'
                             />

--- a/api/web/src/components/CloudTAK/Menu/MenuIconsets.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuIconsets.vue
@@ -114,7 +114,7 @@
                     <div
                         v-for='iconset in list.items'
                         :key='iconset.uid'
-                        class='col-12 hover-dark cursor-pointer py-2 px-3'
+                        class='col-12 hover cursor-pointer py-2 px-3'
                         @click='router.push(`/menu/iconset/${iconset.uid}`)'
                     >
                         <div class='d-flex align-items-center'>

--- a/api/web/src/components/CloudTAK/Menu/MenuImports.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuImports.vue
@@ -55,7 +55,7 @@
                     :key='imported.id'
                     @click='router.push(`/menu/imports/${imported.id}`)'
                 >
-                    <div class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover-dark'>
+                    <div class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover'>
                         <div class='col-auto'>
                             <Status
                                 :dark='true'

--- a/api/web/src/components/CloudTAK/Menu/MenuMission.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuMission.vue
@@ -25,7 +25,7 @@
                 <template #dropdown>
                     <div clas='col-12'>
                         <div
-                            class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                            class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                             @click='shareToPackageSetup'
                         >
                             <IconPackages
@@ -35,7 +35,7 @@
                             <span class='mx-2'>Export Data Package</span>
                         </div>
                         <div
-                            class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2 py-2'
+                            class='cursor-pointer col-12 hover d-flex align-items-center px-2 py-2'
                             @click='exportToPackage'
                         >
                             <IconFileZip

--- a/api/web/src/components/CloudTAK/Menu/MenuMissions.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuMissions.vue
@@ -44,7 +44,7 @@
                 <div
                     v-for='(mission, mission_it) in filteredList'
                     :key='mission_it'
-                    class='cursor-pointer col-12 py-2 hover-dark'
+                    class='cursor-pointer col-12 py-2 hover'
                     @click='openMission(mission, false)'
                 >
                     <div class='px-3 d-flex'>

--- a/api/web/src/components/CloudTAK/Menu/MenuOverlayExplorer.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuOverlayExplorer.vue
@@ -34,7 +34,7 @@
                     <div
                         v-for='ov in list.items'
                         :key='ov.id'
-                        class='cursor-pointer col-12 py-2 px-3 hover-dark'
+                        class='cursor-pointer col-12 py-2 px-3 hover'
                         @click='createOverlay(ov)'
                     >
                         <div class='col-12 py-2 px-2 d-flex align-items-center'>

--- a/api/web/src/components/CloudTAK/Menu/MenuRoutes.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuRoutes.vue
@@ -33,7 +33,7 @@
                     :key='cot.id'
                 >
                     <div
-                        class='col-12 py-2 px-3 d-flex align-items-center hover-dark user-select-none cursor-pointer'
+                        class='col-12 py-2 px-3 d-flex align-items-center hover user-select-none cursor-pointer'
                         @click='clickRoute(cot)'
                     >
                         <div class='col-auto'>

--- a/api/web/src/components/CloudTAK/Menu/MenuSettingsTokens.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuSettingsTokens.vue
@@ -23,7 +23,7 @@
             <div
                 v-for='t in tokens.items'
                 :key='t.id'
-                class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover-dark'
+                class='cursor-pointer col-12 py-2 px-3 d-flex align-items-center hover'
                 @click='token = t'
             >
                 <IconRobot

--- a/api/web/src/components/CloudTAK/Menu/MenuVideos.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuVideos.vue
@@ -100,7 +100,7 @@
                         <div
                             v-for='connection in connections.videoConnections'
                             :key='connection.uuid'
-                            class='d-flex align-items-center px-3 py-2 hover-dark cursor-pointer'
+                            class='d-flex align-items-center px-3 py-2 hover cursor-pointer'
                             @click='floatStore.addConnection(connection)'
                         >
                             <span class='me-1'>
@@ -163,7 +163,7 @@
                     v-for='l in leases.items'
                     v-else
                     :key='l.id'
-                    class='col-12 py-2 px-3 d-flex align-items-center hover-dark cursor-pointer'
+                    class='col-12 py-2 px-3 d-flex align-items-center hover cursor-pointer'
                     @click='lease = l'
                 >
                     <div class='row g-0 w-100'>

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionContents.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionContents.vue
@@ -47,7 +47,7 @@
             <div
                 v-for='content in mission.contents'
                 :key='content.data.uid'
-                class='col-12 d-flex px-2 py-2 hover-dark'
+                class='col-12 d-flex px-2 py-2 hover'
             >
                 <div>
                     <span
@@ -97,7 +97,7 @@
                 <div
                     v-for='imp in imports.items'
                     :key='imp.id'
-                    class='col-12 d-flex px-2 py-2 hover-dark align-items-center cursor-pointer'
+                    class='col-12 d-flex px-2 py-2 hover align-items-center cursor-pointer'
                     @click='router.push(`/menu/imports/${imp.id}`)'
                 >
                     <Status :status='imp.status' />

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionLayerTree.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionLayerTree.vue
@@ -12,7 +12,7 @@
             v-for='layer in layers'
             :key='layer.uid'
         >
-            <div class='col-12 hover-dark d-flex align-items-center px-3 py-2'>
+            <div class='col-12 hover d-flex align-items-center px-3 py-2'>
                 <IconChevronRight
                     v-if='layer.type === "UID" && !opened.has(layer.uid)'
                     :size='20'

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionTimeline.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionTimeline.vue
@@ -21,7 +21,7 @@
             <div
                 v-for='change in changes'
                 :key='change.contentUid'
-                class='col-12 hover-dark px-2 py-1'
+                class='col-12 hover px-2 py-1'
             >
                 <template v-if='change.type === "CREATE_MISSION"'>
                     <IconSquarePlus

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionUsers.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionUsers.vue
@@ -10,7 +10,7 @@
         <div
             v-for='sub of subscriptions'
         >
-            <div class='col-12 py-2 px-2 d-flex hover-dark'>
+            <div class='col-12 py-2 px-2 d-flex hover'>
                 <div class='col-12 d-flex align-items-center'>
                     <IconUserBolt
                         v-if='sub.role.type === "MISSION_OWNER"'

--- a/api/web/src/components/CloudTAK/Query/Reverse.vue
+++ b/api/web/src/components/CloudTAK/Query/Reverse.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class='col-12 row g-0 hover-dark'>
+    <div class='col-12 row g-0 hover'>
         <div class='col-12'>
             <label class='subheader mx-2'>ArcGIS Reverse Geocode</label>
         </div>

--- a/api/web/src/components/CloudTAK/Query/Weather.vue
+++ b/api/web/src/components/CloudTAK/Query/Weather.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class='col-12 row g-0 hover-dark'>
+    <div class='col-12 row g-0 hover'>
         <div class='col-12'>
             <label class='subheader mx-2'>National Weather Service</label>
         </div>

--- a/api/web/src/components/CloudTAK/util/Contact.vue
+++ b/api/web/src/components/CloudTAK/util/Contact.vue
@@ -4,7 +4,7 @@
         :class='{
             "cursor-pointer": isZoomable(contact),
             "cursor-default": !isZoomable(contact),
-            "hover-dark": hover,
+            "hover": hover,
             "py-2": !compact
         }'
         @click='flyTo(contact)'

--- a/api/web/src/components/CloudTAK/util/Icons.vue
+++ b/api/web/src/components/CloudTAK/util/Icons.vue
@@ -29,7 +29,7 @@
                         class='col-sm-2'
                         @click='router.push(`/menu/iconset/${icon.iconset}/${encodeURIComponent(icon.name)}`)'
                     >
-                        <div class='card card-sm hover-dark cursor-pointer'>
+                        <div class='card card-sm hover cursor-pointer'>
                             <div class='col-12'>
                                 <div
                                     class='d-flex justify-content-center mt-3'

--- a/api/web/src/components/CloudTAK/util/MenuItem.vue
+++ b/api/web/src/components/CloudTAK/util/MenuItem.vue
@@ -2,7 +2,7 @@
     <div
         tabindex='0'
         role='menuitem'
-        class='cursor-pointer col-12 py-2 px-3 hover-dark'
+        class='cursor-pointer col-12 py-2 px-3 hover'
         :class='{
             "d-flex align-items-center": props.flex
         }'

--- a/api/web/src/components/CloudTAK/util/PropertyType.vue
+++ b/api/web/src/components/CloudTAK/util/PropertyType.vue
@@ -80,7 +80,7 @@
 
                         <template v-for='item of list.items'>
                             <div
-                                class='d-flex align-items-center px-2 py-2 hover-dark cursor-pointer rounded'
+                                class='d-flex align-items-center px-2 py-2 hover cursor-pointer rounded'
                                 @click='updateType(item)'
                             >
                                 <FeatureIcon

--- a/api/web/src/components/CloudTAK/util/SelectFeats.vue
+++ b/api/web/src/components/CloudTAK/util/SelectFeats.vue
@@ -68,7 +68,7 @@
 
                         <template #dropdown>
                             <div
-                                class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2'
+                                class='cursor-pointer col-12 hover d-flex align-items-center px-2'
                                 @click='share = ShareType.PACKAGE'
                             >
                                 <IconPackages
@@ -78,7 +78,7 @@
                                 New Data Package
                             </div>
                             <div
-                                class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2'
+                                class='cursor-pointer col-12 hover d-flex align-items-center px-2'
                                 @click='share = ShareType.MISSION'
                             >
                                 <IconAmbulance
@@ -88,7 +88,7 @@
                                 Add to Data Sync
                             </div>
                             <div
-                                class='cursor-pointer col-12 hover-dark d-flex align-items-center px-2'
+                                class='cursor-pointer col-12 hover d-flex align-items-center px-2'
                                 @click='deleteFeatures'
                             >
                                 <IconTrash

--- a/api/web/src/components/CloudTAK/util/ShareToMission.vue
+++ b/api/web/src/components/CloudTAK/util/ShareToMission.vue
@@ -36,7 +36,7 @@
             >
                 <div v-for='mission in missions'>
                     <div
-                        class='col-12 cursor-pointer hover-dark py-2'
+                        class='col-12 cursor-pointer hover py-2'
                         @click='selected.has(mission) ? selected.delete(mission) : selected.add(mission)'
                     >
                         <div class='d-flex align-items-center'>

--- a/api/web/src/components/CloudTAK/util/Subscriptions.vue
+++ b/api/web/src/components/CloudTAK/util/Subscriptions.vue
@@ -24,9 +24,9 @@
             <div
                 v-for='ch in processChannels'
                 :key='ch.name'
-                class='col-lg-12 hover-dark'
+                class='col-lg-12 hover'
             >
-                <div class='hover-dark'>
+                <div class='hover'>
                     <div class='px-2'>
                         <div class='col-12 py-2 px-2 d-flex align-items-center'>
                             <IconEye

--- a/api/web/src/components/Connection/AgencySelect.vue
+++ b/api/web/src/components/Connection/AgencySelect.vue
@@ -67,7 +67,7 @@
                             <div
                                 v-for='agency in list.items'
                                 :key='agency.id'
-                                class='hover-light px-2 py-2 cursor-pointer row rounded col-12'
+                                class='hover px-2 py-2 cursor-pointer row rounded col-12'
                                 @click='selected = agency'
                             >
                                 <div class='d-flex align-items-center'>

--- a/api/web/src/components/Connection/CertificateMachineUser.vue
+++ b/api/web/src/components/Connection/CertificateMachineUser.vue
@@ -58,7 +58,7 @@
                     v-else
                 >
                     <div
-                        class='hover-light px-2 py-2 cursor-pointer row'
+                        class='hover px-2 py-2 cursor-pointer row'
                         @click='push(channel)'
                     >
                         <div class='col-md-4'>

--- a/api/web/src/components/Layer/LayerIncomingConfig.vue
+++ b/api/web/src/components/Layer/LayerIncomingConfig.vue
@@ -86,25 +86,25 @@
                                         class='px-1 py-1'
                                     >
                                         <li
-                                            class='py-1 px-1 cursor-pointer hover-light'
+                                            class='py-1 px-1 cursor-pointer hover'
                                             @click='incoming.cron = "rate(1 minute)"'
                                         >
                                             rate(1 minute)
                                         </li>
                                         <li
-                                            class='py-1 px-1 cursor-pointer hover-light'
+                                            class='py-1 px-1 cursor-pointer hover'
                                             @click='incoming.cron = "rate(5 minutes)"'
                                         >
                                             rate(5 minutes)
                                         </li>
                                         <li
-                                            class='py-1 px-1 cursor-pointer hover-light'
+                                            class='py-1 px-1 cursor-pointer hover'
                                             @click='incoming.cron = "cron(15 10 * * ? *)"'
                                         >
                                             cron(15 10 * * ? *)
                                         </li>
                                         <li
-                                            class='py-1 px-1 cursor-pointer hover-light'
+                                            class='py-1 px-1 cursor-pointer hover'
                                             @click='incoming.cron = "cron(0/5 8-17 ? * MON-FRI *)"'
                                         >
                                             cron(0/5 8-17 ? * MON-FRI *)

--- a/api/web/src/components/Layer/LayerIncomingStyles.vue
+++ b/api/web/src/components/Layer/LayerIncomingStyles.vue
@@ -125,7 +125,7 @@
                         <div
                             tabindex='0'
                             role='menuitem'
-                            class='cursor-pointer hover-light list-group-item list-group-item-action'
+                            class='cursor-pointer hover list-group-item list-group-item-action'
                             @click='query = q_idx'
                         >
                             <div class='d-flex'>
@@ -148,7 +148,7 @@
             </template>
             <template v-else-if='query !== null'>
                 <div class='card-body'>
-                    <div class='col-md-12 hover-light rounded px-2 py-2'>
+                    <div class='col-md-12 hover rounded px-2 py-2'>
                         <TablerInput
                             v-model='queries[query].query'
                             :disabled='disabled'

--- a/api/web/src/components/Layer/utils/StyleSingle.vue
+++ b/api/web/src/components/Layer/utils/StyleSingle.vue
@@ -1,6 +1,6 @@
 <template>
     <div class='row g-2'>
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconLicense
                     :size='20'
@@ -24,7 +24,7 @@
             />
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'> 
                 <label class='user-select-none subheader'><IconBlockquote
                     :size='20'
@@ -48,7 +48,7 @@
             />
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconBlockquote
                     :size='20'
@@ -71,7 +71,7 @@
             />
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconLink
                     :size='20'
@@ -152,7 +152,7 @@
             </div>
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconLicense
                     :size='20'
@@ -176,7 +176,7 @@
             />
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconBlockquote
                     :size='20'
@@ -200,7 +200,7 @@
             />
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconBlockquote
                     :size='20'
@@ -224,7 +224,7 @@
             />
         </div>
 
-        <div class='col-md-12 hover-light rounded px-2 py-2'>
+        <div class='col-md-12 hover rounded px-2 py-2'>
             <div class='col-12 d-flex align-items-center'>
                 <label class='user-select-none subheader'><IconLink
                     :size='20'
@@ -249,7 +249,7 @@
         </div>
 
         <template v-if='mode === "point"'>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconCategory
                         :size='20'
@@ -272,7 +272,7 @@
                     :schema='props.schema'
                 />
             </div>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconPhoto
                         :size='20'
@@ -293,7 +293,7 @@
                     :disabled='disabled || !filters[mode].enabled.icon'
                 />
             </div>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconPaint
                         :size='20'
@@ -314,7 +314,7 @@
                     :disabled='disabled || !filters[mode].enabled["marker-color"]'
                 />
             </div>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'>
                         <IconGhost
@@ -347,7 +347,7 @@
             </div>
         </template>
         <template v-else-if='mode !== "point"'>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconPaint
                         :size='20'
@@ -370,7 +370,7 @@
                 />
             </div>
 
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconBorderStyle2
                         :size='20'
@@ -391,7 +391,7 @@
                     :options='["Solid", "Dashed", "Dotted", "Outlined"]'
                 />
             </div>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconRuler2
                         :size='20'
@@ -414,7 +414,7 @@
                     :step='1'
                 />
             </div>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'>
                         <IconGhost
@@ -447,7 +447,7 @@
             </div>
         </template>
         <template v-if='mode === "polygon"'>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'><IconPaint
                         :size='20'
@@ -468,7 +468,7 @@
                     :disabled='disabled || !filters[mode].enabled.fill'
                 />
             </div>
-            <div class='col-md-12 hover-light rounded px-2 py-2'>
+            <div class='col-md-12 hover rounded px-2 py-2'>
                 <div class='col-12 d-flex align-items-center'>
                     <label class='user-select-none subheader'>
                         <IconGhost

--- a/api/web/src/components/LayerAlerts.vue
+++ b/api/web/src/components/LayerAlerts.vue
@@ -49,7 +49,7 @@
                                 <div
                                     v-for='alert in list.items'
                                     :key='alert.id'
-                                    class='hover-light'
+                                    class='hover'
                                 >
                                     <div class='row px-3 py-2'>
                                         <div class='d-flex'>

--- a/api/web/src/components/Styling/Style.vue
+++ b/api/web/src/components/Styling/Style.vue
@@ -53,7 +53,7 @@
             :key='l.id'
         >
             <div
-                class='hover-light cursor-pointer'
+                class='hover cursor-pointer'
                 @click='open.has(l.id) ? open.delete(l.id) : open.add(l.id)'
             >
                 <div class='px-3 py-2 d-flex align-items-center'>

--- a/api/web/src/components/util/LayerSelect.vue
+++ b/api/web/src/components/util/LayerSelect.vue
@@ -50,7 +50,7 @@
                         v-else
                     >
                         <div
-                            class='hover-light px-2 py-2 cursor-pointer row rounded'
+                            class='hover px-2 py-2 cursor-pointer row rounded'
                             @click='selected = layer'
                         >
                             <div class='col-md-4'>

--- a/api/web/src/components/util/LayerTaskSelect.vue
+++ b/api/web/src/components/util/LayerTaskSelect.vue
@@ -82,7 +82,7 @@
                         >
                             <div class='col-sm-6 col-lg-3'>
                                 <div
-                                    class='card card-link cursor-pointer hover-light'
+                                    class='card card-link cursor-pointer hover'
                                     @click='selected = select(task)'
                                 >
                                     <div class='card-header d-flex align-items-center user-select-none'>

--- a/api/web/src/components/util/LayerTemplateSelect.vue
+++ b/api/web/src/components/util/LayerTemplateSelect.vue
@@ -49,7 +49,7 @@
                         v-else
                     >
                         <div
-                            class='hover-light px-2 py-2 cursor-pointer row rounded'
+                            class='hover px-2 py-2 cursor-pointer row rounded'
                             @click='selected = layer'
                         >
                             <div class='col-md-4'>

--- a/api/web/src/components/util/PublicTilesSelect.vue
+++ b/api/web/src/components/util/PublicTilesSelect.vue
@@ -53,7 +53,7 @@
                         v-else
                     >
                         <div
-                            class='hover-light px-2 py-2 cursor-pointer rounded user-select-none d-flex align-items-center'
+                            class='hover px-2 py-2 cursor-pointer rounded user-select-none d-flex align-items-center'
                             @click='select(task)'
                         >
                             <div v-text='task.name.replace(/^public\//, "").replace(/\.pmtiles$/, "")' />

--- a/api/web/src/components/util/UserSelect.vue
+++ b/api/web/src/components/util/UserSelect.vue
@@ -51,7 +51,7 @@
                                         v-for='user of list.items'
                                         :key='user.username'
                                         tabindex='0'
-                                        class='cursor-pointer my-1 hover-light px-2 py-1'
+                                        class='cursor-pointer my-1 hover px-2 py-1'
                                         @keyup.enter='selected = user'
                                         @click='selected = user'
                                     >


### PR DESCRIPTION
### Context

- :rocket: Use Vue3 Teleport for modals to fix a couple bugs where modals weren't taking over the full page and instead being crammed inside a small div
- :rocket: Move Theme state to HTML element for better thematic support throughout the app
- :rocket: Make `hover` generic based on theme, replacing hardcoded `hover-dark` and `hover-light`
- :rocket: Remove instances of `bg-white` and let the theme do it's magic