### PR TITLE
Remove UUID Dep

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.api",
-    "version": "13.44.0",
+    "version": "13.46.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.api",
-            "version": "13.44.0",
+            "version": "13.46.0",
             "license": "ISC",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -33,7 +33,7 @@
                 "@simplewebauthn/server": "^13.3.0",
                 "@sinclair/typebox": "^0.34.0",
                 "@tak-ps/etl": "^10.0.0",
-                "@tak-ps/node-cot": "^14.25.0",
+                "@tak-ps/node-cot": "^14.45.0",
                 "@tak-ps/node-safeurl": "^1.5.0",
                 "@tak-ps/node-tak": "^12.18.2",
                 "@turf/bbox": "^7.1.0",
@@ -3001,9 +3001,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "14.44.3",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.44.3.tgz",
-            "integrity": "sha512-OwloMd5jnp/eg50NedXnNUE0bDY+ORHYB6/9s/+H6AShM77cyte1NFCANUEQp6gz3qOX1dVee2GBt+wwzpdlCg==",
+            "version": "14.45.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.45.0.tgz",
+            "integrity": "sha512-40jcWZpDAIxPaDpabp51Ei8agss3N9ketqaa1aOR7XbUuSCWqO8PjUT1XEUPmB+t03L7h7fiJYle1gJFHcE/+g==",
             "license": "MIT",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -3026,8 +3026,7 @@
                 "milstandard-e": "^0.2.14",
                 "milsymbol": "^3.0.2",
                 "node-stream-zip": "^1.15.0",
-                "protobufjs": "^8.0.0",
-                "uuid": "^14.0.0"
+                "protobufjs": "^8.0.0"
             },
             "bin": {
                 "cot": "cli.ts"
@@ -11066,19 +11065,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
-        },
-        "node_modules/uuid": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-            "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist-node/bin/uuid"
-            }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/api/package.json
+++ b/api/package.json
@@ -54,7 +54,7 @@
         "@simplewebauthn/server": "^13.3.0",
         "@sinclair/typebox": "^0.34.0",
         "@tak-ps/etl": "^10.0.0",
-        "@tak-ps/node-cot": "^14.25.0",
+        "@tak-ps/node-cot": "^14.45.0",
         "@tak-ps/node-safeurl": "^1.5.0",
         "@tak-ps/node-tak": "^12.18.2",
         "@turf/bbox": "^7.1.0",

--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/cloudtak",
-    "version": "13.45.1",
+    "version": "13.46.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/cloudtak",
-            "version": "13.45.1",
+            "version": "13.46.0",
             "dependencies": {
                 "@capacitor-community/keep-awake": "^8.0.1",
                 "@capacitor-firebase/messaging": "^8.2.0",
@@ -28,7 +28,7 @@
                 "@simplewebauthn/browser": "^13.3.0",
                 "@tabler/core": "^1.4.0",
                 "@tabler/icons-vue": "^3.0.0",
-                "@tak-ps/node-cot": "^14.20.0",
+                "@tak-ps/node-cot": "^14.45.0",
                 "@tak-ps/node-p12": "^1.0.3",
                 "@tak-ps/vue-tabler": "^4.29.3",
                 "@turf/area": "^7.2.0",
@@ -2953,9 +2953,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "14.44.3",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.44.3.tgz",
-            "integrity": "sha512-OwloMd5jnp/eg50NedXnNUE0bDY+ORHYB6/9s/+H6AShM77cyte1NFCANUEQp6gz3qOX1dVee2GBt+wwzpdlCg==",
+            "version": "14.45.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.45.0.tgz",
+            "integrity": "sha512-40jcWZpDAIxPaDpabp51Ei8agss3N9ketqaa1aOR7XbUuSCWqO8PjUT1XEUPmB+t03L7h7fiJYle1gJFHcE/+g==",
             "license": "MIT",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -2978,8 +2978,7 @@
                 "milstandard-e": "^0.2.14",
                 "milsymbol": "^3.0.2",
                 "node-stream-zip": "^1.15.0",
-                "protobufjs": "^8.0.0",
-                "uuid": "^14.0.0"
+                "protobufjs": "^8.0.0"
             },
             "bin": {
                 "cot": "cli.ts"

--- a/api/web/package.json
+++ b/api/web/package.json
@@ -50,7 +50,7 @@
         "@simplewebauthn/browser": "^13.3.0",
         "@tabler/core": "^1.4.0",
         "@tabler/icons-vue": "^3.0.0",
-        "@tak-ps/node-cot": "^14.20.0",
+        "@tak-ps/node-cot": "^14.45.0",
         "@tak-ps/node-p12": "^1.0.3",
         "@tak-ps/vue-tabler": "^4.29.3",
         "@turf/area": "^7.2.0",


### PR DESCRIPTION
### Context

- :arrow_up: Update node-cot to remove `uuid` dependency and use `crypto.randomUUID()` instead.
