### PR TITLE
Add isTracked

### DIFF
--- a/api/lib/connection-pool.ts
+++ b/api/lib/connection-pool.ts
@@ -297,22 +297,29 @@ export default class ConnectionPool extends Map<number | string, ConnectionClien
             }
         }).on('end', async () => {
             console.error(`not ok - ${connConfig.id} - ${connConfig.name} @ end`);
-            if (!tak.destroyed) {
+            if (this.isTracked(connClient)) {
                 this.retry(connClient);
             }
         }).on('timeout', async () => {
             console.error(`not ok - ${connConfig.id} - ${connConfig.name} @ timeout`);
-            if (!tak.destroyed) {
+            if (this.isTracked(connClient)) {
                 this.retry(connClient);
             }
         }).on('error', async (err) => {
             console.error(`not ok - ${connConfig.id} - ${connConfig.name} @ error:${err}`);
-            if (!tak.destroyed) {
+            if (this.isTracked(connClient)) {
                 this.retry(connClient);
             }
         });
 
         return connClient;
+    }
+
+    /**
+     * Determine whether a connection is still managed by the pool.
+     */
+    private isTracked(connClient: ConnectionClient): boolean {
+        return this.has(connClient.config.id);
     }
 
     async retry(connClient: ConnectionClient): Promise<void> {
@@ -322,26 +329,44 @@ export default class ConnectionPool extends Map<number | string, ConnectionClien
         } else if (this.closed) {
             console.error(`ok - Not Retrying: ${connClient.config.id} - ${connClient.config.name} - Connection Pool Closed`);
             return;
-        } else if (connClient.tak.destroyed) {
-            console.error(`ok - Not Retrying: ${connClient.config.id} - ${connClient.config.name} - Connection Destroyed`);
-            return;
         }
 
         connClient.retrying = true;
 
-        const retryms = Math.min(connClient.retry * 1000, 15000);
-        if (connClient.retry <= 15) connClient.retry++
-        console.log(`not ok - ${connClient.config.uid()} - ${connClient.config.name} - retrying in ${retryms}ms`)
-        await sleep(retryms);
+        const isFirstRetry = connClient.retry === 0;
+        const nextRetry = Math.min(connClient.retry + 1, 15);
+        const retryms = isFirstRetry ? 0 : Math.min(nextRetry * 1000, 15000);
+        connClient.retry = nextRetry;
 
-        if (connClient.tak.destroyed) {
-            console.log('ok - TAK Client has been closed - not retrying');
+        console.log(`not ok - ${connClient.config.uid()} - ${connClient.config.name} - retrying in ${retryms}ms`)
+        if (retryms > 0) await sleep(retryms);
+
+        if (this.closed) {
+            console.error(`ok - Not Retrying: ${connClient.config.id} - ${connClient.config.name} - Connection Pool Closed`);
             connClient.retrying = false;
             return;
-        } else {
-            connClient.retrying = false
-            await connClient.tak.reconnect();
         }
+
+        if (!this.isTracked(connClient)) {
+            console.log('ok - Connection no longer tracked - not retrying');
+            connClient.retrying = false;
+            return;
+        }
+
+        try {
+            await connClient.tak.reconnect();
+        } catch (err) {
+            console.error(`not ok - ${connClient.config.id} - ${connClient.config.name} - reconnect failed: ${err instanceof Error ? err.message : String(err)}`);
+            connClient.retrying = false;
+
+            if (!this.closed && this.isTracked(connClient)) {
+                await this.retry(connClient);
+            }
+
+            return;
+        }
+
+        connClient.retrying = false;
     }
 
     delete(id: number | string): boolean {


### PR DESCRIPTION
This pull request improves the reliability and correctness of connection retry logic in the `ConnectionPool` class. The main changes ensure that retries are only attempted for connections still managed by the pool, and that retry timing and error handling are more robust.

**Connection management and retry logic:**

* Replaced checks for `tak.destroyed` with a new `isTracked` method to ensure retries are only attempted for connections still managed by the pool. This prevents unnecessary retries for connections that have been removed.
* Added a private `isTracked(connClient)` method that checks if a connection is still present in the pool using its `id`.

**Retry timing and error handling:**

* Refactored the retry timing logic to ensure the first retry happens immediately, and subsequent retries are capped appropriately.
* Improved error handling during reconnection attempts: if a reconnect fails, the retry logic recursively attempts to reconnect again, but only if the pool is not closed and the connection is still tracked.
* Ensured that the `retrying` flag is set and cleared appropriately, avoiding duplicate retries and ensuring proper cleanup when a connection is no longer tracked or the pool is closed.