### PR TITLE
Filter By Basemap Type

### DIFF
--- a/api/web/src/components/CloudTAK/Menu/MenuBasemaps.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuBasemaps.vue
@@ -318,6 +318,8 @@ async function fetchList() {
         if (paging.value.collection) url.searchParams.append('collection', String(paging.value.collection));
         url.searchParams.append('limit', String(paging.value.limit));
         url.searchParams.append('page', String(paging.value.page));
+        url.searchParams.append('type', 'vector');
+        url.searchParams.append('type', 'raster');
         list.value = await std(url) as BasemapList;
     } catch (err) {
         error.value = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
### Context

- Expands the `type` query parameter to allow querying for multiple types in a single query
- Only queries for `raster` and `vector` in basemap UI

Closes: https://github.com/dfpc-coe/CloudTAK/issues/925