### PR TITLE
Increase Default Circle Marker Size for Better Visibility

### DIFF
--- a/api/web/src/base/utils/styles.ts
+++ b/api/web/src/base/utils/styles.ts
@@ -91,7 +91,7 @@ export default function styles(id: string, opts: {
         layout: {},
         paint: {
             'circle-color': ["string", ["get", "marker-color"], "#00FF00"],
-            'circle-radius': ["number", ["get", "marker-radius"], 4],
+            'circle-radius': ["number", ["get", "marker-radius"], 8],
             'circle-opacity': ["number", ["get", "marker-opacity"], 1],
         }
     }


### PR DESCRIPTION
### Problem
The current default circle marker radius of 4 pixels makes point features difficult to see and interact with on the map, especially at lower zoom levels or on high-DPI displays.

### Solution
- Increase default `circle-radius` from 4 to 8 pixels in the circle layer specification
- Maintains all other default properties (green color, full opacity)
- Preserves ability for features to override size via `marker-radius` property

### Changes
```typescript
// Before
'circle-radius': ["number", ["get", "marker-radius"], 4],

// After  
'circle-radius': ["number", ["get", "marker-radius"], 8],
```

### Benefits
* **Improved Visibility:** Larger markers are easier to spot on the map

* **Better UX:** Increased click target size improves user interaction

* **Accessibility:** Better visibility for users with visual impairments

* **Consistency:** Aligns with modern mapping interface standards

### Testing
* Verified existing functionality remains unchanged
* Confirmed features can still override default via marker-radius property
* No breaking changes to existing layer configurations

Improves overall user experience while maintaining backward compatibility.

### Example
Multiple dots (333 to be exact) distributed across NZ. In this case they represent the shaking intensity information for current geological activities (earthquake). 
<img width="1716" height="1261" alt="image" src="https://github.com/user-attachments/assets/67929f9c-76bf-4029-b498-b00a88d4e3f1" />
