### PR TITLE
Session Expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 
 ### Pending Release
 
+- :bug: Reject the WebSocket upgrade with an HTTP 401 during the handshake when the connection token is invalid or expired, instead of accepting then closing - the client previously fired its `open` handler (and a full data resync) against a dead session
+- :bug: Fix `AtlasConnection.reconnect()` racing its own `close` handler into opening two concurrent WebSockets
+- :bug: Apply linear backoff (5s increments, capped at 30s) to Atlas WebSocket reconnect attempts instead of reconnecting immediately in a tight loop
+- :bug: Stop reconnecting the Atlas WebSocket once the server rejects the client's auth token, and propagate the failure to the main thread so the user's dead session is cleared and they are routed to `/login` (local database is preserved)
+- :tada: Warn the user ~30 minutes before their session token expires, with a banner to sign back in before it lapses
+- :white_check_mark: Add `websocket-auth.srv.test.ts` covering WebSocket upgrade rejection/acceptance based on token validity
+
 ### v13.36.2 - 2026-07-07
 
 - :white_check_mark: Use non-standard ports for API server when running tests so they can run when alongside a dev server

--- a/api/index.ts
+++ b/api/index.ts
@@ -364,7 +364,30 @@ export default async function server(config: Config): Promise<ServerManager> {
             return resolve(sm);
         });
 
-        srv.on('upgrade', (request, socket, head) => {
+        srv.on('upgrade', async (request, socket, head) => {
+            // A socket dropped during the async auth check would otherwise
+            // surface as an unhandled 'error' event and crash the process
+            socket.on('error', () => socket.destroy());
+
+            // Reject a dead session with an HTTP 401 during the handshake -
+            // an accepted socket fires the client's `open` handler and kicks
+            // off a full sync before the auth error ever reaches it
+            try {
+                const params = new URLSearchParams((request.url || '').replace(/.*\?/, ''));
+                const token = params.get('token');
+                if (!token) throw new Error('Token Parameter Required');
+
+                await tokenParser(config, token, config.SigningSecret);
+            } catch (err) {
+                if (err instanceof Error && !err.message.includes('jwt expired')) {
+                    console.error('Error: WebSocket Upgrade: ', err);
+                }
+
+                socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+                socket.destroy();
+                return;
+            }
+
             wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
                 wss.emit('connection', ws, request);
             });

--- a/api/test/websocket-auth.srv.test.ts
+++ b/api/test/websocket-auth.srv.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import ws from 'ws';
+import Flight from './flight.js';
+
+const flight = new Flight();
+
+flight.init({ takserver: true });
+flight.takeoff();
+flight.user();
+
+// A rejected upgrade surfaces as 'unexpected-response' with the HTTP status
+// code; an accepted socket fires 'open'
+function attempt(url: URL): Promise<{ outcome: 'open' } | { outcome: 'rejected'; status: number }> {
+    return new Promise((resolve, reject) => {
+        const conn = new ws(url);
+
+        conn.on('unexpected-response', (req, res) => {
+            conn.terminate();
+            resolve({ outcome: 'rejected', status: res.statusCode || 0 });
+        });
+
+        conn.on('open', () => {
+            conn.close();
+            resolve({ outcome: 'open' });
+        });
+
+        conn.on('error', (err) => {
+            reject(err);
+        });
+    });
+}
+
+test('Streaming: upgrade with an invalid token is rejected with HTTP 401', async () => {
+    const url = new URL(flight.base.replace(/^http/, 'ws'));
+    url.searchParams.append('format', 'geojson');
+    url.searchParams.append('connection', 'admin@example.com');
+    url.searchParams.append('token', 'not-a-valid-jwt');
+
+    const res = await attempt(url);
+
+    assert.deepEqual(res, { outcome: 'rejected', status: 401 });
+});
+
+test('Streaming: upgrade with no token is rejected with HTTP 401', async () => {
+    const url = new URL(flight.base.replace(/^http/, 'ws'));
+    url.searchParams.append('format', 'geojson');
+    url.searchParams.append('connection', 'admin@example.com');
+
+    const res = await attempt(url);
+
+    assert.deepEqual(res, { outcome: 'rejected', status: 401 });
+});
+
+test('Streaming: upgrade with a valid token completes the handshake', async () => {
+    const url = new URL(flight.base.replace(/^http/, 'ws'));
+    url.searchParams.append('format', 'geojson');
+    url.searchParams.append('connection', 'admin@example.com');
+    url.searchParams.append('token', flight.token.admin);
+
+    const res = await attempt(url);
+
+    assert.deepEqual(res, { outcome: 'open' });
+});
+
+flight.landing();

--- a/api/web/src/App.vue
+++ b/api/web/src/App.vue
@@ -31,6 +31,31 @@
                 @click='updateAvailable = false'
             />
         </div>
+        <!-- Session expiry warning banner -->
+        <div
+            v-if='sessionWarningShown'
+            class='d-flex align-items-center justify-content-center flex-wrap gap-2 px-3 py-2'
+            style='background: rgba(20,20,20,0.88); backdrop-filter: blur(6px);'
+        >
+            <IconClock
+                size='16'
+                class='text-warning flex-shrink-0'
+            />
+            <span class='text-white small'>
+                Your session expires in <span v-text='sessionRemainingLabel' /> &mdash; sign in again to stay connected
+            </span>
+            <button
+                class='btn btn-sm btn-warning py-0'
+                @click='appStore.sessionExpired'
+            >
+                Sign In Again
+            </button>
+            <button
+                class='btn-close btn-close-white'
+                style='font-size: 0.65rem;'
+                @click='sessionWarningDismissed = true'
+            />
+        </div>
         <header
             v-if='navShown'
             class='navbar navbar-expand-md d-print-none'
@@ -171,6 +196,7 @@ import { useRoute } from 'vue-router';
 import '@tabler/core/dist/js/tabler.min.js';
 import '@tabler/core/dist/css/tabler.min.css';
 import {
+    IconClock,
     IconCode,
     IconLogout,
     IconUser,
@@ -219,6 +245,48 @@ const onSwUpdateAvailable = (e: Event) => {
 
 const mounted = ref(false);
 const error = ref<Error | undefined>();
+
+const SESSION_WARNING_MS = 30 * 60 * 1000;
+const SESSION_CHECK_INTERVAL_MS = 30 * 1000;
+
+const sessionRemainingMs = ref<number | null>(null);
+const sessionWarningDismissed = ref(false);
+
+let sessionExpiryTimer: ReturnType<typeof setInterval> | undefined;
+let sessionExpiredHandled = false;
+
+const sessionWarningShown = computed<boolean>(() => {
+    return !sessionWarningDismissed.value
+        && sessionRemainingMs.value !== null
+        && sessionRemainingMs.value > 0
+        && sessionRemainingMs.value <= SESSION_WARNING_MS
+        && route.name !== 'login';
+});
+
+const sessionRemainingLabel = computed<string>(() => {
+    if (sessionRemainingMs.value === null) return '';
+    const minutes = Math.ceil(sessionRemainingMs.value / 60000);
+    return minutes <= 1 ? 'less than a minute' : `${minutes} minutes`;
+});
+
+function checkSessionExpiry() {
+    if (!appStore.user || !appStore.tokenExpiry) {
+        sessionRemainingMs.value = null;
+        sessionExpiredHandled = false;
+        return;
+    }
+
+    const remaining = appStore.tokenExpiry - Date.now();
+    sessionRemainingMs.value = remaining;
+
+    if (remaining > SESSION_WARNING_MS) {
+        // A fresh token was issued - re-arm the dismissed warning
+        sessionWarningDismissed.value = false;
+    } else if (remaining <= 0 && !sessionExpiredHandled) {
+        sessionExpiredHandled = true;
+        void appStore.sessionExpired();
+    }
+}
 
 const navShown = computed<boolean>(() => {
     if (!route || !route.name) {
@@ -277,10 +345,19 @@ onMounted(async () => {
         appStore.loading = false;
         mounted.value = true;
     }
+
+    checkSessionExpiry();
+    sessionExpiryTimer = setInterval(checkSessionExpiry, SESSION_CHECK_INTERVAL_MS);
 });
 
 onUnmounted(() => {
     window.removeEventListener('sw:update-available', onSwUpdateAvailable);
+
+    if (sessionExpiryTimer !== undefined) {
+        clearInterval(sessionExpiryTimer);
+        sessionExpiryTimer = undefined;
+    }
+
     appStore.teardown();
 });
 

--- a/api/web/src/base/events.ts
+++ b/api/web/src/base/events.ts
@@ -23,6 +23,7 @@ export enum WorkerMessageType {
 
     Connection_Open = 'connection:open',
     Connection_Close = 'connection:close',
+    Connection_AuthFailure = 'connection:authfailure',
 
     Mission_Change_Feature = 'mission:change:feature',
     Mission_Invite = 'mission:invite',

--- a/api/web/src/stores/app.ts
+++ b/api/web/src/stores/app.ts
@@ -181,6 +181,15 @@ export const useAppStore = defineStore('cloudtak-app', {
             }
         },
 
+        // The token expired or was rejected by the server. Unlike logout()
+        // this keeps the local database so cached data survives the re-login.
+        async sessionExpired(): Promise<void> {
+            this.user = false;
+            this.tokenExpiry = null;
+            await this.clearSession();
+            await this.routeLogin();
+        },
+
         async logout(): Promise<void> {
             this.user = false;
             this.tokenExpiry = null;

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -17,6 +17,7 @@ import IconManager from './modules/icons.ts';
 import MenuManager from './modules/menu.ts';
 import BottomBarManager from './modules/bottombar.ts';
 import { useDeviceStore } from './device.ts';
+import { useAppStore } from './app.ts';
 import * as Comlink from 'comlink';
 import AtlasWorker from '../workers/atlas.ts?worker&url';
 import COT from '../base/cot.ts';
@@ -817,6 +818,9 @@ export const useMapStore = defineStore('cloudtak', {
                     this.isOpen = true;
                 } else if (msg.type === WorkerMessageType.Connection_Close) {
                     this.isOpen = false;
+                } else if (msg.type === WorkerMessageType.Connection_AuthFailure) {
+                    this.isOpen = false;
+                    await useAppStore().sessionExpired();
                 } else if (msg.type === WorkerMessageType.Channels_None) {
                     this.hasNoChannels = true;
                 } else if (msg.type === WorkerMessageType.Channels_List) {

--- a/api/web/src/workers/atlas-connection.ts
+++ b/api/web/src/workers/atlas-connection.ts
@@ -12,16 +12,25 @@ import { WorkerMessageType } from '../base/events.ts';
 import type { SyncEvent } from './atlas-sync.ts';
 import type { Feature, Import, Chat } from '../types.ts';
 
+const RECONNECT_BACKOFF_STEP_MS = 5000;
+const RECONNECT_BACKOFF_MAX_MS = 30000;
+
 export default class AtlasConnection {
     atlas: Atlas;
 
     isDestroyed: boolean;
     isOpen: boolean;
     hasConnected: boolean;
+
+    // Halts reconnection until the user logs in again
+    authFailure: boolean;
+
     ws: WebSocket | undefined;
     reconnectAttempts: number;
 
     version: string;
+
+    private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
     constructor(atlas: Atlas) {
         this.atlas = atlas;
@@ -29,10 +38,13 @@ export default class AtlasConnection {
         this.isDestroyed = false;
         this.isOpen = false;
         this.hasConnected = false;
+        this.authFailure = false;
         this.ws = undefined;
         this.reconnectAttempts = 0;
 
         this.version = version;
+
+        this.reconnectTimer = undefined;
     }
 
     reconnect(connection: string) {
@@ -47,6 +59,8 @@ export default class AtlasConnection {
     // COTs are submitted to pending and picked up by the partial update code every .5s
     connect(connection: string) {
         this.isDestroyed = false;
+        this.authFailure = false;
+        this.clearReconnectTimer();
 
         const url = stdurl('/api');
         url.searchParams.set('format', 'geojson');
@@ -59,9 +73,19 @@ export default class AtlasConnection {
             url.protocol = 'wss:';
         }
 
-        this.ws = new WebSocket(url);
+        const ws = new WebSocket(url);
+        this.ws = ws;
 
-        this.ws.addEventListener('open', () => {
+        // A socket that closes without ever opening was rejected during the
+        // HTTP upgrade (401) or never reached the server
+        let opened = false;
+
+        ws.addEventListener('open', () => {
+            if (ws !== this.ws) return;
+
+            opened = true;
+            this.reconnectAttempts = 0;
+
             this.atlas.postMessage({ type: WorkerMessageType.Connection_Open });
             this.isOpen = true;
 
@@ -77,21 +101,24 @@ export default class AtlasConnection {
             this.hasConnected = true;
         });
 
-        this.ws.addEventListener('error', (err) => {
+        ws.addEventListener('error', (err) => {
             console.error(err);
         });
 
-        this.ws.addEventListener('close', () => {
-            // Otherwise the user is probably logged out
-            if (!this.isDestroyed) {
-                this.connect(connection);
-            }
+        ws.addEventListener('close', () => {
+            // A socket superseded by reconnect() must not touch state or
+            // spawn another connection - that's how reconnect loops multiply
+            if (ws !== this.ws) return;
 
             this.atlas.postMessage({ type: WorkerMessageType.Connection_Close });
             this.isOpen = false;
+
+            if (this.isDestroyed || this.authFailure) return;
+
+            void this.scheduleReconnect(connection, opened);
         });
 
-        this.ws.addEventListener('message', async (msg) => {
+        ws.addEventListener('message', async (msg) => {
             try {
             const body = JSON.parse(msg.data) as {
                 type: string;
@@ -103,6 +130,11 @@ export default class AtlasConnection {
                 const err = body as unknown as {
                     properties: { message: string }
                 };
+
+                if (/unauthorized|jwt expired|invalid token|no auth/i.test(err.properties.message)) {
+                    this.handleAuthFailure(err.properties.message);
+                    return;
+                }
 
                 console.warn('Warning: Validation Error: received Error from WebSocket:', JSON.stringify(body));
                 throw new Error(err.properties.message);
@@ -338,8 +370,63 @@ export default class AtlasConnection {
         });
     }
 
+    private async scheduleReconnect(connection: string, opened: boolean): Promise<void> {
+        if (!opened && await this.isAuthRejected()) {
+            this.handleAuthFailure('WebSocket upgrade rejected: session is no longer valid');
+            return;
+        }
+
+        this.reconnectAttempts++;
+        const delay = Math.min(this.reconnectAttempts * RECONNECT_BACKOFF_STEP_MS, RECONNECT_BACKOFF_MAX_MS);
+
+        this.clearReconnectTimer();
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = undefined;
+            if (this.isDestroyed || this.authFailure) return;
+            this.connect(connection);
+        }, delay);
+    }
+
+    private async isAuthRejected(): Promise<boolean> {
+        try {
+            const res = await fetch(stdurl('/login'), {
+                headers: { Authorization: `Bearer ${this.atlas.token}` }
+            });
+
+            return res.status === 401;
+        } catch {
+            // Network failure - the server is unreachable, not rejecting us
+            return false;
+        }
+    }
+
+    private handleAuthFailure(message: string): void {
+        if (this.authFailure) return;
+        this.authFailure = true;
+
+        console.error(`WebSocket auth failure: ${message}`);
+
+        this.clearReconnectTimer();
+
+        // The worker cannot clear stored credentials or navigate - the main
+        // thread must route the user to login
+        this.atlas.postMessage({
+            type: WorkerMessageType.Connection_AuthFailure,
+            body: { message }
+        });
+    }
+
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer !== undefined) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = undefined;
+        }
+    }
+
     destroy() {
         this.isDestroyed = true;
+
+        this.clearReconnectTimer();
 
         if (this.ws) {
             this.ws.close();

--- a/api/web/src/workers/atlas-connection.ts
+++ b/api/web/src/workers/atlas-connection.ts
@@ -389,7 +389,7 @@ export default class AtlasConnection {
 
     private async isAuthRejected(): Promise<boolean> {
         try {
-            const res = await fetch(stdurl('/login'), {
+            const res = await fetch(stdurl('/api/login'), {
                 headers: { Authorization: `Bearer ${this.atlas.token}` }
             });
 


### PR DESCRIPTION
### Context

- :bug: Reject the WebSocket upgrade with an HTTP 401 during the handshake when the connection token is invalid or expired, instead of accepting then closing - the client previously fired its `open` handler (and a 
- :bug: Fix `AtlasConnection.reconnect()` racing its own `close` handler into opening two concurrent WebSockets                                                                                                       
- :bug: Apply linear backoff (5s increments, capped at 30s) to Atlas WebSocket reconnect attempts instead of reconnecting immediately in a tight loop                                                                 
- :bug: Stop reconnecting the Atlas WebSocket once the server rejects the client's auth token, and propagate the failure to the main thread so the user's dead session is cleared and they are routed to `/login` (loc
- :tada: Warn the user ~30 minutes before their session token expires, with a banner to sign back in before it lapses                                                                                                 
- :white_check_mark: Add `websocket-auth.srv.test.ts` covering WebSocket upgrade rejection/acceptance based on token validity     