### PR TITLE
Prevent XML Escaping

### DIFF
--- a/api/lib/style.ts
+++ b/api/lib/style.ts
@@ -393,7 +393,7 @@ export default class Style {
         let t = this.templates.get(template);
 
         if (!t) {
-            t = handlebars.compile(template);
+            t = handlebars.compile(template, { noEscape: true });
             this.templates.set(template, t);
         }
 

--- a/api/test/style.test.ts
+++ b/api/test/style.test.ts
@@ -1775,3 +1775,70 @@ test('Style: Marti - styles disabled prevents marti_archive from being applied',
     if (!feat) assert.fail('Feature marked as null');
     assert.equal(feat.properties.marti_archive, undefined);
 });
+
+test('Style: Template - ampersand in metadata is not HTML-encoded in callsign', async () => {
+    const style = new Style({
+        enabled_styles: true,
+        styles: {
+            callsign: '{{AgencyName}}',
+        },
+    });
+
+    const feat = await style.feat({
+        type: 'Feature',
+        properties: {
+            metadata: {
+                AgencyName: 'Colorado Parks & Wildlife Marine Evidence Recovery Team',
+            },
+        },
+        geometry: { type: 'Point', coordinates: [0, 0] },
+    });
+
+    if (!feat) assert.fail('Feature marked as null');
+    assert.equal(feat.properties.callsign, "Colorado Parks & Wildlife Marine Evidence Recovery Team");
+});
+
+test('Style: Template - apostrophe in metadata is not XML-encoded in callsign', async () => {
+    const style = new Style({
+        enabled_styles: true,
+        styles: {
+            callsign: '{{AgencyName}}',
+        },
+    });
+
+    const feat = await style.feat({
+        type: 'Feature',
+        properties: {
+            metadata: {
+                AgencyName: "Larimer County Sheriff's Office",
+            },
+        },
+        geometry: { type: 'Point', coordinates: [0, 0] },
+    });
+
+    if (!feat) assert.fail('Feature marked as null');
+    assert.equal(feat.properties.callsign, "Larimer County Sheriff's Office");
+});
+
+test('Style: Template - special chars in remarks are not HTML-encoded', async () => {
+    const style = new Style({
+        enabled_styles: true,
+        styles: {
+            remarks: 'Agency: {{AgencyName}}\nType: {{AgencyType}}',
+        },
+    });
+
+    const feat = await style.feat({
+        type: 'Feature',
+        properties: {
+            metadata: {
+                AgencyName: 'Colorado Parks & Wildlife',
+                AgencyType: "Sheriff's Office",
+            },
+        },
+        geometry: { type: 'Point', coordinates: [0, 0] },
+    });
+
+    if (!feat) assert.fail('Feature marked as null');
+    assert.equal(feat.properties.remarks, "Agency: Colorado Parks & Wildlife\nType: Sheriff's Office");
+});

--- a/api/test/style.test.ts
+++ b/api/test/style.test.ts
@@ -1795,7 +1795,7 @@ test('Style: Template - ampersand in metadata is not HTML-encoded in callsign', 
     });
 
     if (!feat) assert.fail('Feature marked as null');
-    assert.equal(feat.properties.callsign, "Colorado Parks & Wildlife Marine Evidence Recovery Team");
+    assert.equal(feat.properties.callsign, 'Colorado Parks & Wildlife Marine Evidence Recovery Team');
 });
 
 test('Style: Template - apostrophe in metadata is not XML-encoded in callsign', async () => {
@@ -1810,14 +1810,14 @@ test('Style: Template - apostrophe in metadata is not XML-encoded in callsign', 
         type: 'Feature',
         properties: {
             metadata: {
-                AgencyName: "Larimer County Sheriff's Office",
+                AgencyName: 'Larimer County Sheriff\'s Office',
             },
         },
         geometry: { type: 'Point', coordinates: [0, 0] },
     });
 
     if (!feat) assert.fail('Feature marked as null');
-    assert.equal(feat.properties.callsign, "Larimer County Sheriff's Office");
+    assert.equal(feat.properties.callsign, 'Larimer County Sheriff\'s Office');
 });
 
 test('Style: Template - special chars in remarks are not HTML-encoded', async () => {
@@ -1833,12 +1833,12 @@ test('Style: Template - special chars in remarks are not HTML-encoded', async ()
         properties: {
             metadata: {
                 AgencyName: 'Colorado Parks & Wildlife',
-                AgencyType: "Sheriff's Office",
+                AgencyType: 'Sheriff\'s Office',
             },
         },
         geometry: { type: 'Point', coordinates: [0, 0] },
     });
 
     if (!feat) assert.fail('Feature marked as null');
-    assert.equal(feat.properties.remarks, "Agency: Colorado Parks & Wildlife\nType: Sheriff's Office");
+    assert.equal(feat.properties.remarks, 'Agency: Colorado Parks & Wildlife\nType: Sheriff\'s Office');
 });


### PR DESCRIPTION
### Context

- :bug: Styled features are geojson features and should not have XML escaped characters in their human readable properties. This lead to a bug where CloudTAK would detect a mission change as the escaped XML did not match the unescaped XML returned by TAK server, resulting in a constant barrage of change messages.