### PR TITLE
Add a volume for the postgis container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
             - POSTGRES_DB=gis
             - POSTGRES_USER=docker
             - POSTGRES_PASSWORD=docker
+        volumes:
+            - .docker-postgis:/var/lib/postgresql/data
 
     store:
         platform: linux/amd64


### PR DESCRIPTION
Previously, the postgis container did not have a volume mounted for the database to be stored on the host.  Upon running "docker compose down", the data would be wiped, and the server would need to be reconfigured. Now, the data persists unless the volume is specifically removed

Re: https://github.com/dfpc-coe/CloudTAK/pull/1102

