### PR TITLE
fix: log actual AWS_REGION value instead of hardcoded us-east-1

### DIFF
--- a/api/lib/config.ts
+++ b/api/lib/config.ts
@@ -153,7 +153,7 @@ export default class Config {
         });
 
         if (!config.silent) {
-            console.error('ok - set env AWS_REGION: us-east-1');
+            console.error(`ok - set env AWS_REGION: ${process.env.AWS_REGION}`);
             console.log(`ok - PMTiles: ${config.PMTILES_URL}`);
             console.error(`ok - StackName: ${config.StackName}`);
         }


### PR DESCRIPTION
I have a custom S3 compatible datastore and was confused why it was telling me it was using region "us-east-1", now logs what the environment variable is set to.