### PR TITLE
Remove MediaSecret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@ CLOUDTAK_Mode=docker-compose
 CLOUDTAK_Config_media_url=http://media
 
 SigningSecret=coe-wildland-fire
-MediaSecret=coe-wildland-fire-video
 
 ASSET_BUCKET=cloudtak
 AWS_S3_Endpoint=http://store:9000


### PR DESCRIPTION
### Context

MediaSecret is no longer used with the new Media Infra API strategy. Remove it from the example env.