### PR TITLE
Idle Load

### DIFF
--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -15,9 +15,9 @@
             style='width: 100%;'
         />
 
-        <MapLoading v-if='loading || !mapStore.isLoaded' />
+        <MapLoading v-if='loading || !mapStore.isMapLoaded' />
 
-        <template v-if='mapStore.isLoaded && !loading'>
+        <template v-if='mapStore.isMapLoaded && !loading'>
             <WarnConfiguration
                 v-if='warnConfiguration'
                 @close='warnConfiguration = false'
@@ -269,7 +269,7 @@
             </TablerModal>
 
             <div
-                v-if='mapStore.isLoaded && mode === "Default"'
+                v-if='mapStore.isMapLoaded && mode === "Default"'
                 class='d-flex position-absolute top-0 text-white'
                 style='
                     z-index: 5;
@@ -358,7 +358,7 @@
 
             <MainMenu
                 v-if='
-                    mapStore.isLoaded
+                    mapStore.isMapLoaded
                         && (
                             (noMenuShown && !isMobileDetected)
                             || (!noMenuShown)
@@ -368,7 +368,7 @@
             />
 
             <div
-                v-if='mapStore.isLoaded && isMobileDetected && mode === "Default"'
+                v-if='mapStore.isMapLoaded && isMobileDetected && mode === "Default"'
                 class='position-absolute'
                 style='
                     z-index: 4;

--- a/api/web/src/components/CloudTAK/Menu/MenuFeatures.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuFeatures.vue
@@ -1,7 +1,6 @@
 <template>
     <MenuTemplate
         name='Saved Features'
-        :loading='!mapStore.isLoaded'
     >
         <template #buttons>
             <TablerDropdown>

--- a/api/web/src/components/CloudTAK/Menu/MenuFeaturesDeleted.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuFeaturesDeleted.vue
@@ -1,7 +1,6 @@
 <template>
     <MenuTemplate
         name='Deleted Features'
-        :loading='!mapStore.isLoaded'
     >
         <template #buttons>
             <TablerDropdown>

--- a/api/web/src/components/CloudTAK/Menu/MenuOverlays.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuOverlays.vue
@@ -51,7 +51,7 @@
                     {{ dragHintCopy }}
                 </p>
 
-                <TablerLoading v-if='loading || !isLoaded' />
+                <TablerLoading v-if='loading' />
 
                 <template v-else>
                     <div
@@ -313,7 +313,6 @@ type OverlayStatus = { label: string; variant: string; tooltip?: string };
 type OverlayUpdate = Parameters<Overlay['update']>[0];
 type OverlayCard = { overlay: Overlay; visible: boolean; status: OverlayStatus; badges: OverlayBadge[] };
 
-const mapStore = useMapStore();
 const router = useRouter();
 
 let sortable: Sortable | undefined;
@@ -324,7 +323,6 @@ const opened = ref<Set<number>>(new Set());
 const overlayFilter = ref('');
 const overlayRenderTick = ref(0);
 
-const isLoaded = mapStore.isLoaded;
 const dbOverlays = ref<DBOverlay[]>([]);
 
 let listSubscription: Subscription | undefined;

--- a/api/web/src/components/CloudTAK/Menu/MenuOverlays.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuOverlays.vue
@@ -303,7 +303,6 @@ import {
 import StandardItem from '../util/StandardItem.vue';
 import Sortable from 'sortablejs';
 import type { SortableEvent } from 'sortablejs';
-import { useMapStore } from '../../../../src/stores/map.ts';
 import type Overlay from '../../../../src/base/overlay-class.ts';
 import type { DBOverlay } from '../../../../src/database.ts';
 import OverlayManager from '../../../../src/base/overlay.ts';

--- a/api/web/src/components/CloudTAK/Menu/MenuRoutes.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuRoutes.vue
@@ -1,7 +1,6 @@
 <template>
     <MenuTemplate
         name='Routes'
-        :loading='!mapStore.isLoaded'
     >
         <template #buttons>
             <TablerIconButton

--- a/api/web/src/components/CloudTAK/Menu/MenuRoutesNew.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuRoutesNew.vue
@@ -1,7 +1,6 @@
 <template>
     <MenuTemplate
         name='New Route'
-        :loading='!mapStore.isLoaded'
     >
         <template #default>
             <TablerLoading

--- a/api/web/src/components/CloudTAK/Menu/Overlays/TreeCots.vue
+++ b/api/web/src/components/CloudTAK/Menu/Overlays/TreeCots.vue
@@ -176,122 +176,12 @@
                 </div>
             </template>
         </div>
-
-        <div
-            v-if='Object.keys(paths).length'
-            class='ms-3'
-            @click.stop
-        >
-            <div class='d-flex align-items-center px-3 py-2 me-2 cloudtak-hover'>
-                <IconChevronRight
-                    v-if='!treeState.paths._shown'
-                    :size='20'
-                    stroke='1'
-                    class='cursor-pointer'
-                    @click='treeState.paths._loading = treeState.paths._shown = true'
-                />
-                <IconChevronDown
-                    v-else-if='treeState.paths._shown'
-                    :size='20'
-                    stroke='1'
-                    class='cursor-pointer'
-                    @click='treeState.paths._shown = false'
-                />
-                <IconFolder
-                    class='mx-2'
-                    :size='20'
-                    stroke='2'
-                /> Your Features
-
-                <div class='ms-auto btn-list cloudtak-hover-hidden'>
-                    <TablerDelete
-                        :size='20'
-                        class='cursor-pointer'
-                        displaytype='icon'
-                        @delete='deleteFeatures("/")'
-                    />
-                </div>
-            </div>
-
-            <template v-if='treeState.paths._shown'>
-                <div
-                    v-for='path in Object.keys(paths)'
-                    class='ms-3'
-                >
-                    <template v-if='path === "/"'>
-                        <TablerLoading
-                            v-if='treeState.paths.nodes[path]._loading'
-                            :compact='true'
-                        />
-                        <template v-else>
-                            <Feature
-                                v-for='cot of paths[path]'
-                                :key='cot.id'
-                                :feature='cot'
-                            />
-                        </template>
-                    </template>
-                    <template v-else>
-                        <div class='d-flex align-items-center py-2 ps-2 ms-2 cloudtak-hover'>
-                            <IconChevronRight
-                                v-if='!treeState.paths.nodes[path]._shown'
-                                :size='20'
-                                stroke='1'
-                                class='cursor-pointer'
-                                @click='treeState.paths.nodes[path]._loading = treeState.paths.nodes[path]._shown = true'
-                            />
-                            <IconChevronDown
-                                v-else-if='treeState.paths.nodes[path]._shown'
-                                :size='20'
-                                stroke='1'
-                                class='cursor-pointer'
-                                @click='treeState.paths.nodes[path]._shown = false'
-                            />
-
-                            <IconFolder
-                                :size='20'
-                                stroke='2'
-                                class='mx-2'
-                            />
-                            <span
-                                class='mx-2'
-                                v-text='path.replace(/(^\/|\/$)/g, "")'
-                            />
-                            <div
-                                v-if='element._internal'
-                                class='ms-auto'
-                            >
-                                <TablerDelete
-                                    :size='20'
-                                    displaytype='icon'
-                                    @click='deleteFeatures(path)'
-                                />
-                            </div>
-                        </div>
-                        <div class='ms-3'>
-                            <TablerLoading
-                                v-if='treeState.paths.nodes[path]._loading'
-                                :compact='true'
-                            />
-                            <template v-else>
-                                <Feature
-                                    v-for='cot of paths[path]'
-                                    :key='cot.id'
-                                    :feature='cot'
-                                />
-                            </template>
-                        </div>
-                    </template>
-                </div>
-            </template>
-        </div>
     </template>
 </template>
 
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue';
 import {
-    TablerDelete,
     TablerLoading,
 } from '@tak-ps/vue-tabler';
 import Contact from '../../util/Contact.vue';
@@ -328,7 +218,6 @@ interface TreeBranchState extends TreeNodeState {
 interface TreeState {
     groups: TreeBranchState;
     markers: TreeBranchState;
-    paths: TreeBranchState;
 }
 
 const loading = ref<boolean>(true);
@@ -339,7 +228,6 @@ const deleteMarkerModal = ref<{ shown: boolean; marker: string | null }>({
 
 const markers = ref<Record<string, Set<COT>>>({});
 const groups = ref<Record<string, Set<COT>>>({});
-const paths = ref<Record<string, Set<COT>>>({});
 
 function makeContact(cot: COT): ContactData {
     const p = cot.properties ?? {};
@@ -366,11 +254,6 @@ const treeState = ref<TreeState>({
         _loading: false,
         nodes: {},
     },
-    paths: {
-        _shown: false,
-        _loading: false,
-        nodes: {},
-    },
 });
 
 onMounted(async () => {
@@ -387,9 +270,6 @@ watch(treeState.value, async () => {
 async function refresh(): Promise<void> {
     rebuilding.value = true;
 
-    const remotePaths = (await mapStore.worker.db.paths()).map((p) => p.path).sort((a) => {
-        return a === '/' ? 1 : -1;
-    });
     const remoteGroups = await mapStore.worker.db.groups();
     const remoteMarkers = await mapStore.worker.db.markers();
 
@@ -412,34 +292,6 @@ async function refresh(): Promise<void> {
         }
 
         treeState.value.markers.nodes[marker]._loading = false;
-    }
-
-    for (const path of Object.keys(treeState.value.paths.nodes)) {
-        if (!remotePaths.includes(path)) {
-            delete treeState.value.paths.nodes[path];
-            delete paths.value[path];
-        }
-    }
-
-    for (const path of remotePaths) {
-        paths.value[path] = new Set<COT>();
-
-        if (treeState.value.paths.nodes[path] === undefined) {
-            treeState.value.paths.nodes[path] = { _shown: false, _loading: false };
-        }
-    }
-
-    if (treeState.value.paths._shown && !treeState.value.paths.nodes['/']._shown) {
-        treeState.value.paths.nodes['/']._loading = true;
-        treeState.value.paths.nodes['/']._shown = true;
-    }
-
-    for (const path of remotePaths) {
-        if (treeState.value.paths.nodes[path]._shown) {
-            paths.value[path] = await mapStore.worker.db.pathFeatures(path);
-        }
-
-        treeState.value.paths.nodes[path]._loading = false;
     }
 
     for (const group of remoteGroups) {
@@ -482,36 +334,6 @@ async function deleteMarkers(marker?: string | null): Promise<void> {
             ($exists(properties.archived) = false or ($exists(properties.archived) and properties.archived = false))
         `);
         treeState.value.markers._loading = false;
-    }
-
-    await refresh();
-    loading.value = false;
-}
-
-async function deleteFeatures(path: string): Promise<void> {
-    loading.value = true;
-
-    if (path) {
-        treeState.value.paths.nodes[path]._loading = true;
-
-        await mapStore.worker.db.filterDelete(`
-            $exists(properties.archived)
-            and $exists(path)
-            and properties.archived = true
-            and path = '${path}'
-        `);
-
-        treeState.value.paths.nodes[path]._loading = false;
-    } else {
-        treeState.value.paths._loading = true;
-
-        await mapStore.worker.db.filterDelete(`
-            $exists(properties.archived)
-            and $exists(path)
-            and properties.archived = true
-        `);
-
-        treeState.value.paths._loading = false;
     }
 
     await refresh();

--- a/api/web/src/main.ts
+++ b/api/web/src/main.ts
@@ -119,7 +119,7 @@ for (const path in plugins) {
 }
 
 const mapStore = useMapStore(pinia);
-watch(() => mapStore.isLoaded, async (isLoaded) => {
+watch(() => mapStore.isMapLoadedFully, async (isLoaded) => {
     if (isLoaded) {
         for (const instance of pluginInstances) {
             await instance.enable();

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -696,7 +696,7 @@ export const useMapStore = defineStore('cloudtak', {
                 }
 
                 if (opts?.reload) {
-                    await sub.reload();
+                    await sub.refresh();
                 }
             } else {
                 try {

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -684,7 +684,7 @@ export const useMapStore = defineStore('cloudtak', {
 
             const { value: token } = await Preferences.get({ key: 'token' });
 
-            const sub = (await Subscription.from(guid, token || '', { subscribed: true })) || null;
+            let sub = (await Subscription.from(guid, token || '', { subscribed: true })) || null;
 
             if (sub) {
                 // Get map data on the map ASAP, even if it is stale

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -707,11 +707,6 @@ export const useMapStore = defineStore('cloudtak', {
                         missiontoken: overlay.token || undefined
                     });
                 } catch (err) {
-                    // Offline/low-bandwidth: keep the locally persisted
-                    // features rendered above. The next full sync or manual
-                    // reload refreshes from the server.
-                    if (!sub) throw err;
-
                     console.warn(`Mission:${guid} network refresh failed, using local data:`, err);
                 }
             }

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -708,6 +708,7 @@ export const useMapStore = defineStore('cloudtak', {
                     });
                 } catch (err) {
                     console.warn(`Mission:${guid} network refresh failed, using local data:`, err);
+                    return null;
                 }
             }
 

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -132,7 +132,10 @@ export const useMapStore = defineStore('cloudtak', {
         hasSnapping: boolean;
         hasNoChannels: boolean;
         channelChange: boolean;
-        isLoaded: boolean;
+        // Is the map ready to be shown to users
+        isMapLoaded: boolean;
+        // Is all data/overlays loaded
+        isMapLoadedFully: boolean;
         isOpen: boolean;
         userOrientationMode: boolean;
         pitch: number;
@@ -189,7 +192,8 @@ export const useMapStore = defineStore('cloudtak', {
             hasNoChannels: false,
             channelChange: false,
             isOpen: false,
-            isLoaded: false,
+            isMapLoaded: false,
+            isMapLoadedFully: false,
             userOrientationMode: false,
             pitch: 0,
             bearing: 0,
@@ -680,18 +684,37 @@ export const useMapStore = defineStore('cloudtak', {
 
             const { value: token } = await Preferences.get({ key: 'token' });
 
-            let sub: Subscription | null = null;
-            if (!opts?.reload) {
-                sub = (await Subscription.from(guid, token || '', { subscribed: true })) || null;
-            }
+            const sub = (await Subscription.from(guid, token || '', { subscribed: true })) || null;
 
-            if (!sub) {
-                sub = await Subscription.load(guid, {
-                    token: token || '',
-                    reload: opts?.reload || false,
-                    subscribed: true,
-                    missiontoken: overlay.token || undefined
-                });
+            if (sub) {
+                // Get map data on the map ASAP, even if it is stale
+                // @ts-expect-error Source.setData is not defined
+                oStore.setData(await sub.feature.collection(false));
+
+                if (overlay.active) {
+                    await this.makeActiveMission(sub);
+                }
+
+                if (opts.reload) {
+                    await sub.reload({ token: token || '' });
+                }
+            } else {
+                try {
+                    sub = await Subscription.load(guid, {
+                        token: token || '',
+                        reload: opts?.reload || false,
+                        subscribed: true,
+                        missiontoken: overlay.token || undefined
+                    });
+                } catch (err) {
+                    // Offline/low-bandwidth: keep the locally persisted
+                    // features rendered above. The next full sync or manual
+                    // reload refreshes from the server.
+                    if (!local) throw err;
+
+                    console.warn(`Mission:${guid} network refresh failed, using local data:`, err);
+                    sub = local;
+                }
             }
 
             // @ts-expect-error Source.setData is not defined
@@ -968,6 +991,10 @@ export const useMapStore = defineStore('cloudtak', {
             });
             map.addControl(routingControl);
             (map as mapgl.Map & { _routingControl?: RoutingControl })._routingControl = routingControl;
+
+            map.once('load', async () => {
+                this.isMapLoaded = true;
+            });
 
             map.once('idle', async () => {
                 const displayProjection = await ProfileConfig.get('display_projection');
@@ -1360,10 +1387,6 @@ export const useMapStore = defineStore('cloudtak', {
 
                 this.loadMission(overlay.mode_id!, {
                     reload: true
-                }).then(async (sub) => {
-                    if (sub && overlay.active) {
-                        await this.makeActiveMission(sub);
-                    }
                 }).catch((err) => {
                     console.error('Failed to load Mission', err);
                     overlay._error = err instanceof Error ? err : new Error(String(err));
@@ -1372,7 +1395,7 @@ export const useMapStore = defineStore('cloudtak', {
                 });
             }
 
-            this.isLoaded = true;
+            this.isMapLoaded = true;
 
             // Map is initialized & loaded - kick off a full data type
             // synchronization with the TAK Server in the Atlas worker
@@ -1393,7 +1416,7 @@ export const useMapStore = defineStore('cloudtak', {
          * PATCH the API and echo the event back to the originating client.
          */
         reconcileOverlays: async function(): Promise<void> {
-            if (!this.isLoaded) return;
+            if (!this.isMapLoaded) return;
 
             const desired = await OverlayManager.list({ localFirst: true });
             const desiredIds = new Set(desired.map((item) => item.id));

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -695,8 +695,8 @@ export const useMapStore = defineStore('cloudtak', {
                     await this.makeActiveMission(sub);
                 }
 
-                if (opts.reload) {
-                    await sub.reload({ token: token || '' });
+                if (opts?.reload) {
+                    await sub.reload();
                 }
             } else {
                 try {
@@ -710,10 +710,9 @@ export const useMapStore = defineStore('cloudtak', {
                     // Offline/low-bandwidth: keep the locally persisted
                     // features rendered above. The next full sync or manual
                     // reload refreshes from the server.
-                    if (!local) throw err;
+                    if (!sub) throw err;
 
                     console.warn(`Mission:${guid} network refresh failed, using local data:`, err);
-                    sub = local;
                 }
             }
 

--- a/api/web/src/workers/atlas-sync.ts
+++ b/api/web/src/workers/atlas-sync.ts
@@ -24,6 +24,7 @@ import type Atlas from './atlas.ts';
 import { std } from '../std.ts';
 import type { Feature, ProfileOverlay } from '../types.ts';
 import { WorkerMessageType } from '../base/events.ts';
+
 // base/overlay.ts (OverlayManager) cannot be imported here - it pulls in the
 // map store & maplibre-gl which touch `document` at import time and break the
 // worker. The worker-safe sync shared with OverlayManager lives in overlay-sync.


### PR DESCRIPTION
### Context

- :bug: Tie loading state to end on `load` event instead of `idle` as immediate features can prevent `idle` state
- :rocket: Immediately show local Data Sync features (and then request a refresh) if they are available locally
- :rocket: Remove "Your Features" tree from the overlay menu now that it is surfaced via MenuFeatures