### PR TITLE
Use heuristic to disable globe mode when close to 3d terrain surface

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.api",
-    "version": "12.105.1",
+    "version": "12.105.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.api",
-            "version": "12.105.1",
+            "version": "12.105.2",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-cloudformation": "^3.279.0",

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -956,10 +956,8 @@ async function mountMap(): Promise<void> {
     return new Promise((resolve) => {
         mapStore.map.once('idle', async () => {
             const displayProjection = await ProfileConfig.get('display_projection');
-
-            if (displayProjection && displayProjection.value === 'globe') {
-                mapStore.map.setProjection({ type: "globe" });
-            }
+            mapStore.isGlobeEnabled = displayProjection?.value === 'globe';
+            mapStore.syncTerrainAndProjection();
 
             await mapStore.icons.updateImages();
 

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -957,7 +957,7 @@ async function mountMap(): Promise<void> {
         mapStore.map.once('idle', async () => {
             const displayProjection = await ProfileConfig.get('display_projection');
             mapStore.isGlobeEnabled = displayProjection?.value === 'globe';
-            mapStore.syncTerrainAndProjection();
+            mapStore.updateProjection();
 
             await mapStore.icons.updateImages();
 

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -37,7 +37,7 @@ export type BrowserPermissionState = PermissionState | 'unsupported' | 'unknown'
 type BrowserPermissionType = 'location' | 'notification' | 'orientation' | 'storage' | 'camera';
 
 // Zoom level at or above which we switch from globe to mercator (when user has globe enabled)
-const GLOBE_ZOOM_THRESHOLD = 10;
+const GLOBE_HEIGHT_THRESHOLD = 50_000;
 
 export const useMapStore = defineStore('cloudtak', {
     state: (): {
@@ -618,7 +618,7 @@ export const useMapStore = defineStore('cloudtak', {
                 });
 
                 this.isTerrainEnabled = true;
-                this.syncTerrainAndProjection();
+                this.updateProjection();
             } else {
                 this.hasTerrain = false;
             }
@@ -631,16 +631,28 @@ export const useMapStore = defineStore('cloudtak', {
             this.isTerrainEnabled = false;
         },
 
-        syncTerrainAndProjection: function(): void {
-            const zoom = this.map.getZoom();
+        updateProjection: function(): void {
+            // Estimate camera height above terrain from zoom and pitch.
+            // getCameraAltitude() is broken in globe mode, so we avoid it entirely.
+            const EARTH_CIRCUMFERENCE = 2 * Math.PI * 6_371_008.8;
+            const height = EARTH_CIRCUMFERENCE / Math.pow(2, this.map.getZoom()) * Math.cos(this.map.getPitch() * Math.PI / 180);
 
-            const wantGlobe = this.isGlobeEnabled && !(this.isTerrainEnabled && zoom >= GLOBE_ZOOM_THRESHOLD);
+            console.log(height);
+
+            const wantGlobe =
+              this.isGlobeEnabled &&
+              !(
+                this.isTerrainEnabled &&
+                height <= GLOBE_HEIGHT_THRESHOLD
+              );
 
             const currentProjection = this.map.getProjection()?.type ?? 'mercator';
             if (wantGlobe && currentProjection !== 'globe') {
+                console.log('Enable GLOBE')
                 this.map.setProjection({ type: 'globe' });
                 this.map.setSky({});
             } else if (!wantGlobe && currentProjection !== 'mercator') {
+                console.log('Disable GLOBE')
                 this.map.setProjection({ type: 'mercator' });
             }
         },
@@ -807,7 +819,7 @@ export const useMapStore = defineStore('cloudtak', {
                     this.updateDistanceUnit(msg.body.unit);
                 } else if (msg.type === WorkerMessageType.Map_Projection) {
                     this.isGlobeEnabled = msg.body.type === 'globe';
-                    this.syncTerrainAndProjection();
+                    this.updateProjection();
                 } else if (msg.type === WorkerMessageType.Connection_Open) {
                     this.isOpen = true;
                 } else if (msg.type === WorkerMessageType.Connection_Close) {
@@ -1031,7 +1043,11 @@ export const useMapStore = defineStore('cloudtak', {
             });
 
             map.on('zoomend', () => {
-                this.syncTerrainAndProjection();
+                this.updateProjection();
+            });
+
+            map.on("pitchend", () => {
+              this.updateProjection();
             });
 
             map.on('click', async (e: MapMouseEvent) => {

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -36,6 +36,9 @@ export type TAKNotification = { type: string; name: string; body: string; url: s
 export type BrowserPermissionState = PermissionState | 'unsupported' | 'unknown';
 type BrowserPermissionType = 'location' | 'notification' | 'orientation' | 'storage' | 'camera';
 
+// Zoom level at or above which we switch from globe to mercator (when user has globe enabled)
+const GLOBE_ZOOM_THRESHOLD = 10;
+
 export const useMapStore = defineStore('cloudtak', {
     state: (): {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,6 +94,7 @@ export const useMapStore = defineStore('cloudtak', {
         hasSnapping: boolean;
         hasNoChannels: boolean;
         isTerrainEnabled: boolean;
+        isGlobeEnabled: boolean;
         isLoaded: boolean;
         isOpen: boolean;
         isOnline: boolean;
@@ -142,6 +146,7 @@ export const useMapStore = defineStore('cloudtak', {
             hasTerrain: false,
             hasNoChannels: false,
             isTerrainEnabled: false,
+            isGlobeEnabled: false,
             isOpen: false,
             isLoaded: false,
             isOnline: navigator.onLine,
@@ -613,6 +618,7 @@ export const useMapStore = defineStore('cloudtak', {
                 });
 
                 this.isTerrainEnabled = true;
+                this.syncTerrainAndProjection();
             } else {
                 this.hasTerrain = false;
             }
@@ -623,6 +629,20 @@ export const useMapStore = defineStore('cloudtak', {
             this.map.removeSource('-2');
 
             this.isTerrainEnabled = false;
+        },
+
+        syncTerrainAndProjection: function(): void {
+            const zoom = this.map.getZoom();
+
+            const wantGlobe = this.isGlobeEnabled && !(this.isTerrainEnabled && zoom >= GLOBE_ZOOM_THRESHOLD);
+
+            const currentProjection = this.map.getProjection()?.type ?? 'mercator';
+            if (wantGlobe && currentProjection !== 'globe') {
+                this.map.setProjection({ type: 'globe' });
+                this.map.setSky({});
+            } else if (!wantGlobe && currentProjection !== 'mercator') {
+                this.map.setProjection({ type: 'mercator' });
+            }
         },
 
         returnHome: function(): void {
@@ -721,7 +741,6 @@ export const useMapStore = defineStore('cloudtak', {
             this._boundOnOffline = (): void => { this.isOnline = false; };
             this._boundOnDeviceOrientation = (event: DeviceOrientationEvent): void => {
                 if (!this.userOrientationMode) return;
-                
                 let heading: number | null = null;
                 const iOSEvent = event as DeviceOrientationEvent & { webkitCompassHeading?: number };
                 if (iOSEvent.webkitCompassHeading !== undefined) {
@@ -729,7 +748,6 @@ export const useMapStore = defineStore('cloudtak', {
                 } else if (event.alpha !== null) {
                     heading = 360 - event.alpha;
                 }
-                
                 if (heading !== null && this.map) {
                     this.map.setBearing(heading);
                 }
@@ -788,7 +806,8 @@ export const useMapStore = defineStore('cloudtak', {
                 } else if (msg.type === WorkerMessageType.Profile_Distance_Unit) {
                     this.updateDistanceUnit(msg.body.unit);
                 } else if (msg.type === WorkerMessageType.Map_Projection) {
-                    map.setProjection(msg.body);
+                    this.isGlobeEnabled = msg.body.type === 'globe';
+                    this.syncTerrainAndProjection();
                 } else if (msg.type === WorkerMessageType.Connection_Open) {
                     this.isOpen = true;
                 } else if (msg.type === WorkerMessageType.Connection_Close) {
@@ -1009,6 +1028,10 @@ export const useMapStore = defineStore('cloudtak', {
                 } else {
                     this.draw.snapping.clear();
                 }
+            });
+
+            map.on('zoomend', () => {
+                this.syncTerrainAndProjection();
             });
 
             map.on('click', async (e: MapMouseEvent) => {

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -36,8 +36,10 @@ export type TAKNotification = { type: string; name: string; body: string; url: s
 export type BrowserPermissionState = PermissionState | 'unsupported' | 'unknown';
 type BrowserPermissionType = 'location' | 'notification' | 'orientation' | 'storage' | 'camera';
 
-// Zoom level at or above which we switch from globe to mercator (when user has globe enabled)
-const GLOBE_HEIGHT_THRESHOLD = 50_000;
+// Hysteresis thresholds to avoid thrashing at the boundary.
+// Must zoom in past ENTER to switch to mercator, must zoom out past LEAVE to switch back to globe.
+const GLOBE_ENTER_HEIGHT = 17_000;
+const GLOBE_LEAVE_HEIGHT = 20_000;
 
 export const useMapStore = defineStore('cloudtak', {
     state: (): {
@@ -635,23 +637,20 @@ export const useMapStore = defineStore('cloudtak', {
             // Estimate camera height above terrain from zoom and pitch.
             // getCameraAltitude() is broken in globe mode, so we avoid it entirely.
             const EARTH_CIRCUMFERENCE = 2 * Math.PI * 6_371_008.8;
-            const height = EARTH_CIRCUMFERENCE / Math.pow(2, this.map.getZoom()) * Math.cos(this.map.getPitch() * Math.PI / 180);
+            const pitchFactor = Math.cos((this.map.getPitch() * Math.PI) / 180) * 0.7 + 0.3;
+            const height = (EARTH_CIRCUMFERENCE / Math.pow(2, this.map.getZoom())) * pitchFactor;
 
             console.log(height);
 
-            const wantGlobe =
-              this.isGlobeEnabled &&
-              !(
-                this.isTerrainEnabled &&
-                height <= GLOBE_HEIGHT_THRESHOLD
-              );
-
             const currentProjection = this.map.getProjection()?.type ?? 'mercator';
-            if (wantGlobe && currentProjection !== 'globe') {
+            const shouldEnterGlobe = this.isGlobeEnabled && (!this.isTerrainEnabled || height > GLOBE_ENTER_HEIGHT);
+            const shouldLeaveGlobe = !this.isGlobeEnabled || (this.isTerrainEnabled && height < GLOBE_LEAVE_HEIGHT);
+
+            if (shouldEnterGlobe && currentProjection !== 'globe') {
                 console.log('Enable GLOBE')
                 this.map.setProjection({ type: 'globe' });
                 this.map.setSky({});
-            } else if (!wantGlobe && currentProjection !== 'mercator') {
+            } else if (shouldLeaveGlobe && currentProjection === 'globe') {
                 console.log('Disable GLOBE')
                 this.map.setProjection({ type: 'mercator' });
             }


### PR DESCRIPTION
This PR adds a heuristic to disable the globe projection when the user gets "close" to 3d terrain. 

MapLibre doesn't "officially" support 3d terrain with the globe projection. There are some known rough edges, bugs, performance problems, etc.

This heuristic aims to keep the globe projection on when the user is zoomed out enough that they can perceive the curvature of the earth and turn it off when the user is directly interacting with individual 3d terrain features.

MapLibre has a `map.transform.getCameraAltitude()` method but that breaks in globe mode so the heuristic estimates camera altitude from zoom level and pitch instead.

The heuristic uses different enter and leave thresholds (17km / 20km) to prevent thrashing at the boundary.

## Before

![Mar-19-2026 11-31-52](https://github.com/user-attachments/assets/be57943b-1118-4623-ba61-7ebfa641a870)

Note how the map "jumps" after each move event.

## After

![Mar-19-2026 11-31-01](https://github.com/user-attachments/assets/81f87820-8609-4f2d-a6df-ba7a794d4ed0)
