### PR TITLE
Add Hard App Refresh

### DIFF
--- a/api/web/src/components/CloudTAK/Menu/MenuSettings.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuSettings.vue
@@ -16,6 +16,11 @@
                 label='API Tokens'
                 @select='router.push("/menu/settings/tokens")'
             />
+            <MenuItemCard
+                :icon='IconRefresh'
+                label='Refresh App'
+                @select='refreshApp()'
+            />
         </div>
     </MenuTemplate>
 </template>
@@ -25,10 +30,34 @@ import { useRouter } from 'vue-router';
 import MenuTemplate from '../util/MenuTemplate.vue';
 import MenuItemCard from './MenuItemCard.vue';
 import {
+    IconRefresh,
     IconRobot,
     IconUserCog,
     IconAdjustments,
 } from '@tabler/icons-vue';
 
 const router = useRouter();
+
+async function refreshApp() {
+    if (!navigator.onLine) {
+        throw new Error('Cannot refresh app while offline.');
+    }
+
+    if ('serviceWorker' in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        for (const registration of registrations) {
+            await registration.unregister();
+        }
+    }
+
+    if ('caches' in window) {
+        const keys = await caches.keys();
+        for (const key of keys) {
+            await caches.delete(key);
+        }
+    }
+
+    window.location.reload();
+}
 </script>
+


### PR DESCRIPTION
### Context

If the ServiceWorkers and/or cache get into a state where the application is preventing an update, allow an escape hatch for a user to force an app refresh without having to uninstall and reinstall the PWA