### PR TITLE
Set CPU/Memory Size as Parameter

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -14,8 +14,7 @@ for (const env of [
     'API_URL'
 ]) {
     if (!process.env[env]) {
-        console.error(`${env} Env Var must be set`);
-        process.exit();
+        throw new Error(`${env} Env Var must be set`);
     }
 }
 

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -5,7 +5,7 @@ export default {
         SubdomainPrefix: {
             Description: 'Prefix of domain: ie "map" of map.example.com',
             Type: 'String'
-        }
+        },
         ComputeCpu: {
             Description: 'The number of CPU units used by the task',
             Type: 'Number',

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -6,6 +6,16 @@ export default {
             Description: 'Prefix of domain: ie "map" of map.example.com',
             Type: 'String'
         }
+        ComputeCpu: {
+            Description: 'The number of CPU units used by the task',
+            Type: 'Number',
+            Default: 1024
+        },
+        ComputeMemory: {
+            Description: 'The amount of memory (in MiB) used by the task',
+            Type: 'Number',
+            Default: 4096 * 2
+        }
     },
     Resources: {
         ELBDNS: {
@@ -391,8 +401,8 @@ export default {
             DependsOn: ['SigningSecret', 'MediaSecret'],
             Properties: {
                 Family: cf.stackName,
-                Cpu: 1024 * 1,
-                Memory: 4096 * 2,
+                Cpu: cf.ref('ComputeCpu'),
+                Memory: cf.ref('ComputeMemory'),
                 NetworkMode: 'awsvpc',
                 RequiresCompatibilities: ['FARGATE'],
                 Tags: [{

--- a/cloudformation/lib/events.js
+++ b/cloudformation/lib/events.js
@@ -68,8 +68,8 @@ export default {
             DependsOn: ['SigningSecret', 'MediaSecret'],
             Properties: {
                 Family: cf.join([cf.stackName, '-events']),
-                Cpu: 1024 * 1,
-                Memory: 4096 * 2,
+                Cpu: cf.ref('ComputeCpu'),
+                Memory: cf.ref('ComputeMemory'),
                 NetworkMode: 'awsvpc',
                 RequiresCompatibilities: ['FARGATE'],
                 Tags: [{


### PR DESCRIPTION
### Context

Make ECS Task Definition CPU/Memory a configurable paramters to allow us to downsize CloudTAK size (and costs!) in a staging environment.