### PR TITLE
Icon Support

### DIFF
--- a/api/lib/initialization.ts
+++ b/api/lib/initialization.ts
@@ -66,7 +66,7 @@ export default class Bulldozer {
                         }
 
                         const parsed = path.parse(file);
-                        const name = parsed.name;
+                        const name = parsed.dir ? `${parsed.dir}/${parsed.name}` : parsed.name;
                         const format = parsed.ext.toLowerCase();
 
                         this.config.models.Icon.generate({

--- a/api/routes/icons.ts
+++ b/api/routes/icons.ts
@@ -466,12 +466,26 @@ export default async function router(schema: Schema, config: Config) {
             }
 
             if (isNaN(Number(req.params.icon))) {
-                const { name, dir } = path.parse(decodeURIComponent(String(req.params.icon)));
-                const full = dir ? `${dir}/${name}` : name;
+                const decoded = decodeURIComponent(String(req.params.icon)).replace(/^\/+/, '');
+                const { name, dir, ext } = path.posix.parse(decoded);
+                const iconName = dir ? `${dir}/${name}` : name;
+                const iconPath = `${req.params.iconset}/${decoded}`;
+                const iconPathNoExt = `${req.params.iconset}/${iconName}`;
+                const format = ext.toLowerCase();
 
                 const icon = await config.models.Icon.from(sql`
                     iconset = ${req.params.iconset}
-                    AND name = ${full}
+                    AND (
+                        path = ${iconPath}
+                        OR (
+                            path = ${iconPathNoExt}
+                            AND (${format} = '' OR format = ${format})
+                        )
+                        OR (
+                            name = ${iconName}
+                            AND (${format} = '' OR format = ${format})
+                        )
+                    )
                 `);
 
                 return res.json(icon);

--- a/api/test/iconsets.srv.test.ts
+++ b/api/test/iconsets.srv.test.ts
@@ -394,4 +394,32 @@ test('POST: /api/iconset/:iconset/icon - PNG with dots in filename', async () =>
     }
 });
 
+test('GET: /api/iconset/:iconset/icon/:icon - path lookup with seeded leaf-only name', async () => {
+    try {
+        if (!flight.config) throw new Error('Flight config not initialized');
+
+        const seeded = await flight.config.models.Icon.generate({
+            iconset: 'test-iconset',
+            name: 'open-diamond',
+            format: '.png',
+            type2525b: null,
+            data: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+            path: 'test-iconset/Shapes/open-diamond.png',
+        });
+
+        const res = await flight.fetch('/api/iconset/test-iconset/icon/Shapes%2Fopen-diamond.png', {
+            method: 'GET',
+            auth: {
+                bearer: flight.token.admin,
+            },
+        }, true);
+
+        assert.equal(res.body.id, seeded.id);
+        assert.equal(res.body.name, 'open-diamond');
+        assert.equal(res.body.path, 'test-iconset/Shapes/open-diamond.png');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
 flight.landing();

--- a/api/web/src/base/icon.ts
+++ b/api/web/src/base/icon.ts
@@ -207,9 +207,13 @@ async function syncIconset(iconset: Iconset, token: string): Promise<void> {
     ) as IconList;
 
     const rows: DBIcon[] = [];
+    const prefix = `${iconset.uid}/`;
     for (const icon of list.items) {
         const blob = dataUrlToBlob(icon.data);
-        const path = stripExt(icon.name);
+        const sourcePath = icon.path && icon.path.startsWith(prefix)
+            ? icon.path.slice(prefix.length)
+            : icon.name;
+        const path = stripExt(sourcePath);
 
         rows.push({
             name: `${iconset.uid}:${path}`,


### PR DESCRIPTION
### Context

Uploaded/default iconset icons could fail to render when the icon lived under a subfolder because the frontend Dexie cache and path-style icon lookup did not consistently preserve the icon’s relative path. The map would request keys like [<iconset>:Folder/icon](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), but cached rows could be keyed from the wrong value, causing MapLibre to fall back to the tinted dot.

This fixes iconset path handling by using the canonical icon path when hydrating Dexie, preserving subfolders in cached image IDs. It also makes [GET /iconset/:iconset/icon/:icon](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) resolve both extensionless and extension-including stored paths, and updates default iconset seeding so [icons.name](vscode-file://vscode-app/snap/code/241/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) matches the full relative path without the file extension.

Closes: https://github.com/dfpc-coe/CloudTAK/issues/1447