### PR TITLE
Update Database Type

### DIFF
--- a/cloudformation/lib/db.js
+++ b/cloudformation/lib/db.js
@@ -4,11 +4,9 @@ export default {
     Parameters: {
         DatabaseType: {
             Type: 'String',
-            Default: 'db.t4g.micro',
+            Default: 'db.t4g.medium',
             Description: 'Database size to create',
             AllowedValues: [
-                'db.t4g.micro',
-                'db.t4g.small',
                 'db.t4g.medium'
             ]
         }


### PR DESCRIPTION
### Context

AWS Aurora has minimum database types, this updates the CloudFormation defaults to respect these minimums 