### PR TITLE
Update NodeJS PMTiles Cleanup Runner

### DIFF
--- a/cloudformation/lib/pmtiles.js
+++ b/cloudformation/lib/pmtiles.js
@@ -83,7 +83,7 @@ export default {
                 MemorySize: 128,
                 Timeout: 900,
                 Description: 'Cleanup old files from EFS',
-                Runtime: 'nodejs20.x',
+                Runtime: 'nodejs24.x',
                 Handler: 'index.handler',
                 Role: cf.getAtt('EFSCleanupLambdaRole', 'Arn'),
                 Code: {


### PR DESCRIPTION
### Context

- :rocket: Update NodeJS@20 => NodeJS@24 for the PMTiles cleanup runner as AWS is retiring the v20 runtime