### PR TITLE
Decouple read-only route access from the TAK connection pool

### DIFF
--- a/api/lib/connection-config.ts
+++ b/api/lib/connection-config.ts
@@ -1,8 +1,8 @@
 import { Static, Type } from '@sinclair/typebox';
 import type { Feature } from 'geojson';
 import type { Connection } from './schema.js';
-import { X509Certificate } from 'crypto';
 import { InferSelectModel, sql } from 'drizzle-orm';
+import ConnectionControl from './control/connection.js';
 import Config from './config.js';
 
 export const ConnectionAuth = Type.Object({
@@ -56,11 +56,7 @@ export class MachineConnConfig implements ConnectionConfig {
     }
 
     uid(): string {
-        const cert = new X509Certificate(this.auth.cert);
-
-        const subject = cert.subject.split('\n').reverse().join(',');
-
-        return subject;
+        return ConnectionControl.uid(this.auth.cert);
     }
 
     async subscription(name: string): Promise<null | MissionSub> {
@@ -229,9 +225,7 @@ export class AdminConnConfig implements ConnectionConfig {
     }
 
     uid(): string {
-        const cert = new X509Certificate(this.auth.cert);
-        const subject = (cert.subject || '').split('\n').reverse().join(',');
-        return subject;
+        return ConnectionControl.uid(this.auth.cert);
     }
 
     async subscription(): Promise<null | MissionSub> {

--- a/api/lib/control/connection.ts
+++ b/api/lib/control/connection.ts
@@ -1,0 +1,12 @@
+import { X509Certificate } from 'crypto';
+
+export default class ConnectionControl {
+    /**
+     * Compute the TAK UID for a Machine Connection from its client
+     * certificate, matching the identity the pooled connection would present
+     */
+    static uid(cert: string): string {
+        const x509 = new X509Certificate(cert);
+        return (x509.subject || '').split('\n').reverse().join(',');
+    }
+}

--- a/api/lib/control/profile.ts
+++ b/api/lib/control/profile.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
+import { sql } from 'drizzle-orm';
 import { TAKRole, TAKGroup } from '@tak-ps/node-tak/lib/api/types';
 import Config from '../config.js';
 import {
@@ -110,6 +111,31 @@ export default class ProfileControl {
 
     constructor(config: Config) {
         this.config = config;
+    }
+
+    /**
+     * Resolve Mission subscription options (name + token) for a user
+     */
+    async subscription(username: string, name: string): Promise<{
+        name: string;
+        token?: string;
+    }> {
+        const missions = await this.config.models.ProfileOverlay.list({
+            where: sql`
+                name = ${name}
+                AND mode = 'mission'
+                AND username = ${username}
+            `,
+        });
+
+        if (missions.items.length === 0) {
+            return { name };
+        }
+
+        return {
+            name: missions.items[0].name,
+            token: missions.items[0].token || undefined,
+        };
     }
 
     async from(email: string): Promise<Static<typeof ProfileResponse>> {

--- a/api/lib/data-mission.ts
+++ b/api/lib/data-mission.ts
@@ -6,6 +6,7 @@ import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 import type { MissionLayer } from '@tak-ps/node-tak/lib/api/mission-layer';
 import { MissionLayerType } from '@tak-ps/node-tak/lib/api/mission-layer';
 import Config from './config.js';
+import ConnectionControl from './control/connection.js';
 import type { Mission } from '@tak-ps/node-tak/lib/api/mission';
 
 export const MAX_LAYERS_IN_DATA_SYNC = 5;
@@ -66,10 +67,9 @@ export default class DataMission {
                 mission_token: mission.token || undefined,
             });
 
-            const conn = config.conns.get(data.connection);
-            if (conn) {
+            if (connection.enabled) {
                 await api.Mission.subscribe(data.name, {
-                    uid: conn.config.uid(),
+                    uid: ConnectionControl.uid(connection.auth.cert),
                 }, {
                     token: mission.token || undefined,
                 });

--- a/api/lib/tak-channels.ts
+++ b/api/lib/tak-channels.ts
@@ -1,0 +1,17 @@
+import type { TAKAPI } from '@tak-ps/node-tak';
+
+/**
+ * Resolve the active channel bitpos set for a given Profile or Connection
+ * without requiring a pooled TAK connection.
+ *
+ * `useCache: true` defers caching to the TAK Server, which serves the user's
+ * cached group selection - a client-side cache here would go stale across
+ * horizontally scaled API instances when channel selections change
+ */
+export default async function activeChannels(api: TAKAPI): Promise<Set<number>> {
+    return new Set(
+        (await api.Group.list({ useCache: true })).data
+            .filter(group => group.active)
+            .map(group => group.bitpos),
+    );
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.api",
-    "version": "13.39.0",
+    "version": "13.41.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.api",
-            "version": "13.39.0",
+            "version": "13.41.1",
             "license": "ISC",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -178,9 +178,9 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1083.0.tgz",
-            "integrity": "sha512-MBST0cuPgZDKRcllxOyqQrG1FDkO6T684lGxmHQu3MBD0gr3Anuk7leIodABzgM1TfiCTnHYPaO0DTKZ4ehwOw==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1085.0.tgz",
+            "integrity": "sha512-FzlmVJZYTNHR98P8x8rftIEcVmBZCG32/JBMOqjiM/+FNI4xHZwR6vpPBQSSRbPWTeRt9ngHjDLo/rz1gDwq2A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -197,9 +197,9 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1083.0.tgz",
-            "integrity": "sha512-k9n4XAYtl0QhQLQA9SGEl3hpqvTmlrAbPP44xJ4fzeZrYtRdRuvq5jTo8IcbId0VrPsBPB04DU6uJjulfgoQSA==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1085.0.tgz",
+            "integrity": "sha512-2WyjUH6zdRvPSvL/8JJYo6BJfK4hNn9RA3+3XEfPczQ/uYxhFfIR8hbNIrRQe7ffb9X8CCxN6YpSQtw8iXQboA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -217,9 +217,9 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1083.0.tgz",
-            "integrity": "sha512-rTfxzi7nhd7FXrdASPhenE0aZmrFMY8D1c8CUyE/L+FlfWrCO/e5LbFrxnUvrteY1KM+VUVWzZHjrmfHQW3upw==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1085.0.tgz",
+            "integrity": "sha512-jNMt5zMsnJ6X0fZJKKNU5/qTQ98OIsUSFLqDh+FTXQTiEI3NTq95gAdsaAwXVWO9hTaT5gY7fbwF5Ally69bwg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -236,9 +236,9 @@
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1083.0.tgz",
-            "integrity": "sha512-8NjmlxWdOdE+9N+qGv4VlRbBiQtCJvbj2Yk2WXYiQdB/fhXy3ECL+aGJLfdXs2CSAEebmJFDSTwdOHoq2aCf/Q==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1085.0.tgz",
+            "integrity": "sha512-I1MWQNb01MlfC2MENTll+GrRV2RSGmkQSyB289CEY2QGf4ImqeEsySWFtpau/39zqTxqOyx/jfXrT5vdr3hOyQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -255,9 +255,9 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1083.0.tgz",
-            "integrity": "sha512-k6O+nOkNFy3LPpZ/GFD/admJMAhzdpxbZ6swdXoWjRltYAFVhXFdI6pdIWfai0gVA+xZ7MKM9sRTiPLBASnYiQ==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1085.0.tgz",
+            "integrity": "sha512-Ms41fQmgYK/iF89KLoLVxSwPGtCwIYGyH+1Ovm6l7jiubxDmUfzU7keLzZHOymfxfDz5bBcqfwID65fuMKEnYQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -274,9 +274,9 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1083.0.tgz",
-            "integrity": "sha512-3YOicHy6qjexsy4rHk5jPvtLgg6Ho1u+ycOWtJcVTAIMlMq32MRtnhllAyFSezhAXeBnnLLtKtAGXim7vV8oog==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
+            "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/checksums": "^3.1000.16",
@@ -296,9 +296,9 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1083.0.tgz",
-            "integrity": "sha512-B4l5PW46ijHgke4dk/7JqPGhxYsoJTsWqdSSvM9J7JZj47zoVLONvbmNgpnS7ASl0xosZeP+TyJa6/fFNtAEBg==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1085.0.tgz",
+            "integrity": "sha512-CGaiSJvhM0aGqE+xQBHqwJvbVLQA0voqg97+i4dW6MxXNDa01oAD/asUdBpmmvUEpT4D3khjNyNuvyY9oh8DkQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -315,9 +315,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1083.0.tgz",
-            "integrity": "sha512-onW6oteUiZbVpGn2oMsPVk9bNKLLoYkIjzbmnNvIjPGvOTt5EWCW3huPWDfuKUiM69NkExWGqn0obmxfh52yqw==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1085.0.tgz",
+            "integrity": "sha512-ND4HTISx/vwGhNmqgwaI/oQRVrTwqGerPJL0a6z0bRRme73fQ8RcciuVEDZT/klD5/J/uvw8g7cWlo+XjIMF/Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -335,9 +335,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1083.0.tgz",
-            "integrity": "sha512-3DRm8UNj3aByu0U5Sgvs5Ut3V1XbWiST/JWF3/Zk57kFeVYm4a/EjQH4k9jTI8pk4dmYkZZJMcaecqTRRYzYZg==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1085.0.tgz",
+            "integrity": "sha512-ej/Fhb74+ZzmU5vUBQ+zZvrZ223dq5QxrmU6ufCKALvFz5u66z3+dR3jwtUUIOjxLeLXy4Y6YHy6+Z76JkhJAA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "^3.975.1",
@@ -522,9 +522,9 @@
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1083.0.tgz",
-            "integrity": "sha512-r9PY+w81yeFIMKy/tAPRDD1AJnygXMdwUZOx5dGGHwx9Azk8CYYm9mA9Km5XxSdPihlrJ5sSleaHNFN0VHrIDA==",
+            "version": "3.1085.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1085.0.tgz",
+            "integrity": "sha512-S+yCGIMxQ5Zs2A5ZDdYfXwOxu5kKjBaCQVOxp6+mnwCQYXUNkBD/aKCnW1eniMTavzz3YidhD5eTFpDlcUv2gQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/core": "^3.29.2",
@@ -538,7 +538,7 @@
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.1083.0"
+                "@aws-sdk/client-s3": "^3.1085.0"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
@@ -2861,12 +2861,12 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
-            "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
+            "version": "3.29.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+            "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2874,13 +2874,13 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.4.7",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
-            "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+            "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2888,13 +2888,13 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.6.4",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
-            "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+            "version": "5.6.5",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+            "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2902,13 +2902,13 @@
             }
         },
         "node_modules/@smithy/middleware-compression": {
-            "version": "4.5.7",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.7.tgz",
-            "integrity": "sha512-+6KtzRfzBNLQHQXmTBnUJyUAaq8cYp5GPGJSab3ahsVEgdnC/p/TO3BAyvXw9I5F+hDnwjUAV1EGQCD4NcQOiw==",
+            "version": "4.5.8",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.8.tgz",
+            "integrity": "sha512-ODHXD5tDW3+25pfiLjJ2ZTIHRfWWxqVGPqIMz1NjmiV4bG4i1S0kuibHxik6WXibR03nmDGMiI1/hF6647F/Zg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "fflate": "0.8.1",
                 "tslib": "^2.6.2"
             },
@@ -2917,13 +2917,13 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
-            "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+            "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2931,13 +2931,13 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
-            "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+            "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2945,9 +2945,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.16.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
-            "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3819,9 +3819,9 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5160,6 +5160,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
@@ -5174,6 +5175,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -5186,6 +5188,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5198,6 +5201,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.3.0"
@@ -5213,6 +5217,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
             "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
@@ -5432,6 +5437,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
             "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -5670,9 +5676,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-            "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+            "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
             "devOptional": true,
             "license": "MIT",
             "workspaces": [
@@ -6705,6 +6711,7 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
             "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+            "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -9193,18 +9200,122 @@
             "license": "MIT"
         },
         "node_modules/sanitize-html": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
-            "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
+            "version": "2.17.6",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
+            "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
             "license": "MIT",
             "dependencies": {
                 "deepmerge": "^4.2.2",
                 "escape-string-regexp": "^4.0.0",
-                "htmlparser2": "^10.1.0",
+                "htmlparser2": "^12.0.0",
                 "is-plain-object": "^5.0.0",
                 "launder": "^1.7.1",
                 "parse-srcset": "^1.0.2",
                 "postcss": "^8.3.11"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/dom-serializer": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+            "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^3.0.0",
+                "domhandler": "^6.0.0",
+                "entities": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domelementtype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+            "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domhandler": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+            "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domutils": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+            "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^3.0.0",
+                "domelementtype": "^3.0.0",
+                "domhandler": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/htmlparser2": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+            "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^3.0.0",
+                "domhandler": "^6.0.0",
+                "domutils": "^4.0.2",
+                "entities": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/save-pixels": {

--- a/api/routes/attachments.ts
+++ b/api/routes/attachments.ts
@@ -7,11 +7,13 @@ import Err from '@openaddresses/batch-error';
 import Auth from '../lib/auth.js';
 import S3 from '../lib/aws/s3.js';
 import Config from '../lib/config.js';
+import ProfileControl from '../lib/control/profile.js';
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 import { MissionOptions } from '@tak-ps/node-tak/lib/api/mission';
 
 export default async function router(schema: Schema, config: Config) {
     const attachmentControl = new AttachmentControl(config);
+    const profileControl = new ProfileControl(config);
 
     await schema.get('/attachment', {
         name: 'List Attachments',
@@ -121,7 +123,7 @@ export default async function router(schema: Schema, config: Config) {
                             creatorUid: profile.username,
                         }, stream);
 
-                        const opts: Static<typeof MissionOptions> = await config.conns.subscription(user.email, req.query.mission);
+                        const opts: Static<typeof MissionOptions> = await profileControl.subscription(user.email, req.query.mission);
 
                         await api.Mission.attachContents(
                             req.query.mission,

--- a/api/routes/connection-layer-cot.ts
+++ b/api/routes/connection-layer-cot.ts
@@ -307,14 +307,13 @@ export default async function router(schema: Schema, config: Config) {
 
             if (!layer.connection) throw new Err(400, null, 'Layer is not attached to a Connection');
 
-            const pooledClient = await config.conns.get(layer.connection);
-            if (!pooledClient) throw new Err(500, null, `Pooled Client for ${layer.connection} not found in config`);
+            const layerConnection = await config.models.Connection.from(layer.connection);
 
             const api = await TAKAPI.init(
                 new URL(String(config.server.api)),
                 new APIAuthCertificate(
-                    pooledClient.config.auth.cert,
-                    pooledClient.config.auth.key,
+                    layerConnection.auth.cert,
+                    layerConnection.auth.key,
                 ),
             );
 
@@ -355,14 +354,13 @@ export default async function router(schema: Schema, config: Config) {
 
             if (!layer.connection) throw new Err(400, null, 'Layer is not attached to a connection');
 
-            const pooledClient = await config.conns.get(layer.connection);
-            if (!pooledClient) throw new Err(500, null, `Pooled Client for ${layer.connection} not found in config`);
+            const layerConnection = await config.models.Connection.from(layer.connection);
 
             const api = await TAKAPI.init(
                 new URL(String(config.server.api)),
                 new APIAuthCertificate(
-                    pooledClient.config.auth.cert,
-                    pooledClient.config.auth.key,
+                    layerConnection.auth.cert,
+                    layerConnection.auth.key,
                 ),
             );
 

--- a/api/routes/connection-layer-cot.ts
+++ b/api/routes/connection-layer-cot.ts
@@ -302,18 +302,18 @@ export default async function router(schema: Schema, config: Config) {
             }, req.params.connectionid);
 
             if (connection.readonly) throw new Err(400, null, 'Connection is Read-Only mode');
+            if (!connection.enabled) throw new Err(400, null, 'Connection is disabled');
 
             const layer = await config.models.Layer.augmented_from(req.params.layerid);
 
             if (!layer.connection) throw new Err(400, null, 'Layer is not attached to a Connection');
-
-            const layerConnection = await config.models.Connection.from(layer.connection);
+            if (layer.connection !== connection.id) throw new Err(400, null, 'Layer does not belong to this connection');
 
             const api = await TAKAPI.init(
                 new URL(String(config.server.api)),
                 new APIAuthCertificate(
-                    layerConnection.auth.cert,
-                    layerConnection.auth.key,
+                    connection.auth.cert,
+                    connection.auth.key,
                 ),
             );
 
@@ -349,18 +349,18 @@ export default async function router(schema: Schema, config: Config) {
             }, req.params.connectionid);
 
             if (connection.readonly) throw new Err(400, null, 'Connection is Read-Only mode');
+            if (!connection.enabled) throw new Err(400, null, 'Connection is disabled');
 
             const layer = await config.models.Layer.augmented_from(req.params.layerid);
 
             if (!layer.connection) throw new Err(400, null, 'Layer is not attached to a connection');
-
-            const layerConnection = await config.models.Connection.from(layer.connection);
+            if (layer.connection !== connection.id) throw new Err(400, null, 'Layer does not belong to this connection');
 
             const api = await TAKAPI.init(
                 new URL(String(config.server.api)),
                 new APIAuthCertificate(
-                    layerConnection.auth.cert,
-                    layerConnection.auth.key,
+                    connection.auth.cert,
+                    connection.auth.key,
                 ),
             );
 

--- a/api/routes/marti-mission-layers.ts
+++ b/api/routes/marti-mission-layers.ts
@@ -4,6 +4,7 @@ import Schema from '@openaddresses/batch-schema';
 import Err from '@openaddresses/batch-error';
 import Auth from '../lib/auth.js';
 import Config from '../lib/config.js';
+import ProfileControl from '../lib/control/profile.js';
 import * as Default from '../lib/limits.js';
 import { MissionOptions } from '@tak-ps/node-tak/lib/api/mission';
 import { MissionLayer, MissionLayerType } from '@tak-ps/node-tak/lib/api/mission-layer';
@@ -14,6 +15,8 @@ import {
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 
 export default async function router(schema: Schema, config: Config) {
+    const profileControl = new ProfileControl(config);
+
     await schema.get('/marti/missions/:name/layer', {
         name: 'List Layers',
         group: 'MartiMissionLayer',
@@ -31,7 +34,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const list = await api.MissionLayer.list(
                 req.params.name,
@@ -62,7 +65,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const layer = await api.MissionLayer.get(
                 req.params.name,
@@ -100,7 +103,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const create = await api.MissionLayer.create(
                 req.params.name,
@@ -139,7 +142,7 @@ export default async function router(schema: Schema, config: Config) {
             if (req.body.name) {
                 const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                     ? { token: String(req.headers['missionauthorization']) }
-                    : await config.conns.subscription(user.email, req.params.name);
+                    : await profileControl.subscription(user.email, req.params.name);
 
                 await api.MissionLayer.rename(
                     req.params.name,
@@ -179,7 +182,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             await api.MissionLayer.delete(
                 req.params.name,

--- a/api/routes/marti-mission-logs.ts
+++ b/api/routes/marti-mission-logs.ts
@@ -6,12 +6,15 @@ import { MissionOptions } from '@tak-ps/node-tak/lib/api/mission';
 import { MissionLog } from '@tak-ps/node-tak/lib/api/mission-log';
 import Auth from '../lib/auth.js';
 import Config from '../lib/config.js';
+import ProfileControl from '../lib/control/profile.js';
 import {
     TAKItem,
 } from '@tak-ps/node-tak/lib/api/types';
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 
 export default async function router(schema: Schema, config: Config) {
+    const profileControl = new ProfileControl(config);
+
     await schema.get('/marti/missions/:name/log', {
         name: 'List Logs',
         group: 'MartiMissionLog',
@@ -44,7 +47,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const mission = await api.Mission.get(
                 req.params.name,
@@ -116,7 +119,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const log = await api.MissionLog.create(
                 req.params.name,
@@ -163,7 +166,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const mission = await api.MissionLog.update(
                 req.params.name,
@@ -201,7 +204,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             await api.MissionLog.delete(
                 req.params.log,

--- a/api/routes/marti-mission.ts
+++ b/api/routes/marti-mission.ts
@@ -8,6 +8,7 @@ import S3 from '../lib/aws/s3.js';
 import Err from '@openaddresses/batch-error';
 import Auth from '../lib/auth.js';
 import Config from '../lib/config.js';
+import ProfileControl from '../lib/control/profile.js';
 import { GenericMartiResponse, StandardResponse } from '../lib/types.js';
 import * as Default from '../lib/limits.js';
 import {
@@ -28,6 +29,8 @@ import {
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 
 export default async function router(schema: Schema, config: Config) {
+    const profileControl = new ProfileControl(config);
+
     await schema.get('/marti/missions/:name', {
         name: 'Get Mission',
         group: 'MartiMissions',
@@ -58,7 +61,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const mission = await api.Mission.get(
                 req.params.name,
@@ -91,7 +94,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.guid);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const features = await api.Mission.latestFeats(req.params.guid, opts);
 
@@ -120,7 +123,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.guid);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const missionContent = await api.Mission.detachContents(
                 req.params.guid,
@@ -151,7 +154,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const mission = await api.Mission.get(
                 req.params.name,
@@ -190,7 +193,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const changes = await api.Mission.changes(
                 req.params.name,
@@ -221,7 +224,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const mission = await api.Mission.delete(
                 req.params.name,
@@ -281,7 +284,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const { groups, ...rest } = req.body;
 
@@ -392,7 +395,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             if (req.query.download) {
                 res.setHeader('Content-Disposition', `attachment; filename="${req.params.name}.${req.query.format}"`);
@@ -410,7 +413,7 @@ export default async function router(schema: Schema, config: Config) {
             } else if (['geojson', 'kml'].includes(req.query.format)) {
                 const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                     ? { token: String(req.headers['missionauthorization']) }
-                    : await config.conns.subscription(user.email, req.params.name);
+                    : await profileControl.subscription(user.email, req.params.name);
 
                 const fc = {
                     type: 'FeatureCollection',
@@ -463,7 +466,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const role = await api.Mission.role(
                 req.params.name,
@@ -492,7 +495,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const subs = await api.Mission.subscriptions(
                 req.params.name,
@@ -521,7 +524,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const roles = await api.Mission.subscriptionRoles(
                 req.params.name,
@@ -558,7 +561,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const missions = await api.Mission.contacts(
                 req.params.name,
@@ -617,7 +620,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             await api.Mission.attachContents(
                 req.params.name,
@@ -673,7 +676,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const missionContent = await api.Mission.attachContents(
                 req.params.name,
@@ -708,7 +711,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.name);
 
             const missionContent = await api.Mission.detachContents(
                 req.params.name,
@@ -742,7 +745,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.guid);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const invites = await api.MissionInvite.get(req.params.guid, opts);
 
@@ -773,7 +776,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.guid);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.MissionInvite.invite(
                 req.params.guid,
@@ -815,7 +818,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.guid);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.MissionInvite.uninvite(
                 req.params.guid,
@@ -855,7 +858,7 @@ export default async function router(schema: Schema, config: Config) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await config.conns.subscription(user.email, req.params.guid);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const uids = Array.isArray(req.query.uid) ? req.query.uid : [req.query.uid];
 

--- a/api/routes/marti-package.ts
+++ b/api/routes/marti-package.ts
@@ -14,6 +14,8 @@ import Schema from '@openaddresses/batch-schema';
 import Err from '@openaddresses/batch-error';
 import Auth, { AuthUserAccess } from '../lib/auth.js';
 import Config from '../lib/config.js';
+import ProfileControl from '../lib/control/profile.js';
+import activeChannels from '../lib/tak-channels.js';
 import { Basemap as BasemapParser } from '@tak-ps/node-cot';
 import { Content } from '@tak-ps/node-tak/lib/api/files';
 import { Package } from '@tak-ps/node-tak/lib/api/package';
@@ -24,9 +26,9 @@ import {
 import stream2buffer from '../lib/stream.js';
 import { PackageResponse } from './types.js';
 
-async function activeChannelNames(config: Config, email: string, api: TAKAPI): Promise<Set<string>> {
+async function activeChannelNames(api: TAKAPI): Promise<Set<string>> {
     const groups = await api.Group.list({ useCache: true });
-    const activeBitpos = await config.conns.activeChannels(email, api);
+    const activeBitpos = await activeChannels(api);
 
     return new Set(
         groups.data
@@ -121,6 +123,8 @@ function packageExpirationForUpdate(value: string | number | null | undefined): 
 }
 
 export default async function router(schema: Schema, config: Config) {
+    const profileControl = new ProfileControl(config);
+
     await schema.post('/marti/package', {
         name: 'Create File Package',
         group: 'MartiPackages',
@@ -488,7 +492,7 @@ export default async function router(schema: Schema, config: Config) {
 
                     const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                         ? { token: String(req.headers['missionauthorization']) }
-                        : await config.conns.subscription(user.email, guid);
+                        : await profileControl.subscription(user.email, guid);
 
                     await api.Mission.upload(
                         guid,
@@ -658,7 +662,7 @@ export default async function router(schema: Schema, config: Config) {
                 );
 
                 const [userChannels, packageChannels] = await Promise.all([
-                    activeChannelNames(config, user.email, userApi),
+                    activeChannelNames(userApi),
                     packageChannelNames(userApi, latest),
                 ]);
 

--- a/api/routes/marti-subscriptions.ts
+++ b/api/routes/marti-subscriptions.ts
@@ -8,6 +8,7 @@ import {
     TAKList,
 } from '@tak-ps/node-tak/lib/api/types';
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
+import activeChannels from '../lib/tak-channels.js';
 
 export default async function router(schema: Schema, config: Config) {
     await schema.get('/marti/subscription', {
@@ -23,7 +24,7 @@ export default async function router(schema: Schema, config: Config) {
             const user = await Auth.as_user(config, req);
             const profile = await config.models.Profile.from(user.email);
             const api = await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(profile.auth.cert, profile.auth.key));
-            const channels = await config.conns.activeChannels(user.email, api);
+            const channels = await activeChannels(api);
 
             const subs = await api.Subscription.list(req.query);
 
@@ -61,7 +62,7 @@ export default async function router(schema: Schema, config: Config) {
                 page: -1,
                 limit: -1,
             });
-            const channels = await config.conns.activeChannels(user.email, api);
+            const channels = await activeChannels(api);
 
             let done = false;
             for (const sub of subs.data) {

--- a/api/routes/profile-asset.ts
+++ b/api/routes/profile-asset.ts
@@ -11,6 +11,7 @@ import jwt from 'jsonwebtoken';
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 import { ProfileFile, ProfileFileChannel } from '../lib/schema.js';
 import Config from '../lib/config.js';
+import activeChannels from '../lib/tak-channels.js';
 import * as Default from '../lib/limits.js';
 
 export default async function router(schema: Schema, config: Config) {
@@ -55,9 +56,8 @@ export default async function router(schema: Schema, config: Config) {
         try {
             const user = await Auth.as_user(config, req);
             const profile = await config.models.Profile.from(user.email);
-            const api = config.conns.get(user.email)?.api
-                ?? await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(profile.auth.cert, profile.auth.key));
-            const channels = [...await config.conns.activeChannels(user.email, api)];
+            const api = await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(profile.auth.cert, profile.auth.key));
+            const channels = [...await activeChannels(api)];
             const where = channels.length
                 ? sql`
                     name ~* ${req.query.filter}
@@ -328,11 +328,10 @@ export default async function router(schema: Schema, config: Config) {
                 }
 
                 const profile = await config.models.Profile.from(user.email);
-                const api = config.conns.get(user.email)?.api
-                    ?? await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(profile.auth.cert, profile.auth.key));
-                const activeChannels = await config.conns.activeChannels(user.email, api);
+                const api = await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(profile.auth.cert, profile.auth.key));
+                const active = await activeChannels(api);
 
-                if (!fileChannels.some(bp => activeChannels.has(bp))) {
+                if (!fileChannels.some(bp => active.has(bp))) {
                     throw new Err(403, null, 'You do not have permission to view this asset');
                 }
             }

--- a/api/routes/profile-overlays.ts
+++ b/api/routes/profile-overlays.ts
@@ -2,6 +2,7 @@ import { Static, Type } from '@sinclair/typebox';
 import { BasemapProtocol, TileJSONActions } from '../lib/interface-basemap.js';
 import { fromProtocol } from '../lib/factory-basemap.js';
 import Config from '../lib/config.js';
+import ProfileControl from '../lib/control/profile.js';
 import Schema from '@openaddresses/batch-schema';
 import S3 from '../lib/aws/s3.js';
 import Err from '@openaddresses/batch-error';
@@ -41,6 +42,8 @@ function serializeOverlay(
 }
 
 export default async function router(schema: Schema, config: Config) {
+    const profileControl = new ProfileControl(config);
+
     await schema.get('/profile/overlay', {
         name: 'Get Overlays',
         group: 'ProfileOverlays',
@@ -140,7 +143,7 @@ export default async function router(schema: Schema, config: Config) {
                         return { keep: false as const, item };
                     }
                 } else if (item.mode === 'mission' && item.mode_id && api) {
-                    const subscription = await config.conns.subscription(user.email, item.name);
+                    const subscription = await profileControl.subscription(user.email, item.name);
                     if (!(await api.Mission.access(item.mode_id, subscription))) {
                         return { keep: false as const, item };
                     }

--- a/api/test/marti-package.srv.test.ts
+++ b/api/test/marti-package.srv.test.ts
@@ -459,11 +459,6 @@ test('PATCH api/marti/package/:uid - User with overlapping active channel can up
     let uploadHit = false;
 
     try {
-        flight.config?.conns.set('pkgowner@example.com', {
-            channels: new Set([1]),
-            destroy: () => {},
-        } as any);
-
         flight.tak.mockMarti.unshift(async (request: IncomingMessage, response: ServerResponse) => {
             if (!request.method || !request.url) {
                 return false;
@@ -523,7 +518,7 @@ test('PATCH api/marti/package/:uid - User with overlapping active channel can up
                         created: new Date().toISOString(),
                         type: 'SYSTEM',
                         bitpos: 1,
-                        active: false,
+                        active: true,
                     }, {
                         name: 'Red',
                         direction: 'IN',
@@ -682,11 +677,6 @@ test('PATCH api/marti/package/:uid - User without overlapping active channel can
     let attemptedUpdate = false;
 
     try {
-        flight.config?.conns.set('pkgviewer@example.com', {
-            channels: new Set([1]),
-            destroy: () => {},
-        } as any);
-
         flight.tak.mockMarti.unshift(async (request: IncomingMessage, response: ServerResponse) => {
             if (!request.method || !request.url) {
                 return false;
@@ -723,7 +713,7 @@ test('PATCH api/marti/package/:uid - User without overlapping active channel can
                         created: new Date().toISOString(),
                         type: 'SYSTEM',
                         bitpos: 1,
-                        active: false,
+                        active: true,
                     }, {
                         name: 'Red',
                         direction: 'IN',


### PR DESCRIPTION
### Context

- :rocket: Reduce stateful internals in favour of using stateless or cloudTAK database backed calls