### PR TITLE
Content-Encoding

### DIFF
--- a/tasks/pmtiles/src/lib/tiles.ts
+++ b/tasks/pmtiles/src/lib/tiles.ts
@@ -462,8 +462,8 @@ export class FileTiles {
                 if (isGzip) {
                     res.send(buffer);
                 } else {
-                    const recompressed_data = zlib.gzipSync(buffer);
-                    res.send(recompressed_data);
+                    const compressed_data = zlib.gzipSync(buffer);
+                    res.send(compressed_data);
                 }
             } else {
                 if (isGzip) {


### PR DESCRIPTION
### Context

- :bug: Ensure Content-Encoding in API Gateway context is always set correctly by sniffing the actual contents of the buffer returned by the PMTiles Class