### PR TITLE
Mission Layer & Feature Visibility Toggles

### DIFF
--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/cloudtak",
-    "version": "13.5.0",
+    "version": "13.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/cloudtak",
-            "version": "13.5.0",
+            "version": "13.6.0",
             "dependencies": {
                 "@capacitor-community/background-geolocation": "^1.2.26",
                 "@capacitor-community/keep-awake": "^8.0.1",

--- a/api/web/src/base/subscription.ts
+++ b/api/web/src/base/subscription.ts
@@ -1,5 +1,7 @@
 import { db } from '../database.ts'
+import { v4 as randomUUID } from 'uuid';
 import { std, stdurl } from '../std.ts';
+import Filter from './filter.ts';
 import SubscriptionLog from './subscription-log.ts';
 import SubscriptionChanges from './subscription-changes.ts';
 import SubscriptionContents from './subscription-contents.ts';
@@ -195,6 +197,8 @@ export default class Subscription {
                 });
             }
 
+            await exists.loadHiddenFeatureIds();
+
             if (exists.templateid) {
                 try {
                     await MissionTemplate.load(exists.templateid);
@@ -239,6 +243,8 @@ export default class Subscription {
             });
 
             await sub.refresh();
+
+            await sub.loadHiddenFeatureIds();
 
             if (sub.templateid) {
                 try {
@@ -584,5 +590,102 @@ export default class Subscription {
             token: this.token,
             headers: Subscription.headers(this.missiontoken)
         })
+    }
+
+    // ---------------------------------------------------------------------
+    // Feature visibility (hide/show) — persisted as DB filter rows.
+    //
+    // Each hidden feature gets its own Filter row keyed by an external id of
+    // `mission-<guid>-hide-<featId>` and a JSONata query of `id = "<featId>"`.
+    // Subscription.feature.collection(false) already applies all DB filters
+    // when loading mission features for rendering, so the persisted filter
+    // becomes the single source of truth — surviving page refresh, scaling
+    // via IndexedDB, and re-using the existing global filter pipeline.
+    //
+    // The mirrored in-memory `hiddenFeatureIds` is a presentation-only
+    // convenience for the Mission Layers UI so it can reactively render the
+    // correct eye/eye-off icon without re-querying the DB on every paint.
+    // It is reloaded from IndexedDB in loadHiddenFeatureIds() and refreshed
+    // after each mutation here.
+    // ---------------------------------------------------------------------
+
+    hiddenFeatureIds: Set<string> = new Set();
+
+    _hideExternalPrefix(): string {
+        return `mission-${this.guid}-hide-`;
+    }
+
+    _hideExternalFor(featId: string): string {
+        return `${this._hideExternalPrefix()}${featId}`;
+    }
+
+    async loadHiddenFeatureIds(): Promise<void> {
+        const prefix = this._hideExternalPrefix();
+        const rows = await db.filter
+            .where('external')
+            .startsWith(prefix)
+            .toArray();
+        this.hiddenFeatureIds = new Set(
+            rows.map((r) => r.external.slice(prefix.length))
+        );
+    }
+
+    async hideFeature(
+        featId: string,
+        opts: { displayName?: string } = {}
+    ): Promise<void> {
+        if (this.hiddenFeatureIds.has(featId)) return;
+        await Filter.create(
+            opts.displayName ?? featId,
+            this._hideExternalFor(featId),
+            'Mission',
+            true,
+            `id = "${featId}"`
+        );
+        this.hiddenFeatureIds.add(featId);
+    }
+
+    async hideFeatures(
+        featIds: string[],
+        opts: { displayNames?: Record<string, string> } = {}
+    ): Promise<void> {
+        const toAdd = featIds.filter((id) => !this.hiddenFeatureIds.has(id));
+        if (!toAdd.length) return;
+        await db.filter.bulkAdd(toAdd.map((id) => ({
+            id: randomUUID(),
+            name: opts.displayNames?.[id] ?? id,
+            external: this._hideExternalFor(id),
+            source: 'Mission',
+            internal: true,
+            query: `id = "${id}"`,
+        })));
+        for (const id of toAdd) this.hiddenFeatureIds.add(id);
+    }
+
+    async showFeature(featId: string): Promise<void> {
+        if (!this.hiddenFeatureIds.has(featId)) return;
+        await Filter.delete({ external: this._hideExternalFor(featId) });
+        this.hiddenFeatureIds.delete(featId);
+    }
+
+    async showFeatures(featIds: string[]): Promise<void> {
+        const toRemove = featIds.filter((id) => this.hiddenFeatureIds.has(id));
+        if (!toRemove.length) return;
+        // Dexie has no bulk-delete-by-external; do them serially. The size
+        // here is the number of features being un-hidden in a single user
+        // action which is small in practice (one layer's subtree).
+        for (const id of toRemove) {
+            await Filter.delete({ external: this._hideExternalFor(id) });
+            this.hiddenFeatureIds.delete(id);
+        }
+    }
+
+    async showAll(): Promise<void> {
+        if (this.hiddenFeatureIds.size === 0) return;
+        await db.filter
+            .where('external')
+            .startsWith(this._hideExternalPrefix())
+            .delete();
+        this.hiddenFeatureIds.clear();
     }
 }

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionLayerTree.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionLayerTree.vue
@@ -49,6 +49,7 @@
 
                 <span
                     class='mx-2'
+                    :class='{ "text-muted": isHidden(layer) }'
                     v-text='layer.name'
                 />
 
@@ -63,6 +64,25 @@
                             :text-color='layer.uids && layer.uids.length > 0 ? "#2563eb" : "#6b7280"'
                         >{{ `${layer.uids ? layer.uids.length : 0} Features` }}</TablerBadge>
                     </span>
+
+                    <TablerIconButton
+                        v-if='canHide(layer)'
+                        :title='isHidden(layer) ? "Show layer" : "Hide layer"'
+                        :disabled='parentHidden'
+                        :size='24'
+                        @click='emit("toggleHidden", layer.uid)'
+                    >
+                        <IconEyeOff
+                            v-if='isHidden(layer)'
+                            :size='20'
+                            stroke='1'
+                        />
+                        <IconEye
+                            v-else
+                            :size='20'
+                            stroke='1'
+                        />
+                    </TablerIconButton>
 
                     <TablerIconButton
                         v-if='props.subscription.role.permissions.includes("MISSION_WRITE")'
@@ -99,13 +119,21 @@
                     :key='cot.id'
                     :delete-button='false'
                     :feature='cot'
+                    :hide-button='true'
+                    :hidden='isFeatureHidden(cot.id) || isHidden(layer)'
+                    @toggle-hidden='emit("toggleFeatureHidden", String(cot.id))'
                 />
                 <MissionLayerTree
                     v-if='layer.mission_layers && layer.mission_layers.length'
                     :layers='layer.mission_layers as Array<MissionLayer>'
                     :feats='feats'
                     :subscription='subscription'
+                    :hidden-features='props.hiddenFeatures'
+                    :overlay-visible='overlayVisible'
+                    :parent-hidden='parentHidden || isLayerSubtreeAllHidden(layer)'
                     @refresh='emit("refresh")'
+                    @toggle-hidden='(uid: string) => emit("toggleHidden", uid)'
+                    @toggle-feature-hidden='(id: string) => emit("toggleFeatureHidden", id)'
                 />
                 <TablerNone
                     v-if='!layer.uids || !layer.uids.length'
@@ -121,6 +149,9 @@
             :key='feat.id'
             :delete-button='false'
             :feature='feat'
+            :hide-button='true'
+            :hidden='isFeatureHidden(feat.id)'
+            @toggle-hidden='emit("toggleFeatureHidden", String(feat.id))'
         />
     </template>
 </template>
@@ -139,6 +170,8 @@ import {
     IconPencil,
     IconMap,
     IconPin,
+    IconEye,
+    IconEyeOff,
 } from '@tabler/icons-vue';
 import {
     TablerBadge,
@@ -150,16 +183,90 @@ import {
 import FeatureRow from '../../util/FeatureRow.vue';
 import MissionLayerEdit from './MissionLayerEdit.vue';
 
-const emit = defineEmits([
-    'refresh'
-])
+const emit = defineEmits<{
+    (e: 'refresh'): void;
+    (e: 'toggleHidden', uid: string): void;
+    (e: 'toggleFeatureHidden', id: string): void;
+}>();
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
     layers: Array<MissionLayer>,
     feats: Map<string, Feature>,
     subscription: Subscription,
     orphaned?: Set<string>,
-}>();
+    hiddenFeatures?: Set<string>,
+    overlayVisible?: boolean,
+    parentHidden?: boolean,
+}>(), {
+    orphaned: () => new Set<string>(),
+    hiddenFeatures: () => new Set<string>(),
+    overlayVisible: true,
+    parentHidden: false
+});
+
+function collectLayerSubtreeIds(layer: MissionLayer, out: Set<string>): void {
+    if (layer.uids) {
+        for (const cot of layer.uids) {
+            if (cot && cot.data) out.add(cot.data);
+        }
+    }
+    if (layer.mission_layers) {
+        for (const child of layer.mission_layers as unknown as MissionLayer[]) {
+            collectLayerSubtreeIds(child, out);
+        }
+    }
+    // Cascade waypoints owned by any CoT in the subtree.
+    const seeds = Array.from(out);
+    for (const seed of seeds) {
+        const prefix = `${seed}-pt-`;
+        for (const featId of props.feats.keys()) {
+            const sid = String(featId);
+            if (sid.startsWith(prefix)) out.add(sid);
+        }
+    }
+}
+
+// A layer reports as hidden when every CoT it (or its descendants) reference
+// is in the hiddenFeatures set. With no features at all it's never hidden.
+function isHidden(layer: MissionLayer): boolean {
+    if (!props.overlayVisible) return true;
+    if (props.parentHidden) return true;
+
+    const subtree = new Set<string>();
+    collectLayerSubtreeIds(layer, subtree);
+    if (subtree.size === 0) return false;
+
+    for (const fid of subtree) {
+        if (!props.hiddenFeatures.has(fid)) return false;
+    }
+    return true;
+}
+
+// Mirror of isHidden, used to pass the parent-hidden flag into nested
+// MissionLayerTree recursions. Identical to isHidden(layer) right now but
+// expressed as a layer-only predicate (no overlayVisible override) so the
+// recursion still works when overlayVisible is true.
+function isLayerSubtreeAllHidden(layer: MissionLayer): boolean {
+    const subtree = new Set<string>();
+    collectLayerSubtreeIds(layer, subtree);
+    if (subtree.size === 0) return false;
+    for (const fid of subtree) {
+        if (!props.hiddenFeatures.has(fid)) return false;
+    }
+    return true;
+}
+
+function isFeatureHidden(id: string | number): boolean {
+    // Implicit-hide for orphaned feature rows when the overlay is off.
+    if (!props.overlayVisible) return true;
+    return props.hiddenFeatures.has(String(id));
+}
+
+function canHide(layer: MissionLayer): boolean {
+    // Any container layer that may carry CoT references can be hidden.
+    // GROUPs cascade through children; UID/ITEM layers expose their own uids[].
+    return layer.type === 'UID' || layer.type === 'GROUP' || layer.type === 'ITEM';
+}
 
 const opened = ref<Set<string>>(new Set());
 const edit = ref<Set<string>>(new Set());

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionLayers.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionLayers.vue
@@ -9,6 +9,17 @@
     >
         <template #buttons>
             <TablerIconButton
+                v-if='hasHidden'
+                title='Show all layers'
+                :size='24'
+                @click='showAll'
+            >
+                <IconEye
+                    :size='32'
+                    stroke='1'
+                />
+            </TablerIconButton>
+            <TablerIconButton
                 v-if='!createLayer && !loading && subscription.role && subscription.role.permissions.includes("MISSION_WRITE")'
                 title='New Mission Layer'
                 :size='24'
@@ -54,7 +65,11 @@
                     :layers='layers'
                     :feats='feats'
                     :subscription='props.subscription'
+                    :hidden-features='hiddenIds'
+                    :overlay-visible='overlayVisible'
                     @refresh='refresh'
+                    @toggle-hidden='toggleLayer'
+                    @toggle-feature-hidden='toggleFeature'
                 />
             </template>
         </div>
@@ -77,15 +92,20 @@
             :layers='layers'
             :feats='feats'
             :subscription='subscription'
+            :hidden-features='hiddenIds'
+            :overlay-visible='overlayVisible'
             @refresh='refresh'
+            @toggle-hidden='toggleLayer'
+            @toggle-feature-hidden='toggleFeature'
         />
     </template>
 </template>
 
 <script setup lang='ts'>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import {
     IconFolderPlus,
+    IconEye,
 } from '@tabler/icons-vue';
 import {
     TablerNone,
@@ -97,9 +117,13 @@ import type {
     MissionLayer
 } from '../../../../types.ts';
 import Subscription from '../../../../base/subscription.ts';
+import OverlayManager from '../../../../base/overlay.ts';
 import MenuTemplate from '../../util/MenuTemplate.vue';
 import MissionLayerTree from './MissionLayerTree.vue';
 import MissionLayerCreate from './MissionLayerCreate.vue';
+import { useMapStore } from '../../../../stores/map.ts';
+
+const mapStore = useMapStore();
 
 const props = withDefaults(defineProps<{
     menu?: boolean,
@@ -114,6 +138,22 @@ const feats = ref(new Map());
 const orphaned = ref<Set<string>>(new Set());
 const layers = ref<Array<MissionLayer>>([]);
 
+// Reactive UI mirror of `subscription.hiddenFeatureIds`. The Subscription owns
+// the canonical state (persisted as DB Filter rows keyed by mission GUID); we
+// keep this Vue-reactive copy so the tree re-renders eye/eye-off icons
+// immediately on toggle without having to query Dexie on every paint.
+const hiddenIds = ref<Set<string>>(new Set(props.subscription.hiddenFeatureIds));
+
+const overlayVisible = computed(() => {
+    const overlay = OverlayManager.loadedByMode('mission', props.subscription.guid);
+    return overlay ? overlay.visible : true;
+});
+
+const hasHidden = computed(() => {
+    if (!overlayVisible.value) return true;
+    return hiddenIds.value.size > 0;
+});
+
 onMounted(async () => {
     await refresh();
 });
@@ -123,6 +163,7 @@ async function refresh() {
     loading.value = true;
     await fetchFeats();
     await fetchLayers();
+    await syncHiddenIds();
     loading.value = false;
 }
 
@@ -156,5 +197,205 @@ async function fetchLayers(): Promise<void> {
     if (layers.value) {
         removeFeatures(layers.value);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Toggle plumbing.  Each mutation funnels through subscription.{hide,show}*
+// (which writes a DB Filter row), then syncs the Vue ref + asks the map store
+// to re-pull the mission's filtered feature collection.  No in-memory cache
+// of features lives in this component or the Overlay class.
+// ---------------------------------------------------------------------------
+
+async function syncHiddenIds(): Promise<void> {
+    await props.subscription.loadHiddenFeatureIds();
+    hiddenIds.value = new Set(props.subscription.hiddenFeatureIds);
+}
+
+async function reloadMissionSource(): Promise<void> {
+    try {
+        await mapStore.loadMission(props.subscription.guid);
+    } catch (err) {
+        console.error('Failed to reload mission after hide/show toggle:', err);
+    }
+}
+
+// Walk a single layer subtree, collecting every CoT UID referenced by it
+// (its own uids[], its descendants' uids[], etc.).
+function collectSubtreeFeatureIds(layer: MissionLayer, out: Set<string>): void {
+    if (layer.uids) {
+        for (const cot of layer.uids) {
+            if (cot && cot.data) out.add(cot.data);
+        }
+    }
+    if (layer.mission_layers) {
+        for (const child of layer.mission_layers as unknown as MissionLayer[]) {
+            collectSubtreeFeatureIds(child, out);
+        }
+    }
+}
+
+function findLayerByUid(mlayers: MissionLayer[], uid: string): MissionLayer | undefined {
+    for (const l of mlayers) {
+        if (l.uid === uid) return l;
+        if (l.mission_layers) {
+            const child = findLayerByUid(l.mission_layers as unknown as MissionLayer[], uid);
+            if (child) return child;
+        }
+    }
+    return undefined;
+}
+
+// Cascade KML route waypoints: TAK Server's KML→CoT import emits a parent
+// LineString CoT with children whose UIDs follow `<parent-uid>-pt-N` (one per
+// waypoint along the line). Hiding the parent without these would leave a
+// trail of orphan dots on the map. This is a TAK Server convention rather
+// than a node-cot type, so we discover children by uid-prefix scan over the
+// currently-loaded feature list.
+function expandWithWaypoints(ids: Iterable<string>): Set<string> {
+    const out = new Set<string>(ids);
+    const seeds = Array.from(out);
+    for (const seed of seeds) {
+        const prefix = `${seed}-pt-`;
+        for (const featId of feats.value.keys()) {
+            const sid = String(featId);
+            if (sid.startsWith(prefix)) out.add(sid);
+        }
+    }
+    return out;
+}
+
+function computeLayerFeatureIds(uid: string): Set<string> {
+    const target = findLayerByUid(layers.value, uid);
+    const ids = new Set<string>();
+    if (target) collectSubtreeFeatureIds(target, ids);
+    return expandWithWaypoints(ids);
+}
+
+function displayNameFor(featId: string): string {
+    const feat = feats.value.get(featId);
+    const props = (feat?.properties ?? {}) as Record<string, unknown>;
+    return String(props.callsign ?? props.name ?? featId);
+}
+
+function displayNamesFor(ids: Iterable<string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const id of ids) out[id] = displayNameFor(id);
+    return out;
+}
+
+// Flip an overlay back to visible without going through overlay.update so the
+// (now-removed) "clear hiddenFeatures on becameVisible" hook can't double-fire.
+// Save persists the new visibility to the server.
+function flipOverlayVisibleSilently(overlayId: number): void {
+    const overlay = OverlayManager.loadedFrom(overlayId);
+    if (!overlay) return;
+    overlay.visible = true;
+    if (mapStore._map) {
+        for (const l of overlay.styles) {
+            mapStore.map.setLayoutProperty(l.id, 'visibility', 'visible');
+        }
+    }
+    overlay.save().catch((err) => {
+        console.error('Failed to persist overlay visibility after auto-promote:', err);
+    });
+}
+
+// Express "these features should be visible". Three cases:
+//   1. parent overlay hidden: auto-promote — hide everything else, flip parent visible
+//   2. parent visible, set is currently hidden: additive show (remove from filter)
+//   3. parent visible, set is currently visible: no-op
+async function showFeatureSet(featureIds: Set<string>): Promise<void> {
+    const overlay = OverlayManager.loadedByMode('mission', props.subscription.guid);
+
+    if (overlay && !overlay.visible) {
+        // Hide every other feature so only `featureIds` remain visible.
+        const everythingElse: string[] = [];
+        for (const featId of feats.value.keys()) {
+            const sid = String(featId);
+            if (!featureIds.has(sid)) everythingElse.push(sid);
+        }
+
+        await props.subscription.showAll();
+        await props.subscription.hideFeatures(everythingElse, {
+            displayNames: displayNamesFor(everythingElse),
+        });
+        await syncHiddenIds();
+        flipOverlayVisibleSilently(overlay.id);
+        await reloadMissionSource();
+        return;
+    }
+
+    await props.subscription.showFeatures(Array.from(featureIds));
+    await syncHiddenIds();
+    await reloadMissionSource();
+}
+
+async function hideFeatureSet(featureIds: Set<string>): Promise<void> {
+    await props.subscription.hideFeatures(Array.from(featureIds), {
+        displayNames: displayNamesFor(featureIds),
+    });
+    await syncHiddenIds();
+    await reloadMissionSource();
+}
+
+async function toggleLayer(uid: string): Promise<void> {
+    const subtree = computeLayerFeatureIds(uid);
+    if (subtree.size === 0) return;
+
+    const overlay = OverlayManager.loadedByMode('mission', props.subscription.guid);
+    if (overlay && !overlay.visible) {
+        // Parent-hidden: any click means "show only this one".
+        await showFeatureSet(subtree);
+        return;
+    }
+
+    // Parent-visible: derive intent from current state.
+    let allHidden = true;
+    for (const fid of subtree) {
+        if (!hiddenIds.value.has(fid)) { allHidden = false; break; }
+    }
+    if (allHidden) {
+        await showFeatureSet(subtree);
+    } else {
+        await hideFeatureSet(subtree);
+    }
+}
+
+async function toggleFeature(id: string): Promise<void> {
+    const set = expandWithWaypoints([id]);
+
+    const overlay = OverlayManager.loadedByMode('mission', props.subscription.guid);
+    if (overlay && !overlay.visible) {
+        await showFeatureSet(set);
+        return;
+    }
+
+    if (hiddenIds.value.has(id)) {
+        await showFeatureSet(set);
+    } else {
+        await hideFeatureSet(set);
+    }
+}
+
+async function showAll(): Promise<void> {
+    const overlay = OverlayManager.loadedByMode('mission', props.subscription.guid);
+
+    if (overlay && !overlay.visible) {
+        // Clear any prior hides too, then flip the parent back on.
+        await props.subscription.showAll();
+        await syncHiddenIds();
+        try {
+            await overlay.update({ visible: true });
+        } catch (err) {
+            console.error('Failed to re-enable overlay on Show All:', err);
+        }
+        await reloadMissionSource();
+        return;
+    }
+
+    if (hiddenIds.value.size === 0) return;
+    await props.subscription.showAll();
+    await syncHiddenIds();
+    await reloadMissionSource();
 }
 </script>

--- a/api/web/src/components/CloudTAK/Menu/Overlays/TreeCots.vue
+++ b/api/web/src/components/CloudTAK/Menu/Overlays/TreeCots.vue
@@ -169,6 +169,9 @@
                                     v-for='cot of markers[marker]'
                                     :key='cot.id'
                                     :feature='cot'
+                                    :hide-button='true'
+                                    :hidden='isCotHidden(cot.id)'
+                                    @toggle-hidden='toggleCotHidden(cot)'
                                 />
                             </div>
                         </div>
@@ -228,6 +231,9 @@
                                 v-for='cot of paths[path]'
                                 :key='cot.id'
                                 :feature='cot'
+                                :hide-button='true'
+                                :hidden='isCotHidden(cot.id)'
+                                @toggle-hidden='toggleCotHidden(cot)'
                             />
                         </template>
                     </template>
@@ -278,6 +284,9 @@
                                     v-for='cot of paths[path]'
                                     :key='cot.id'
                                     :feature='cot'
+                                    :hide-button='true'
+                                    :hidden='isCotHidden(cot.id)'
+                                    @toggle-hidden='toggleCotHidden(cot)'
                                 />
                             </template>
                         </div>
@@ -306,6 +315,8 @@ import {
     IconFolder,
 } from '@tabler/icons-vue';
 import { useMapStore } from '../../../../stores/map.ts';
+import { db } from '../../../../database.ts';
+import Filter from '../../../../base/filter.ts';
 import type Overlay from '../../../../base/overlay-class.ts';
 import type COT from '../../../../base/cot.ts';
 import type { Contact as ContactData } from '../../../../types.ts';
@@ -315,6 +326,60 @@ const mapStore = useMapStore();
 defineProps<{
     element: Overlay;
 }>();
+
+// ---------------------------------------------------------------------------
+// Per-CoT visibility toggles for the internal id=-1 "self" overlay.
+//
+// State of truth: DB Filter rows keyed by external="tree-hidden-<cot.id>".
+// On mount we read those rows back and re-establish the in-memory hide on the
+// atlas worker (worker.pendingHidden lives only for the process lifetime,
+// so without this step a page refresh would visually un-hide everything that
+// was hidden in the previous session).
+//
+// Pattern mirrors stores/modules/draw.ts which uses Filter.create +
+// worker.db.hide() for its "edit this CoT" temporary-hide.
+// ---------------------------------------------------------------------------
+
+const HIDDEN_EXTERNAL_PREFIX = 'tree-hidden-';
+const hiddenIds = ref<Set<string>>(new Set());
+
+function isCotHidden(id: string): boolean {
+    return hiddenIds.value.has(id);
+}
+
+async function reloadHiddenIds(): Promise<void> {
+    const rows = await db.filter
+        .where('external')
+        .startsWith(HIDDEN_EXTERNAL_PREFIX)
+        .toArray();
+    hiddenIds.value = new Set(rows.map((r) => r.external.slice(HIDDEN_EXTERNAL_PREFIX.length)));
+}
+
+async function reapplyHiddenToWorker(): Promise<void> {
+    // Re-issue the worker.db.hide() call for every persisted hidden CoT so
+    // the worker drops them from the next diff. Safe to call repeatedly.
+    for (const id of hiddenIds.value) {
+        await mapStore.worker.db.hide(id);
+    }
+    if (hiddenIds.value.size > 0) {
+        await mapStore.refresh();
+    }
+}
+
+async function toggleCotHidden(cot: COT): Promise<void> {
+    const id = cot.id;
+    const external = `${HIDDEN_EXTERNAL_PREFIX}${id}`;
+    if (hiddenIds.value.has(id)) {
+        await Filter.delete({ external });
+        await mapStore.worker.db.unhide(id);
+    } else {
+        const displayName = String(cot.properties?.callsign ?? cot.properties?.name ?? id);
+        await Filter.create(displayName, external, 'AtlasDatabase', true, `id = "${id}"`);
+        await mapStore.worker.db.hide(id);
+    }
+    await reloadHiddenIds();
+    await mapStore.refresh();
+}
 
 interface TreeNodeState {
     _shown: boolean;
@@ -375,6 +440,8 @@ const treeState = ref<TreeState>({
 
 onMounted(async () => {
     loading.value = true;
+    await reloadHiddenIds();
+    await reapplyHiddenToWorker();
     await refresh();
     loading.value = false;
 });

--- a/api/web/src/components/CloudTAK/util/FeatureRow.vue
+++ b/api/web/src/components/CloudTAK/util/FeatureRow.vue
@@ -60,6 +60,7 @@
                     <span
                         v-if='(feature.properties.callsign || "").trim().length > 0'
                         class='fw-semibold text-break'
+                        :class='{ "text-muted": hidden }'
                         v-text='feature.properties.callsign'
                     />
                     <span
@@ -70,6 +71,23 @@
             </div>
 
             <div class='align-self-center me-2 btn-list cloudtak-hover-hidden'>
+                <TablerIconButton
+                    v-if='hideButton'
+                    :title='hidden ? "Show feature" : "Hide feature"'
+                    @click.stop.prevent='emit("toggleHidden")'
+                >
+                    <IconEyeOff
+                        v-if='hidden'
+                        :size='20'
+                        stroke='1'
+                    />
+                    <IconEye
+                        v-else
+                        :size='20'
+                        stroke='1'
+                    />
+                </TablerIconButton>
+
                 <TablerIconButton
                     v-if='infoButton'
                     title='View Info'
@@ -117,6 +135,8 @@ import {
     IconListDetails,
     IconGripVertical,
     IconTrash,
+    IconEye,
+    IconEyeOff,
 } from '@tabler/icons-vue';
 import { useMapStore } from '../../../stores/map.ts';
 const mapStore = useMapStore();
@@ -153,11 +173,19 @@ const props = defineProps({
     compact: {
         type: Boolean,
         default: true
+    },
+    hideButton: {
+        type: Boolean,
+        default: false
+    },
+    hidden: {
+        type: Boolean,
+        default: false
     }
 });
 
 const router = useRouter();
-const emit = defineEmits(['delete']);
+const emit = defineEmits(['delete', 'toggleHidden']);
 
 const isDeleted = ref(false);
 const isDeleting = ref(false);


### PR DESCRIPTION
## Summary

Adds an eye / eye-off toggle to every row in a mission's **Layers** tab so individual mission features (and the layers that contain them) can be hidden and shown independently of the parent overlay's visibility. Solves the common case where a mission contains multiple overlapping items — e.g. several KML route LineStrings for different course tracks — and the operator wants to focus on one without losing the others permanently.

## UX

| Situation | Behaviour |
|---|---|
| Mission overlay ON, all visible | Each row shows an eye. Tap → adds that layer/feature's subtree to the hidden set. |
| Mission overlay ON, some hidden | Hidden rows show eye-off and muted name. Tap eye-off → restores them. |
| Mission overlay OFF (parent hidden) | Every row renders as eye-off — the parent is off, so nothing's visible. |
| Tap eye-off on a row while parent is OFF | **Auto-promote**: parent overlay flips ON and `hiddenFeatures` is seeded with every other feature, so only the tapped subtree renders. |
| Tap eye-off on another row after auto-promote | **Additive show**: that row's subtree gets removed from `hiddenFeatures` and joins the visible set. |
| Tap the parent overlay's eye OFF, then ON | Master switch — second flip clears `hiddenFeatures` so everything truly comes back. |
| "Show all layers" button in the Layers tab header (appears whenever anything is hidden) | Equivalent to flipping the parent eye on. |

KML routes imported into a mission produce a parent LineString CoT plus sibling waypoint CoTs whose UIDs follow `<parent>-pt-N`. Hiding the parent now also hides every waypoint so the whole route disappears visually instead of leaving a string of orphan dots.

## Implementation

`hiddenFeatures: Set<feature.id>` is the single source of truth for what the mission overlay should not render. Two paths feed into it:

- **Layer-row toggle** walks the layer's `uids[]` + recursive `mission_layers` + cascades `-pt-N` waypoint children, then adds/removes that set on `hiddenFeatures`.
- **Feature-row toggle** (used for orphaned CoTs that aren't inside any `mission_layer`) does the same for a single feature plus its waypoints.

A layer row's eye icon is derived from "are all of this layer's subtree features currently hidden", so the icon always tracks the actual map state — no separate flag to drift out of sync.

The hidden features are removed from the GeoJSON `FeatureCollection` before MapLibre sees it:

- `Overlay` caches `_lastFullData` from its `applyData()` call (which `mapStore.loadMission` now uses in place of writing directly to `source.setData`).
- `Overlay.pushData()` filters `_lastFullData` against `hiddenFeatures` and pushes the result to the geojson source.
- `setHiddenFeatures(ids)` updates the set and re-pushes.

This is intentionally **not** done via `map.setFilter` — composing an `["!", ["in", ["id"], ["literal", […]]]]` expression with each style layer's existing filter (which mixes legacy and expression forms for `[has, …]`, `[geometry-type]`, etc.) turned out unreliable in practice. Filtering at the source layer is bulletproof and works uniformly for points, lines, polygons, labels, and course arrows.

## State persistence

A pair of new maps on the Pinia map store keep hides alive across navigation (without persisting through a hard reload):

- `hiddenMissionLayers: Map<missionGuid, Set<layerUid>>`
- `hiddenMissionFeatures: Map<missionGuid, Set<featureId>>`

`MissionLayers.vue` reads from / writes to these on mount and unmount.

## Touched files

| File | What changed |
|---|---|
| `api/web/src/base/overlay.ts` | `hiddenFeatures: Set<string>` + `_lastFullData` cache; `setHiddenFeatures`, `applyData`, `pushData`; `update({visible: true})` clears `hiddenFeatures` on mission overlays going from hidden → visible (master-switch behaviour). |
| `api/web/src/stores/map.ts` | New `hiddenMissionLayers` / `hiddenMissionFeatures` state + getters/setters; `loadMission` routes through `overlay.applyData()` so refreshes preserve the active filter. |
| `api/web/src/components/CloudTAK/Menu/Mission/MissionLayers.vue` | Toggle state, auto-promote logic, additive show/hide, "Show all" header button. |
| `api/web/src/components/CloudTAK/Menu/Mission/MissionLayerTree.vue` | Eye/eye-off button per row, propagation of overlay-visible + hidden-features into recursive subtree, layer's hidden state derived from subtree. |
| `api/web/src/components/CloudTAK/util/FeatureRow.vue` | Opt-in `hideButton` + `hidden` props plus a `toggleHidden` emit. Defaults to off so existing usages (CoT detail, overlay panels, non-mission contexts) are unchanged. |

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 39/39 passing (existing tests; no regressions)
- [x] Manual: subscribe to a mission with 4 overlapping KML routes (~20 feature CoTs including `-pt-N` children); confirm all behaviours from the UX table above
- [x] Manual: confirm other `FeatureRow` consumers (CoT detail page, overlay tree view) render unchanged — `hideButton` defaults to `false`