### PR TITLE
Remove harcoded tileSize from raster-dem source

### DIFF
--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -295,8 +295,7 @@ export const useMapStore = defineStore('cloudtak', {
             if (basemaps.items.length && !this.map.getSource('-2')) {
                 this.map.addSource('-2', {
                     type: 'raster-dem',
-                    url: String(stdurl(`/api/basemap/${basemaps.items[0].id}/tiles?token=${localStorage.token}`)),
-                        tileSize: 256
+                    url: String(stdurl(`/api/basemap/${basemaps.items[0].id}/tiles?token=${localStorage.token}`))
                 })
 
                 this.map.setTerrain({


### PR DESCRIPTION
This PR removes the hardcoded `tileSize: 256` from the `raster-dem` source used by `terrain`, letting MapLibre use the tile size declared in the TileJSON response instead (512px for Mapbox Terrain DEM).

`tileSize` controls how many pixels of screen space correspond to one pixel of DEM data. There's no single "right" value — it's a tradeoff between terrain detail, network transfer, and render performance. I tested a pitched map view in an area with complex terrain:

| `tileSize` | Network transfer |
|------------|-----------------|
| 128px      | 30.7 MB         |
| 256px      | 20.2 MB         |
| 512px      | 12.0 MB         |

Going from 256px to 512px cuts network transfer by ~40% with only a mild difference in terrain detail. The renderer performs better with less data too.

Rather than hardcode a different value, this just removes the override so the source uses whatever tile size its TileJSON recommends.