### PR TITLE
Update MediaInfra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
             - AWS_S3_SecretAccessKey=${AWS_S3_SecretAccessKey}
 
     media:
-        image: ghcr.io/dfpc-coe/media-infra:v8.0.1
+        image: ghcr.io/dfpc-coe/media-infra:v8.1.0
         restart: 'always'
         environment:
             - API_URL=${API_URL}


### PR DESCRIPTION
This pull request updates the `media` service to use a newer version of the `media-infra` Docker image in the `docker-compose.yml` file.

* Docker image update:
  * [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L60-R60): Upgraded the `media` service image from `ghcr.io/dfpc-coe/media-infra:v8.0.1` to `v8.1.0` to use the latest version.