### PR TITLE
Add GHCR workflow for public container images

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -2,22 +2,20 @@ name: GHCR
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+    tags:
+      - '*'
 
 permissions:
   packages: write
   contents: read
+  attestations: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -31,44 +29,25 @@ jobs:
             context: ./tasks/events/
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{github.event.pull_request.head.sha || github.sha}}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Get Semver Tag
-        id: version
-        if: github.ref == 'refs/heads/main'
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          TAGGED=$(git tag --points-at HEAD)
-          if [ -z "$TAGGED" ]; then
-            echo "semver=v${VERSION}" >> $GITHUB_OUTPUT
-            echo "should_tag=true" >> $GITHUB_OUTPUT
-          else
-            echo "should_tag=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{github.repository_owner}}/cloudtak-${{matrix.task}}
-          tags: |
-            type=ref,event=pr
-            type=sha,enable={{is_default_branch}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{steps.version.outputs.semver}},enable=${{steps.version.outputs.should_tag == 'true'}}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cloudtak-${{ matrix.task }}
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Build and Push
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: ${{matrix.context}}
@@ -77,3 +56,10 @@ jobs:
           labels: ${{steps.meta.outputs.labels}}
           cache-from: type=gha,scope=${{matrix.task}}
           cache-to: type=gha,mode=max,scope=${{matrix.task}}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cloudtak-${{ matrix.task }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/api/web/package.json
+++ b/api/web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tak-ps/cloudtak",
     "type": "module",
-    "version": "12.103.0",
+    "version": "12.103.1",
     "types": "dist/types/plugin.d.ts",
     "files": [
         "dist/types"


### PR DESCRIPTION
## Summary

CloudTAK currently only publishes container images to private AWS ECR registries, which requires AWS credentials and access to specific accounts. For those wanting to self-host CloudTAK on Kubernetes (or other container runtimes), there are no pre-built images to consume — you have to clone the repo and build everything manually.

This PR adds a GitHub Actions workflow that builds and publishes the `api`, `pmtiles`, and `events` container images to GHCR (`ghcr.io/<owner>/cloudtak-<service>`), making them publicly consumable without needing AWS access or a manual build step.

## Changes

- `.github/workflows/ghcr.yml` — new workflow that:
  - Builds all three images in parallel via a matrix strategy
  - On `main`: tags with `latest`, short SHA, and the semver from `package.json` (skipped if the commit is already a release tag)
  - On PRs: tags with `pr-<number>` for testing
  - Uses GitHub Actions cache (`type=gha`) per image for faster builds
  - Publishes under `ghcr.io/${{ github.repository_owner }}/...` so it works correctly on forks

## Motivation

Self-hosting CloudTAK on Kubernetes requires pulling images from somewhere. Without public GHCR images, every deployment requires a manual `npm run build` with AWS credentials configured — a significant barrier for anyone not already operating within the COTAK/WFTAK AWS environment.