### PR TITLE
Map Diff Updates

### DIFF
--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -383,7 +383,7 @@ export default class COT {
      */
     as_rendered(): GeoJSONFeature<GeoJSONGeometry, Record<string, unknown>> {
         const feat: GeoJSONFeature<GeoJSONGeometry, Record<string, unknown>> = {
-            id: this.hashCode(this.id),
+            id: this.vectorId(),
             type: 'Feature',
             properties: {
                 id: this.id,        //Vector Tiles only support integer IDs so store in props
@@ -406,14 +406,15 @@ export default class COT {
     /**
      * string hash function to convert the COT ID into a number for use as a vector tile feature ID
      */
-    hashCode(str: string): number {
+    vectorId(): number {
         let h = 0;
-        if (str.length === 0) return h;
-        for (let i = 0; i < str.length; i++) {
-            h = (h << 5) - h + str.charCodeAt(i);
+        if (this.id.length === 0) return h;
+        for (let i = 0; i < this.id.length; i++) {
+            h = (h << 5) - h + this.id.charCodeAt(i);
             h |= 0; // Ensure 32-bit integer
         }
-        return h;
+
+        return h >>> 0; // Convert to unsigned
     }
 
     length(): number {

--- a/api/web/src/components/CloudTAK/CoTView.vue
+++ b/api/web/src/components/CloudTAK/CoTView.vue
@@ -1050,7 +1050,6 @@ function updatePropertyType(type: string): void {
 }
 
 function updateCoordinates(center: number[]): void {
-    console.error('PRE UPDATE COORDINATES', cot.value);
     if (!cot.value) return;
 
     cot.value.properties.center = center;
@@ -1059,7 +1058,6 @@ function updateCoordinates(center: number[]): void {
         cot.value.geometry.coordinates = center;
     }
 
-    console.error('PRE UPDATE COORDINATES', cot.value);
     cot.value.update({});
 }
 

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -823,11 +823,10 @@ async function handleRadial(event: string): Promise<void> {
         const cot = mapStore.radial.cot;
         closeRadial()
 
-        if (route.name === 'home-menu-cot' && route.params.uid === cot.id) {
+        if (route.name === 'home-menu-cot' && route.params.uid === (cot.properties.id || cot.id)) {
             router.push('/');
         }
 
-        console.error(cot, cot.id);
         await mapStore.worker.db.remove(String(cot.properties.id || cot.id), {
             mission: true
         })
@@ -837,7 +836,7 @@ async function handleRadial(event: string): Promise<void> {
         mapStore.locked.push(mapStore.radial.cot.properties ? mapStore.radial.cot.properties.id : mapStore.radial.cot.id);
         closeRadial()
     } else if (event === 'cot:edit') {
-        const cot = await mapStore.worker.db.get(String(mapStore.radial.cot.id ? mapStore.radial.cot.id : mapStore.radial.cot.properties.id))
+        const cot = await mapStore.worker.db.get(mapStore.radial.cot.properties.id || mapStore.radial.cot.id)
         if (!cot) throw new Error('Cannot Find COT Marker');
         await mapStore.draw.edit(cot);
 

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -92,22 +92,7 @@
                         style='width: 40px;'
                     >
                         <TablerIconButton
-                            v-if='
-                                (mapStore.radial.cot && mapStore.locked.length >= 2)
-                                    || (!mapStore.radial.cot && mapStore.locked.length >= 1)
-                            '
-                            title='Map is locked to marker - Click to Unlock'
-                            @click='mapStore.locked.splice(0, mapStore.locked.length)'
-                        >
-                            <IconLockAccess
-                                color='#83b7e8'
-                                :size='20'
-                                stroke='1'
-                                style='margin: 5px 8px'
-                            />
-                        </TablerIconButton>
-                        <TablerIconButton
-                            v-else-if='mapStore.location === LocationState.Live'
+                            v-if='mapStore.location === LocationState.Live'
                             :title='locationTooltip'
                             @click='setLocation'
                         >
@@ -308,6 +293,23 @@
                         :color='mapStore.isTerrainEnabled ? "#1E90FF" : "#FFFFFF"'
                         style='margin: 3px 3px'
                         @click='mapStore.isTerrainEnabled ? mapStore.removeTerrain() : mapStore.addTerrain()'
+                    />
+
+                    <IconLockAccess
+                        v-if='
+                            (mapStore.radial.cot && mapStore.locked.length >= 2)
+                                || (!mapStore.radial.cot && mapStore.locked.length >= 1)
+                        '
+                        v-tooltip='"Map is locked to marker - Click to Unlock"'
+                        title='Map is locked to marker - Click to Unlock'
+                        class='cursor-pointer hover-button'
+                        @click='mapStore.locked.splice(0, mapStore.locked.length)'
+                        role='button'
+                        tabindex='0'
+                        color='red'
+                        :size='32'
+                        stroke='2'
+                        style='margin: 3px 3px'
                     />
                 </div>
             </div>

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -428,7 +428,6 @@ export const useMapStore = defineStore('cloudtak', {
                         '-1': {
                             type: 'geojson',
                             cluster: false,
-                            promoteId: 'id',
                             data: { type: 'FeatureCollection', features: [] }
                         }
                     },
@@ -553,7 +552,7 @@ export const useMapStore = defineStore('cloudtak', {
                         return clickMap.has(feat.layer.id);
                     })
                     .forEach((feat) => {
-                        dedupe.set(String(feat.id), feat);
+                        dedupe.set(String(feat.properties.id || feat.id), feat);
                     })
 
                 const features = Array.from(dedupe.values());

--- a/api/web/src/stores/modules/draw.ts
+++ b/api/web/src/stores/modules/draw.ts
@@ -201,7 +201,7 @@ export default class DrawTool {
                     await this.stop();
 
                     await this.mapStore.worker.db.add(feat, {
-                        authored: !(await this.mapStore.worker.db.has(feat.id))
+                        authored: !(await this.mapStore.worker.db.has(feat.properties.id || feat.id))
                     });
 
                     await this.mapStore.refresh();

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -275,6 +275,7 @@ export default class AtlasDatabase {
             if (!cot) continue;
 
             diff.remove.push(cot.vectorId());
+
             this.cots.delete(id);
         }
 

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -195,7 +195,7 @@ export default class AtlasDatabase {
 
             if (this.pendingHidden.has(String(cot.id))) {
                 this.hidden.add(cot.id);
-                diff.remove.push(String(cot.id))
+                diff.remove.push(cot.vectorId())
                 this.pendingHidden.delete(cot.id);
             } else if (
                 !['Never'].includes(display_stale)
@@ -207,7 +207,7 @@ export default class AtlasDatabase {
                     || display_stale === '1 Hour'       && now > stale + 600000 * 6
                 )
             ) {
-                diff.remove.push(String(cot.id))
+                diff.remove.push(cot.vectorId())
             } else if (!cot.properties.archived) {
                 if (now < stale && (cot.properties['icon-opacity'] !== 1 || cot.properties['marker-opacity'] !== 1)) {
                     cot.properties['icon-opacity'] = 1;
@@ -216,7 +216,7 @@ export default class AtlasDatabase {
                     if (!['Point', 'Polygon', 'LineString'].includes(cot.geometry.type)) continue;
 
                     diff.update.push({
-                        id: String(render.id),
+                        id: render.id,
                         addOrUpdateProperties: Object.keys(render.properties).map((key) => {
                             return { key, value: render.properties ? render.properties[key] : '' }
                         }),
@@ -229,7 +229,7 @@ export default class AtlasDatabase {
                     if (!['Point', 'Polygon', 'LineString'].includes(render.geometry.type)) continue;
 
                     diff.update.push({
-                        id: String(render.id),
+                        id: render.id,
                         addOrUpdateProperties: Object.keys(render.properties).map((key) => {
                             return { key, value: cot.properties ? render.properties[key] : '' }
                         }),
@@ -260,7 +260,7 @@ export default class AtlasDatabase {
             const render = cot.as_rendered();
 
             diff.update.push({
-                id: String(render.id),
+                id: render.id,
                 addOrUpdateProperties: Object.keys(render.properties).map((key) => {
                     return { key, value: render.properties[key] }
                 }),
@@ -271,7 +271,10 @@ export default class AtlasDatabase {
         this.pendingCreate.clear();
 
         for (const id of this.pendingDelete) {
-            diff.remove.push(id);
+            const cot = this.get(id);
+            if (!cot) continue;
+
+            diff.remove.push(cot.vectorId());
             this.cots.delete(id);
         }
 

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -455,7 +455,6 @@ export default class AtlasDatabase {
 
         if (cot.origin.mode === OriginMode.CONNECTION) {
             this.pendingDelete.add(id);
-            this.cots.delete(id);
 
             if (cot.properties.archived) {
                 this.atlas.postMessage({

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -216,7 +216,7 @@ export default class AtlasDatabase {
                     if (!['Point', 'Polygon', 'LineString'].includes(cot.geometry.type)) continue;
 
                     diff.update.push({
-                        id: render.id,
+                        id: Number(render.id),
                         addOrUpdateProperties: Object.keys(render.properties).map((key) => {
                             return { key, value: render.properties ? render.properties[key] : '' }
                         }),
@@ -229,7 +229,7 @@ export default class AtlasDatabase {
                     if (!['Point', 'Polygon', 'LineString'].includes(render.geometry.type)) continue;
 
                     diff.update.push({
-                        id: render.id,
+                        id: Number(render.id),
                         addOrUpdateProperties: Object.keys(render.properties).map((key) => {
                             return { key, value: cot.properties ? render.properties[key] : '' }
                         }),
@@ -260,7 +260,7 @@ export default class AtlasDatabase {
             const render = cot.as_rendered();
 
             diff.update.push({
-                id: render.id,
+                id: Number(render.id),
                 addOrUpdateProperties: Object.keys(render.properties).map((key) => {
                     return { key, value: render.properties[key] }
                 }),

--- a/api/web/src/workers/atlas-profile.ts
+++ b/api/web/src/workers/atlas-profile.ts
@@ -151,7 +151,6 @@ export default class AtlasProfile {
 
             n.onclick = (event) => {
                 event.preventDefault(); // prevent the browser from focusing the Notification's tab
-                console.error(n);
             };
 
         }


### PR DESCRIPTION
### Context

Vector Tiles IDs only support integers however MapLibre allows string types per the GeoJSON spec but under the hood simply runs a parseInt call which resulted in hash collision.

As part of this work the CoTs now use a vectorId function to calculate an unsigned integer for each function.

The Diff code however was conflicting with this use as it still uses a string in some operations.