### PR TITLE
Update Default Memory to 256

### DIFF
--- a/api/routes/connection-layer.ts
+++ b/api/routes/connection-layer.ts
@@ -176,7 +176,7 @@ export default async function router(schema: Schema, config: Config) {
                 description: 'Enable Logging for this Layer'
             }),
             memory: Type.Integer({
-                default: 128,
+                default: 256,
                 description: 'Memory in MB for this Layer',
                 minimum: 128,
                 maximum: 10240

--- a/api/test/connection-layer.srv.test.ts
+++ b/api/test/connection-layer.srv.test.ts
@@ -105,7 +105,7 @@ test('POST: api/connection/1/layer', async (t) => {
              task: 'etl-test-v1.0.0',
              template: false,
              connection: 1,
-             memory: 128,
+             memory: 256,
              timeout: 120,
              parent: {
                  id: 1,
@@ -154,7 +154,7 @@ test('GET: api/connection/1/layer/1', async (t) => {
              task: 'etl-test-v1.0.0',
              template: false,
              connection: 1,
-             memory: 128,
+             memory: 256,
              timeout: 120,
              parent: {
                  id: 1,


### PR DESCRIPTION
### Context

The default memory is often a bottleneck for ETL integrations. The DB default was updated to 256 some time ago however the API default was never updated to match.