### PR TITLE
down => stop

### DIFF
--- a/cloudtak.sh
+++ b/cloudtak.sh
@@ -159,7 +159,7 @@ elif [[ "$SUBCOMMAND" == "start" ]]; then
 
     docker compose up -d api events tiles media
 elif [[ "$SUBCOMMAND" == "stop" ]]; then
-    docker compose down
+    docker compose stop
 elif [[ "$SUBCOMMAND" == "clean" ]]; then
     if ! command -v jq &> /dev/null; then
         echo "jq could not be found, please install jq first."


### PR DESCRIPTION
### Context

`down` in the context of docker destroys the underlying containers, the intended behavior was simply to stop them,