### PR TITLE
Fix #1421: Set explicit Content-Type on private package upload

### DIFF
--- a/api/routes/marti-package.ts
+++ b/api/routes/marti-package.ts
@@ -399,6 +399,7 @@ export default async function router(schema: Schema, config: Config) {
             } else {
                 content = await api.Files.upload({
                     name: hash,
+                    contentType: 'application/zip',
                     contentLength: size,
                     keywords: req.body.keywords,
                     creatorUid,


### PR DESCRIPTION
Fixes #1421.
What
Adds an explicit contentType: 'application/zip' to the Files.upload() call in the PUT /api/marti/package handler.
Why
Without it, node-tak's Files.upload() falls back to mime.getType(opts.name). The name passed in is the package's SHA-256 hash with no file extension, so mime.getType() returns null. The resulting HTTP request to TAKServer's /Marti/sync/upload carries an empty Content-Type, which TAKServer 5.7+ rejects:

ERROR FileManagerApi - Unable to get file:
InvalidMediaTypeException: Invalid mime type "": 'mimeType' must not be empty

A row is created in TAKServer's resource table but the file is unindexed. CloudTAK still returns 200 to the browser, so the failure was invisible at the UI layer. Net effect: markers-with-attachments sent to specific destinations silently fail to deliver.
Only the private-package path is affected. The public path uses Files.uploadPackage() (multipart) and is fine.
Verification
Tested locally on CloudTAK 12.133.0 against TAKServer 5.7-RELEASE8:

TAKServer resource table: pre-patch rows had mimetype = ''; post-patch rows have mimetype = 'application/zip' and intact data_size.
TAKServer api log: no new InvalidMediaTypeException entries after the fix.
End-to-end: markers with photo attachments now deliver successfully to ATAK and iTAK clients (verified with destination clients on cellular networks).

Note for node-tak
A complementary defensive change in node-tak's Files.upload() — falling back to application/octet-stream rather than null when mime.getType() cannot determine a type — would prevent this class of bug from any future caller. Happy to file that separately if it would be helpful.