### PR TITLE
Sink Error

### DIFF
--- a/api/lib/sinks.ts
+++ b/api/lib/sinks.ts
@@ -45,7 +45,7 @@ export default class Sinks {
                 for (const cot of slice) {
                     entries.push({
                         Id: (Math.random() + 1).toString(36).substring(7),
-                        MessageGroupId: `${String(layer.id)}-${cot.uid()}`,
+                        MessageGroupId: `${String(layer.id)}-${cot.uid()}`.slice(0, 128),
                         MessageBody: JSON.stringify({
                             xml: await CoTParser.to_xml(cot),
                             geojson: await CoTParser.to_geojson(cot)


### PR DESCRIPTION
### Context

Several messages failed to be delivered to an outgoing ETL due to the length of the given `uid`. To ensure this does not happen in the future, the MessageGroupID is now truncated to the max 128 characters. 