### PR TITLE
SW Failure

### DIFF
--- a/api/web/public/sw.js
+++ b/api/web/public/sw.js
@@ -16,7 +16,8 @@ self.addEventListener('install', (event) => {
 
                 Object.values(manifest).forEach((entry) => {
                     if (entry.file.endsWith('.html')) {
-                        assets.add(`./${entry.file}`);
+                        // HTML files are not cached except those explicitly added
+                        return;
                     }
 
                     assets.add(`./${entry.src}`);

--- a/api/web/src/base/overlay.ts
+++ b/api/web/src/base/overlay.ts
@@ -168,7 +168,11 @@ export default class Overlay {
         if (this.frequency) {
             this._timer = setInterval(async () => {
                 const mapStore = useMapStore();
-                mapStore.map.refreshTiles(String(this.id));
+                try {
+                    mapStore.map.refreshTiles(String(this.id));
+                } catch (err) {
+                    console.error('Error refreshing tiles for overlay', this.id, err);
+                }
             }, this.frequency * 1000);
         } else {
             this._timer = null;


### PR DESCRIPTION
### Context

The Service Worker was caching all of the HTML files which wouldn't necessarily respect the URL redirects on the server to remove the .html extension. This would result in the Server Worker not being able to be installed.