### PR TITLE
Add robots.txt

### DIFF
--- a/api/web/public/robots.txt
+++ b/api/web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
### Context

Add placeholder robots.txt so tools like Google Pagespeed and Lighhouse don't throw errors

Since almost all content in CloudTAK is behind authentication, the actual robots rules are largely irrelevant 