### PR TITLE
Basemap Token

### DIFF
--- a/api/lib/auth.ts
+++ b/api/lib/auth.ts
@@ -68,13 +68,15 @@ export class AuthResource {
 export class AuthUser {
     access: AuthUserAccess;
     email: string;
+    token: string;
 
     // Username of admin doing the impersonating - if this value is populated the calling user is guarenteed to be an admin
     impersonate?: string;
 
-    constructor(access: AuthUserAccess, email: string) {
+    constructor(access: AuthUserAccess, email: string, token: string) {
         this.access = access;
         this.email = email;
+        this.token = token;
     }
 
     is_admin(): boolean {
@@ -233,7 +235,7 @@ export default class Auth {
         if (imp.agency_admin) access = AuthUserAccess.AGENCY;
         if (imp.system_admin) access = AuthUserAccess.ADMIN;
 
-        const resolved = new AuthUser(access, impersonate);
+        const resolved = new AuthUser(access, impersonate, adminUser.token);
         resolved.impersonate = adminUser.email;
         return resolved;
     }
@@ -329,11 +331,11 @@ export async function tokenParser(
             const profile = await config.models.Profile.from(decoded.id);
 
             if (profile.system_admin) {
-                return new AuthUser(AuthUserAccess.ADMIN, profile.username);
+                return new AuthUser(AuthUserAccess.ADMIN, profile.username, `etl.${token}`);
             } else if (profile.agency_admin.length) {
-                return new AuthUser(AuthUserAccess.AGENCY, profile.username);
+                return new AuthUser(AuthUserAccess.AGENCY, profile.username, `etl.${token}`);
             } else {
-                return new AuthUser(AuthUserAccess.USER, profile.username);
+                return new AuthUser(AuthUserAccess.USER, profile.username, `etl.${token}`);
             }
         } else {
             return new AuthResource(`etl.${token}`, access, decoded.id, decoded.internal);
@@ -355,7 +357,7 @@ export async function tokenParser(
             access
         };
 
-        return new AuthUser(auth.access, auth.email);
+        return new AuthUser(auth.access, auth.email, token);
     }
 }
 

--- a/api/routes/basemap.ts
+++ b/api/routes/basemap.ts
@@ -640,6 +640,12 @@ export default async function router(schema: Schema, config: Config) {
             }
 
             if (basemap.tilejson) {
+                const url = new URL(basemap.tilejson);
+
+                if (url.hostname === new URL(config.PMTILES_URL).hostname) {
+                    url.searchParams.set('token', auth.token);
+                }
+
                 const tj = await fetch(basemap.tilejson);
                 const json = await tj.json();
 


### PR DESCRIPTION
### Context

If a token URL parameter is passed into a basemap POST or PATCH that is related to 
"public" basemaps, the token will expire and then cause the layer to 404.

This PR detects that a tiles request is for a public basemap and uses the users 
current token instead

