### PR TITLE
Remove bg-white from card headers for dark theme support

### DIFF
--- a/api/web/src/components/Layer/LayerIncomingStyles.vue
+++ b/api/web/src/components/Layer/LayerIncomingStyles.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class='card-header bg-white sticky-top'>
+        <div class='card-header sticky-top'>
             <h3 class='card-title'>
                 Style Overrides
             </h3>


### PR DESCRIPTION
### Changes
- Removed `bg-white` class from card header elements that was conflicting with dark theme styling
- Affects sticky card headers in layer styling components

### Why
The `bg-white` class was forcing white backgrounds on card headers, which interferes with the new dark design implementation. Removing this allows the dark theme to properly style these elements.

### Examples
**Before**


**After**