### PR TITLE
Fix Consistent Env Vars

### DIFF
--- a/cloudformation/lib/pmtiles.js
+++ b/cloudformation/lib/pmtiles.js
@@ -29,7 +29,7 @@ export default {
                     Variables: {
                         StackName: cf.stackName,
                         ASSET_BUCKET: cf.ref('AssetBucket'),
-                        APIROOT: cf.join(['https://tiles.', cf.ref('SubdomainPrefix'), '.', cf.importValue(cf.join(['tak-vpc-', cf.ref('Environment'), '-hosted-zone-name']))]),
+                        PMTILES_URL: cf.join(['https://tiles.', cf.ref('SubdomainPrefix'), '.', cf.importValue(cf.join(['tak-vpc-', cf.ref('Environment'), '-hosted-zone-name']))]),
                         SigningSecret: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/api/secret:SecretString::AWSCURRENT}}')
                     }
                 },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         ports:
             - "5002:5002"
         environment:
+            - PMTILES_URL=http://tiles:5002
             - SigningSecret=coe-wildland-fire
             - MediaSecret=coe-wildland-fire-video
             - ASSET_BUCKET=cloudtak

--- a/tasks/pmtiles/src/index.ts
+++ b/tasks/pmtiles/src/index.ts
@@ -5,7 +5,7 @@ import serverless from '@tak-ps/serverless-http';
 
 if (!process.env.SigningSecret) throw new Error('SigningSecret env var must be provided');
 if (!process.env.ASSET_BUCKET) throw new Error('ASSET_BUCKET env var must be provided');
-if (!process.env.APIROOT) process.env.APIROOT = 'http://localhost:5002';
+if (!process.env.PMTILES_URL) process.env.PMTILES_URL = 'http://localhost:5002';
 
 if (!process.env.AWS_REGION) {
     process.env.AWS_REGION = 'us-east-1';

--- a/tasks/pmtiles/src/lib/tiles.ts
+++ b/tasks/pmtiles/src/lib/tiles.ts
@@ -83,7 +83,7 @@ export class FileTiles {
             description: "Hosted by CloudTAK",
             version: "1.0.0",
             scheme: "xyz",
-            tiles: [ process.env.APIROOT + `/tiles/${this.path}/tiles/{z}/{x}/{y}.${format}?token=${token}`],
+            tiles: [ process.env.PMTILES_URL + `/tiles/${this.path}/tiles/{z}/{x}/{y}.${format}?token=${token}`],
             minzoom: header.minZoom,
             maxzoom: header.maxZoom,
             bounds: [ header.minLon, header.minLat, header.maxLon, header.maxLat ],


### PR DESCRIPTION
### Context

Use consistent Env Var names for ease of updating when deploying in a docker-compose context

@chriselsen Note: the CDK stack will need to update to use the now consistent `PMTILES_URL`  env var instead of `APIROOT`