### PR TITLE
Allow CoreEvents through a Connection

### DIFF
--- a/api/common/config.ts
+++ b/api/common/config.ts
@@ -18,6 +18,7 @@ export interface ConfigArgs {
     noevents: boolean;
     nosinks: boolean;
     nogeofence?: boolean;
+    noconnections?: boolean;
     nocache: boolean;
     mode?: ServerMode;
     hubUrl?: string;
@@ -28,6 +29,7 @@ export interface ConfigInit {
     noevents: boolean;
     nosinks: boolean;
     nogeofence: boolean;
+    noconnections: boolean;
     nocache: boolean;
     models: Models;
     StackName: string;
@@ -61,6 +63,7 @@ export default class Config {
     noevents: boolean;
     nosinks: boolean;
     nogeofence: boolean;
+    noconnections: boolean;
     nocache: boolean;
     models: Models;
     StackName: string;
@@ -78,6 +81,7 @@ export default class Config {
         this.noevents = init.noevents;
         this.nosinks = init.nosinks;
         this.nogeofence = init.nogeofence;
+        this.noconnections = init.noconnections;
         this.nocache = init.nocache;
         this.models = init.models;
         this.StackName = init.StackName;
@@ -208,6 +212,7 @@ export default class Config {
             noevents: (args.noevents || false),
             nosinks: (args.nosinks || false),
             nogeofence: (args.nogeofence || false),
+            noconnections: (args.noconnections || false),
             nocache: (args.nocache || false),
             StackName: process.env.StackName,
             server, SigningSecret, API_URL, Bucket, pg, models, PMTILES_URL,

--- a/api/common/schema.ts
+++ b/api/common/schema.ts
@@ -413,7 +413,7 @@ export const Connection = pgTable('connections', {
     created: timestamp({ withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),
     updated: timestamp({ withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),
     username: text().references(() => Profile.username),
-    name: text().notNull(),
+    name: text().notNull().unique(),
     description: text().notNull().default(''),
     enabled: boolean().notNull().default(true),
     features: boolean().notNull().default(false),

--- a/api/common/schema.ts
+++ b/api/common/schema.ts
@@ -48,6 +48,7 @@ export const CoreEvent = pgTable('core_event', {
     updated: timestamp({ withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),
     ended: timestamp({ withTimezone: true, mode: 'string' }),
     username: text().references(() => Profile.username),
+    connection: integer().references(() => Connection.id, { onDelete: 'set null' }),
     priority: text().$type<CoreEvent_Priority>().notNull().default(CoreEvent_Priority.NONE),
     type: text().notNull(), // MIL-STD-2525E Symbol ID
     name: text().notNull(),

--- a/api/common/types.ts
+++ b/api/common/types.ts
@@ -149,6 +149,7 @@ export const CoreEventResponse = Type.Object({
     updated: Type.String(),
     ended: Type.Union([Type.Null(), Type.String()], { description: 'Time at which the Event ended' }),
     username: Type.Union([Type.Null(), Type.String()]),
+    connection: Type.Union([Type.Null(), Type.Integer()], { description: 'Connection that created the Event if created by a Connection or Layer token' }),
     priority: Type.Enum(CoreEvent_Priority),
     type: Type.String({ description: 'MIL-STD-2525E Symbol ID' }),
     name: Type.String(),

--- a/api/derived-types.d.ts
+++ b/api/derived-types.d.ts
@@ -736,7 +736,7 @@ export interface paths {
                     /** @description No Description */
                     type?: ("raster" | "raster-dem" | "vector") | ("raster" | "raster-dem" | "vector")[];
                     /** @description No Description */
-                    sort: "id" | "created" | "updated" | "name" | "url" | "protocol" | "bounds" | "center" | "minzoom" | "maxzoom" | "format" | "type" | "username" | "sharing_enabled" | "sharing_token" | "hidden" | "tilesize" | "attribution" | "collection" | "frequency" | "scheme" | "overlay" | "tilejson" | "enableRLS";
+                    sort: "id" | "created" | "updated" | "parent" | "name" | "url" | "protocol" | "bounds" | "center" | "minzoom" | "maxzoom" | "format" | "type" | "username" | "sharing_enabled" | "sharing_token" | "hidden" | "tilesize" | "attribution" | "collection" | "frequency" | "scheme" | "overlay" | "tilejson" | "enableRLS";
                     /** @description Filter results by a human readable name field */
                     filter: string;
                     /** @description Only show Basemaps belonging to a given collection */
@@ -769,6 +769,8 @@ export interface paths {
                                 id: number;
                                 created: string;
                                 updated: string;
+                                /** @description If set, this Basemap/Overlay is a child of the given parent Basemap/Overlay */
+                                parent: null | number;
                                 name: string;
                                 url: string;
                                 protocol: "zxy" | "mapserver" | "imageserver" | "featureserver" | "hosted";
@@ -1015,6 +1017,8 @@ export interface paths {
                     "application/json": {
                         /** @description Human readable name */
                         name: string;
+                        /** @description Create this Basemap/Overlay as a child of the given parent Basemap/Overlay - only a single level of nesting is supported */
+                        parent?: number;
                         /**
                          * @description Allow CloudTAK users to share this layer with other users
                          * @default true
@@ -1067,6 +1071,8 @@ export interface paths {
                             id: number;
                             created: string;
                             updated: string;
+                            /** @description If set, this Basemap/Overlay is a child of the given parent Basemap/Overlay */
+                            parent: null | number;
                             name: string;
                             url: string;
                             protocol: "zxy" | "mapserver" | "imageserver" | "featureserver" | "hosted";
@@ -1204,6 +1210,8 @@ export interface paths {
                             id: number;
                             created: string;
                             updated: string;
+                            /** @description If set, this Basemap/Overlay is a child of the given parent Basemap/Overlay */
+                            parent: null | number;
                             name: string;
                             url: string;
                             protocol: "zxy" | "mapserver" | "imageserver" | "featureserver" | "hosted";
@@ -1233,6 +1241,43 @@ export interface paths {
                             actions: {
                                 feature: ("query" | "fetch" | "create" | "update" | "delete")[];
                             };
+                            /** @description Child Basemaps/Overlays of this Basemap - only a single level of nesting is supported */
+                            children: {
+                                id: number;
+                                created: string;
+                                updated: string;
+                                /** @description If set, this Basemap/Overlay is a child of the given parent Basemap/Overlay */
+                                parent: null | number;
+                                name: string;
+                                url: string;
+                                protocol: "zxy" | "mapserver" | "imageserver" | "featureserver" | "hosted";
+                                minzoom: number;
+                                maxzoom: number;
+                                format: "png" | "webp" | "jpeg" | "mvt";
+                                type: "raster" | "raster-dem" | "vector";
+                                username: null | string;
+                                sharing_enabled: boolean;
+                                sharing_token: null | string;
+                                hidden: boolean;
+                                tilesize: number;
+                                attribution: null | string;
+                                collection: null | string;
+                                frequency: null | number;
+                                /** @constant */
+                                scheme: "xyz";
+                                overlay: boolean;
+                                encoding?: "mapbox" | "terrarium";
+                                styles?: unknown[];
+                                iconset?: null | string;
+                                title?: string;
+                                snapping_enabled?: boolean;
+                                snapping_layer?: null | string;
+                                bounds?: number[];
+                                center?: number[];
+                                actions: {
+                                    feature: ("query" | "fetch" | "create" | "update" | "delete")[];
+                                };
+                            }[];
                         } | string;
                     };
                 };
@@ -1408,6 +1453,8 @@ export interface paths {
                     "application/json": {
                         /** @description Human readable name */
                         name?: string;
+                        /** @description Make this Basemap/Overlay a child of the given parent Basemap/Overlay - only a single level of nesting is supported */
+                        parent?: null | number;
                         sharing_enabled?: boolean;
                         /** @description Allow CloudTAK line editing to snap to features in this basemap */
                         snapping_enabled?: boolean;
@@ -1451,6 +1498,8 @@ export interface paths {
                             id: number;
                             created: string;
                             updated: string;
+                            /** @description If set, this Basemap/Overlay is a child of the given parent Basemap/Overlay */
+                            parent: null | number;
                             name: string;
                             url: string;
                             protocol: "zxy" | "mapserver" | "imageserver" | "featureserver" | "hosted";
@@ -16537,6 +16586,649 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/core/event": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Core Events */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort: "id" | "created" | "updated" | "ended" | "username" | "connection" | "priority" | "type" | "name" | "external_id" | "editable" | "location" | "remarks" | "geometry" | "enableRLS";
+                    /** @description Filter results by a human readable name field */
+                    filter: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                id: string;
+                                created: string;
+                                updated: string;
+                                /** @description Time at which the Event ended */
+                                ended: null | string;
+                                username: null | string;
+                                /** @description Connection that created the Event if created by a Connection or Layer token */
+                                connection: null | number;
+                                priority: "none" | "low" | "medium" | "high" | "critical";
+                                /** @description MIL-STD-2525E Symbol ID */
+                                type: string;
+                                name: string;
+                                /** @description ID of the Event in an external system */
+                                external_id: string;
+                                /** @description Can users other than the creator edit the Event */
+                                editable: boolean;
+                                /** @description Human readable location - ie: an address */
+                                location: string;
+                                remarks: string;
+                                geometry: {
+                                    /** @constant */
+                                    type: "Point";
+                                    coordinates: [
+                                        number,
+                                        number
+                                    ];
+                                };
+                                /** @description TAK Server Channels the Event is shared with */
+                                channels: number[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a new Core Event */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Human readable name */
+                        name: string;
+                        /** @description MIL-STD-2525E Symbol ID */
+                        type: string;
+                        /** @default none */
+                        priority: "none" | "low" | "medium" | "high" | "critical";
+                        geometry: {
+                            /** @constant */
+                            type: "Point";
+                            coordinates: [
+                                number,
+                                number
+                            ];
+                        };
+                        /**
+                         * @description Human readable location of the Event - ie: an address
+                         * @default
+                         */
+                        location: string;
+                        /** @default  */
+                        remarks: string;
+                        ended?: null | string;
+                        /**
+                         * @description ID of the Event in an external system
+                         * @default
+                         */
+                        external_id: string;
+                        /**
+                         * @description Can users other than the creator edit the Event
+                         * @default true
+                         */
+                        editable: boolean;
+                        /**
+                         * @description TAK Server Channels to share the Event with
+                         * @default []
+                         */
+                        channels: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            created: string;
+                            updated: string;
+                            /** @description Time at which the Event ended */
+                            ended: null | string;
+                            username: null | string;
+                            /** @description Connection that created the Event if created by a Connection or Layer token */
+                            connection: null | number;
+                            priority: "none" | "low" | "medium" | "high" | "critical";
+                            /** @description MIL-STD-2525E Symbol ID */
+                            type: string;
+                            name: string;
+                            /** @description ID of the Event in an external system */
+                            external_id: string;
+                            /** @description Can users other than the creator edit the Event */
+                            editable: boolean;
+                            /** @description Human readable location - ie: an address */
+                            location: string;
+                            remarks: string;
+                            geometry: {
+                                /** @constant */
+                                type: "Point";
+                                coordinates: [
+                                    number,
+                                    number
+                                ];
+                            };
+                            /** @description TAK Server Channels the Event is shared with */
+                            channels: number[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/core/event/{:event}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a Core Event */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":event": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            created: string;
+                            updated: string;
+                            /** @description Time at which the Event ended */
+                            ended: null | string;
+                            username: null | string;
+                            /** @description Connection that created the Event if created by a Connection or Layer token */
+                            connection: null | number;
+                            priority: "none" | "low" | "medium" | "high" | "critical";
+                            /** @description MIL-STD-2525E Symbol ID */
+                            type: string;
+                            name: string;
+                            /** @description ID of the Event in an external system */
+                            external_id: string;
+                            /** @description Can users other than the creator edit the Event */
+                            editable: boolean;
+                            /** @description Human readable location - ie: an address */
+                            location: string;
+                            remarks: string;
+                            geometry: {
+                                /** @constant */
+                                type: "Point";
+                                coordinates: [
+                                    number,
+                                    number
+                                ];
+                            };
+                            /** @description TAK Server Channels the Event is shared with */
+                            channels: number[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete a Core Event */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":event": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update properties of a Core Event */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":event": string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Human readable name */
+                        name?: string;
+                        type?: string;
+                        priority?: "none" | "low" | "medium" | "high" | "critical";
+                        geometry?: {
+                            /** @constant */
+                            type: "Point";
+                            coordinates: [
+                                number,
+                                number
+                            ];
+                        };
+                        location?: string;
+                        remarks?: string;
+                        ended?: null | string;
+                        external_id?: string;
+                        editable?: boolean;
+                        channels?: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            created: string;
+                            updated: string;
+                            /** @description Time at which the Event ended */
+                            ended: null | string;
+                            username: null | string;
+                            /** @description Connection that created the Event if created by a Connection or Layer token */
+                            connection: null | number;
+                            priority: "none" | "low" | "medium" | "high" | "critical";
+                            /** @description MIL-STD-2525E Symbol ID */
+                            type: string;
+                            name: string;
+                            /** @description ID of the Event in an external system */
+                            external_id: string;
+                            /** @description Can users other than the creator edit the Event */
+                            editable: boolean;
+                            /** @description Human readable location - ie: an address */
+                            location: string;
+                            remarks: string;
+                            geometry: {
+                                /** @constant */
+                                type: "Point";
+                                coordinates: [
+                                    number,
+                                    number
+                                ];
+                            };
+                            /** @description TAK Server Channels the Event is shared with */
+                            channels: number[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/api/error": {
         parameters: {
             query?: never;
@@ -27062,7 +27754,101 @@ export interface paths {
                 };
             };
         };
-        put?: never;
+        /** Change the role of an existing mission subscriber */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":name": string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        clientUid: string;
+                        username: string;
+                        role: "MISSION_OWNER" | "MISSION_SUBSCRIBER" | "MISSION_READONLY_SUBSCRIBER";
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
         post?: never;
         delete?: never;
         options?: never;
@@ -31490,7 +32276,6 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        /** @enum {string} */
                         type: "Point" | "LineString" | "Polygon";
                         name: string;
                         style: {
@@ -31809,7 +32594,6 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        /** @enum {string} */
                         type?: "Point" | "LineString" | "Polygon";
                         name?: string;
                         style?: {
@@ -31840,884 +32624,6 @@ export interface paths {
                             name: string;
                             /** Format: uuid */
                             template: string;
-                            type: string;
-                            style: (string | number | boolean | null) | unknown[] | {
-                                [key: string]: unknown;
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/template/mission/{:mission}/palette/{:palette}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Mission Template Palette */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uuid: string;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            /** Format: uuid */
-                            template: string;
-                            features: {
-                                uuid: string;
-                                created: string;
-                                updated: string;
-                                name: string;
-                                /** Format: uuid */
-                                palette: string;
-                                type: string;
-                                style: (string | number | boolean | null) | unknown[] | {
-                                    [key: string]: unknown;
-                                };
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete a Mission Template Palette */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update properties of a Mission Template Palette */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        name?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uuid: string;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            /** Format: uuid */
-                            template: string;
-                            features: {
-                                uuid: string;
-                                created: string;
-                                updated: string;
-                                name: string;
-                                /** Format: uuid */
-                                palette: string;
-                                type: string;
-                                style: (string | number | boolean | null) | unknown[] | {
-                                    [key: string]: unknown;
-                                };
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/template/mission/{:mission}/palette/{:palette}/feature": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Mission Template Palette Features */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort: "uuid" | "name" | "created" | "updated" | "template" | "enableRLS";
-                    /** @description Filter results by a human readable name field */
-                    filter: string;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                uuid: string;
-                                created: string;
-                                updated: string;
-                                name: string;
-                                /** Format: uuid */
-                                palette: string;
-                                type: string;
-                                style: (string | number | boolean | null) | unknown[] | {
-                                    [key: string]: unknown;
-                                };
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create a new Mission Template Palette Feature */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        type: "Point" | "LineString" | "Polygon";
-                        name: string;
-                        style: {
-                            "marker-color"?: string;
-                            "marker-opacity"?: string;
-                            icon?: string;
-                            stroke?: string;
-                            "stroke-style"?: string;
-                            "stroke-opacity"?: string;
-                            "stroke-width"?: string;
-                            fill?: string;
-                            "fill-opacity"?: string;
-                        };
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uuid: string;
-                            created: string;
-                            updated: string;
-                            name: string;
-                            /** Format: uuid */
-                            palette: string;
-                            type: string;
-                            style: (string | number | boolean | null) | unknown[] | {
-                                [key: string]: unknown;
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/template/mission/{:mission}/palette/{:palette}/feature/{:feature}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Mission Template Palette Feature */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                    /** @description No Description */
-                    ":feature": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uuid: string;
-                            created: string;
-                            updated: string;
-                            name: string;
-                            /** Format: uuid */
-                            palette: string;
-                            type: string;
-                            style: (string | number | boolean | null) | unknown[] | {
-                                [key: string]: unknown;
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete a Mission Template Palette Feature */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                    /** @description No Description */
-                    ":feature": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update properties of a Mission Template Palette Feature */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":mission": string;
-                    /** @description No Description */
-                    ":palette": string;
-                    /** @description No Description */
-                    ":feature": string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        type?: "Point" | "LineString" | "Polygon";
-                        name?: string;
-                        style?: {
-                            "marker-color"?: string;
-                            "marker-opacity"?: string;
-                            icon?: string;
-                            stroke?: string;
-                            "stroke-style"?: string;
-                            "stroke-opacity"?: string;
-                            "stroke-width"?: string;
-                            fill?: string;
-                            "fill-opacity"?: string;
-                        };
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uuid: string;
-                            created: string;
-                            updated: string;
-                            name: string;
-                            /** Format: uuid */
-                            palette: string;
                             type: string;
                             style: (string | number | boolean | null) | unknown[] | {
                                 [key: string]: unknown;
@@ -39231,7 +39137,6 @@ export interface paths {
                             username: string;
                             created: string;
                             updated: string;
-                            tak_phone: string;
                             last_login: string;
                             /** @description Does the user have an active CloudTAK Session */
                             active: boolean;
@@ -39239,6 +39144,7 @@ export interface paths {
                             agency_admin: number[];
                             tak_callsign: string;
                             tak_remarks: string;
+                            tak_phone: string;
                             tak_group: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
                             tak_role: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
                             tak_type: string;
@@ -39354,6 +39260,7 @@ export interface paths {
                     "application/json": {
                         tak_callsign?: string;
                         tak_remarks?: string;
+                        tak_phone?: string;
                         tak_group?: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
                         tak_role?: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
                         tak_type?: string;
@@ -39386,7 +39293,6 @@ export interface paths {
                         geometry_point_type?: string;
                         geometry_point_color?: string;
                         geometry_point_icon?: string;
-                        tak_phone?: string;
                     };
                 };
             };
@@ -39401,7 +39307,6 @@ export interface paths {
                             username: string;
                             created: string;
                             updated: string;
-                            tak_phone: string;
                             last_login: string;
                             /** @description Does the user have an active CloudTAK Session */
                             active: boolean;
@@ -39409,6 +39314,7 @@ export interface paths {
                             agency_admin: number[];
                             tak_callsign: string;
                             tak_remarks: string;
+                            tak_phone: string;
                             tak_group: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
                             tak_role: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
                             tak_type: string;
@@ -41756,6 +41662,742 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/type/cot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Type */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    filter: string;
+                    /** @description No Description */
+                    domain?: "a" | "b" | "r" | "t" | "c" | "y";
+                    /** @description No Description */
+                    identity: "p" | "u" | "a" | "f" | "n" | "s" | "h" | "j" | "k" | "o";
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                cot: string;
+                                desc: string;
+                                full?: string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/type/cot/{:type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Type */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":type": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            cot: string;
+                            desc: string;
+                            full?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/user": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Let Admins see users of the system */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort: "id" | "name" | "username" | "last_login" | "auth" | "created" | "updated" | "system_admin" | "agency_admin" | "enableRLS";
+                    /** @description Filter results by a human readable name field */
+                    filter: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                username: string;
+                                created: string;
+                                updated: string;
+                                last_login: string;
+                                /** @description Does the user have an active CloudTAK Session */
+                                active: boolean;
+                                system_admin: boolean;
+                                agency_admin: number[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/user/{:username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Let Admins see a given user of the system */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":username": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            username: string;
+                            created: string;
+                            updated: string;
+                            last_login: string;
+                            /** @description Does the user have an active CloudTAK Session */
+                            active: boolean;
+                            system_admin: boolean;
+                            agency_admin: number[];
+                            tak_callsign: string;
+                            tak_remarks: string;
+                            tak_phone: string;
+                            tak_group: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
+                            tak_role: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
+                            tak_type: string;
+                            tak_loc: {
+                                /** @constant */
+                                type: "Point";
+                                coordinates: number[];
+                            } | null;
+                            tak_loc_freq: number;
+                            menu_order: {
+                                /** @description Menu Key */
+                                key: string;
+                                /**
+                                 * @description Menu Visibility
+                                 * @default full
+                                 */
+                                visibility: "full" | "partial" | "hidden";
+                            }[];
+                            display_projection: "mercator" | "globe";
+                            display_zoom: "always" | "conditional" | "never";
+                            display_style: "System Default" | "Light" | "Dark";
+                            display_coordinate: "dd" | "dm" | "dms" | "mgrs" | "utm";
+                            display_icon_rotation: boolean;
+                            display_stale: "Immediate" | "10 Minutes" | "30 Minutes" | "1 Hour" | "Never";
+                            display_text: "Small" | "Medium" | "Large";
+                            display_distance: "meter" | "kilometer" | "mile";
+                            display_elevation: "meter" | "feet";
+                            display_speed: "m/s" | "km/h" | "mi/h";
+                            display_radiation_dose: "sieverts" | "rems";
+                            geometry_point_type?: string;
+                            geometry_point_color?: string;
+                            geometry_point_icon?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update a User */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":username": string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        tak_callsign?: string;
+                        tak_remarks?: string;
+                        tak_group?: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
+                        tak_type?: string;
+                        tak_role?: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
+                        system_admin?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            username: string;
+                            created: string;
+                            updated: string;
+                            last_login: string;
+                            /** @description Does the user have an active CloudTAK Session */
+                            active: boolean;
+                            system_admin: boolean;
+                            agency_admin: number[];
+                            tak_callsign: string;
+                            tak_remarks: string;
+                            tak_phone: string;
+                            tak_group: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
+                            tak_role: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
+                            tak_type: string;
+                            tak_loc: {
+                                /** @constant */
+                                type: "Point";
+                                coordinates: number[];
+                            } | null;
+                            tak_loc_freq: number;
+                            menu_order: {
+                                /** @description Menu Key */
+                                key: string;
+                                /**
+                                 * @description Menu Visibility
+                                 * @default full
+                                 */
+                                visibility: "full" | "partial" | "hidden";
+                            }[];
+                            display_projection: "mercator" | "globe";
+                            display_zoom: "always" | "conditional" | "never";
+                            display_style: "System Default" | "Light" | "Dark";
+                            display_coordinate: "dd" | "dm" | "dms" | "mgrs" | "utm";
+                            display_icon_rotation: boolean;
+                            display_stale: "Immediate" | "10 Minutes" | "30 Minutes" | "1 Hour" | "Never";
+                            display_text: "Small" | "Medium" | "Large";
+                            display_distance: "meter" | "kilometer" | "mile";
+                            display_elevation: "meter" | "feet";
+                            display_speed: "m/s" | "km/h" | "mi/h";
+                            display_radiation_dose: "sieverts" | "rems";
+                            geometry_point_type?: string;
+                            geometry_point_color?: string;
+                            geometry_point_icon?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/user/{:username}/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Let Admins list login sessions for a given user */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort: "id" | "username" | "created" | "ip" | "device_type" | "browser" | "os" | "user_agent" | "enableRLS";
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":username": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                id: string;
+                                username: string;
+                                created: string;
+                                ip: string;
+                                device_type: string;
+                                browser: string;
+                                os: string;
+                                user_agent: string;
+                                active: boolean;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/iconset": {
         parameters: {
             query?: never;
@@ -43100,742 +43742,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/user": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Let Admins see users of the system */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort: "id" | "name" | "username" | "last_login" | "auth" | "created" | "updated" | "phone" | "system_admin" | "agency_admin" | "enableRLS";
-                    /** @description Filter results by a human readable name field */
-                    filter: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                username: string;
-                                created: string;
-                                updated: string;
-                                last_login: string;
-                                /** @description Does the user have an active CloudTAK Session */
-                                active: boolean;
-                                system_admin: boolean;
-                                agency_admin: number[];
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/user/{:username}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Let Admins see a given user of the system */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":username": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            username: string;
-                            created: string;
-                            updated: string;
-                            tak_phone: string;
-                            last_login: string;
-                            /** @description Does the user have an active CloudTAK Session */
-                            active: boolean;
-                            system_admin: boolean;
-                            agency_admin: number[];
-                            tak_callsign: string;
-                            tak_remarks: string;
-                            tak_group: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
-                            tak_role: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
-                            tak_type: string;
-                            tak_loc: {
-                                /** @constant */
-                                type: "Point";
-                                coordinates: number[];
-                            } | null;
-                            tak_loc_freq: number;
-                            menu_order: {
-                                /** @description Menu Key */
-                                key: string;
-                                /**
-                                 * @description Menu Visibility
-                                 * @default full
-                                 */
-                                visibility: "full" | "partial" | "hidden";
-                            }[];
-                            display_projection: "mercator" | "globe";
-                            display_zoom: "always" | "conditional" | "never";
-                            display_style: "System Default" | "Light" | "Dark";
-                            display_coordinate: "dd" | "dm" | "dms" | "mgrs" | "utm";
-                            display_icon_rotation: boolean;
-                            display_stale: "Immediate" | "10 Minutes" | "30 Minutes" | "1 Hour" | "Never";
-                            display_text: "Small" | "Medium" | "Large";
-                            display_distance: "meter" | "kilometer" | "mile";
-                            display_elevation: "meter" | "feet";
-                            display_speed: "m/s" | "km/h" | "mi/h";
-                            display_radiation_dose: "sieverts" | "rems";
-                            geometry_point_type?: string;
-                            geometry_point_color?: string;
-                            geometry_point_icon?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update a User */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":username": string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        tak_callsign?: string;
-                        tak_remarks?: string;
-                        tak_group?: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
-                        tak_type?: string;
-                        tak_role?: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
-                        system_admin?: boolean;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            username: string;
-                            created: string;
-                            updated: string;
-                            tak_phone: string;
-                            last_login: string;
-                            /** @description Does the user have an active CloudTAK Session */
-                            active: boolean;
-                            system_admin: boolean;
-                            agency_admin: number[];
-                            tak_callsign: string;
-                            tak_remarks: string;
-                            tak_group: "White" | "Yellow" | "Orange" | "Magenta" | "Red" | "Maroon" | "Purple" | "Dark Blue" | "Blue" | "Cyan" | "Teal" | "Green" | "Dark Green" | "Brown";
-                            tak_role: "Team Member" | "Team Lead" | "HQ" | "Sniper" | "Medic" | "Forward Observer" | "RTO" | "K9";
-                            tak_type: string;
-                            tak_loc: {
-                                /** @constant */
-                                type: "Point";
-                                coordinates: number[];
-                            } | null;
-                            tak_loc_freq: number;
-                            menu_order: {
-                                /** @description Menu Key */
-                                key: string;
-                                /**
-                                 * @description Menu Visibility
-                                 * @default full
-                                 */
-                                visibility: "full" | "partial" | "hidden";
-                            }[];
-                            display_projection: "mercator" | "globe";
-                            display_zoom: "always" | "conditional" | "never";
-                            display_style: "System Default" | "Light" | "Dark";
-                            display_coordinate: "dd" | "dm" | "dms" | "mgrs" | "utm";
-                            display_icon_rotation: boolean;
-                            display_stale: "Immediate" | "10 Minutes" | "30 Minutes" | "1 Hour" | "Never";
-                            display_text: "Small" | "Medium" | "Large";
-                            display_distance: "meter" | "kilometer" | "mile";
-                            display_elevation: "meter" | "feet";
-                            display_speed: "m/s" | "km/h" | "mi/h";
-                            display_radiation_dose: "sieverts" | "rems";
-                            geometry_point_type?: string;
-                            geometry_point_color?: string;
-                            geometry_point_icon?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/user/{:username}/session": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Let Admins list login sessions for a given user */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort: "id" | "username" | "created" | "ip" | "device_type" | "browser" | "os" | "user_agent" | "enableRLS";
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":username": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                id: string;
-                                username: string;
-                                created: string;
-                                ip: string;
-                                device_type: string;
-                                browser: string;
-                                os: string;
-                                user_agent: string;
-                                active: boolean;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/type/cot": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Type */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    filter: string;
-                    /** @description No Description */
-                    domain?: "a" | "b" | "r" | "t" | "c" | "y";
-                    /** @description No Description */
-                    identity: "p" | "u" | "a" | "f" | "n" | "s" | "h" | "j" | "k" | "o";
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                cot: string;
-                                desc: string;
-                                full?: string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/type/cot/{:type}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Type */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":type": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            cot: string;
-                            desc: string;
-                            full?: string;
-                        };
-                    };
                 };
                 /** @description Error Response */
                 400: {

--- a/api/derived-types.d.ts
+++ b/api/derived-types.d.ts
@@ -24245,197 +24245,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/api/files/{:hash}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Helper API to download files by file hash */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description No Description */
-                    name?: string;
-                    /** @description No Description */
-                    token?: string;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":hash": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Helper API to delete files by file hash */
-        delete: {
-            parameters: {
-                query?: {
-                    /** @description No Description */
-                    token?: string;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":hash": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/manifest.webmanifest": {
         parameters: {
             query?: never;
@@ -24641,6 +24450,197 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/marti/api/files/{:hash}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Helper API to download files by file hash */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description No Description */
+                    name?: string;
+                    /** @description No Description */
+                    token?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":hash": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Helper API to delete files by file hash */
+        delete: {
+            parameters: {
+                query?: {
+                    /** @description No Description */
+                    token?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":hash": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -39816,6 +39816,114 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/retention": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run a retention action */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        action: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            name: string;
+                            status: "success" | "error";
+                            deleted: number;
+                            duration: number;
+                            message?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/server/repeater": {
         parameters: {
             query?: never;
@@ -40019,114 +40127,6 @@ export interface paths {
                 };
             };
         };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/retention": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Run a retention action */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        action: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            name: string;
-                            status: "success" | "error";
-                            deleted: number;
-                            duration: number;
-                            message?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -42398,6 +42398,1281 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/video/auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Authenticate a request to view a lease */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        user: string;
+                        password: string;
+                        ip: string;
+                        action: "publish" | "read" | "playback" | "api" | "metrics" | "pprof";
+                        path: string;
+                        protocol: string;
+                        id: null | string;
+                        query: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Return information about an active lease given read credentials
+         *
+         *                 If a user has a valid read URL, the API endpoint will allow an authenticated user
+         *                 to get metadata to agument the video stream itself
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    url: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description If a lease request is made, is it likely to succeed */
+                            leasable: boolean;
+                            message?: string;
+                            metadata?: {
+                                name: string;
+                                username: null | string;
+                                active: boolean;
+                                watchers: number;
+                                source_id?: null | string;
+                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                                source_model: string;
+                                protocols: {
+                                    rtmp?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    rtsp?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    webrtc?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    hls?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    srt?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/lease": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all video leases */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    impersonate?: boolean | string;
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort: "id" | "name" | "created" | "updated" | "username" | "connection" | "layer" | "source_id" | "source_type" | "source_model" | "publish" | "recording" | "share" | "ephemeral" | "channel" | "expiration" | "path" | "stream_user" | "stream_pass" | "read_user" | "read_pass" | "proxy" | "enableRLS";
+                    /** @description No Description */
+                    expired: "true" | "false" | "all";
+                    /** @description No Description */
+                    ephemeral: "true" | "false" | "all";
+                    /** @description Filter results by a human readable name field */
+                    filter: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                id: number;
+                                name: string;
+                                created: string;
+                                updated: string;
+                                username: string | null;
+                                connection: number | null;
+                                layer: number | null;
+                                source_id: string | null;
+                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                                source_model: string;
+                                publish: boolean;
+                                recording: boolean;
+                                share: boolean;
+                                ephemeral: boolean;
+                                channel: null | string;
+                                expiration: null | string;
+                                path: string;
+                                stream_user: string | null;
+                                stream_pass: string | null;
+                                read_user: string | null;
+                                read_pass: string | null;
+                                proxy: null | string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a new video Lease */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Human readable name */
+                        name: string;
+                        /**
+                         * @description CloudTAK View lease - hidden in streaming list
+                         * @default false
+                         */
+                        ephemeral: boolean;
+                        /**
+                         * @description Duration in Seconds
+                         * @default 3600
+                         */
+                        duration: number;
+                        /**
+                         * @description System Admins can create non-expiring leases
+                         * @default false
+                         */
+                        permanent: boolean;
+                        /**
+                         * @description Record streams to disk
+                         * @default false
+                         */
+                        recording: boolean;
+                        /**
+                         * @description Publish stream URL to TAK Server Video Manager
+                         * @default false
+                         */
+                        publish: boolean;
+                        /**
+                         * @description Allow other users to manage lease if they are also members of the channel
+                         * @default false
+                         */
+                        share: boolean;
+                        /**
+                         * @description Increase stream security by enforcing a seperate read and write username/password
+                         * @default false
+                         */
+                        secure: boolean;
+                        source_id?: null | string;
+                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                        source_model?: string;
+                        channel?: null | string;
+                        proxy?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            name: string;
+                            created: string;
+                            updated: string;
+                            username: string | null;
+                            connection: number | null;
+                            layer: number | null;
+                            source_id: string | null;
+                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                            source_model: string;
+                            publish: boolean;
+                            recording: boolean;
+                            share: boolean;
+                            ephemeral: boolean;
+                            channel: null | string;
+                            expiration: null | string;
+                            path: string;
+                            stream_user: string | null;
+                            stream_pass: string | null;
+                            read_user: string | null;
+                            read_pass: string | null;
+                            proxy: null | string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/lease/{:lease}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single Video Lease */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number | string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            name: string;
+                            created: string;
+                            updated: string;
+                            username: string | null;
+                            connection: number | null;
+                            layer: number | null;
+                            source_id: string | null;
+                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                            source_model: string;
+                            publish: boolean;
+                            recording: boolean;
+                            share: boolean;
+                            ephemeral: boolean;
+                            channel: null | string;
+                            expiration: null | string;
+                            path: string;
+                            stream_user: string | null;
+                            stream_pass: string | null;
+                            read_user: string | null;
+                            read_pass: string | null;
+                            proxy: null | string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete a video Lease */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update a video Lease */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        /**
+                         * @description Duration in Seconds
+                         * @default 3600
+                         */
+                        duration: number;
+                        source_id?: null | string;
+                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                        source_model?: string;
+                        channel?: null | string;
+                        secure?: boolean;
+                        /** @description Record streams to disk */
+                        recording?: boolean;
+                        /** @description Publish stream URL to TAK Server Video Manager */
+                        publish?: boolean;
+                        /** @description Allow other users to manage lease if they are also members of the channel */
+                        share?: boolean;
+                        /** @description System Admins can create non-expiring leases */
+                        permanent?: boolean;
+                        proxy?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            name: string;
+                            created: string;
+                            updated: string;
+                            username: string | null;
+                            connection: number | null;
+                            layer: number | null;
+                            source_id: string | null;
+                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                            source_model: string;
+                            publish: boolean;
+                            recording: boolean;
+                            share: boolean;
+                            ephemeral: boolean;
+                            channel: null | string;
+                            expiration: null | string;
+                            path: string;
+                            stream_user: string | null;
+                            stream_pass: string | null;
+                            read_user: string | null;
+                            read_pass: string | null;
+                            proxy: null | string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/video/lease/{:lease}/metadata": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single Video Lease Metadata */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number | string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            path?: {
+                                name: string;
+                                confName: string;
+                                source: {
+                                    id: string;
+                                    type: string;
+                                } | null;
+                                ready: boolean;
+                                readyTime: null | string;
+                                tracks: string[];
+                                bytesReceived: number;
+                                bytesSent: number;
+                                readers: {
+                                    type: string;
+                                    id: string;
+                                }[];
+                            };
+                            protocols: {
+                                rtmp?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                rtsp?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                webrtc?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                hls?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                srt?: {
+                                    name: string;
+                                    url: string;
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/service": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Video Service Configuration */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            configured: boolean;
+                            url?: string;
+                            external?: string;
+                            config?: {
+                                api: boolean;
+                                apiAddress: string;
+                                metrics: boolean;
+                                metricsAddress: string;
+                                pprof: boolean;
+                                pprofAddress: string;
+                                playback: boolean;
+                                playbackAddress: string;
+                                rtsp: boolean;
+                                rtspAddress: string;
+                                rtspsAddress: string;
+                                rtspAuthMethods: string[];
+                                rtmp: boolean;
+                                rtmpAddress: string;
+                                rtmpsAddress: string;
+                                hls: boolean;
+                                hlsAddress: string;
+                                webrtc: boolean;
+                                webrtcAddress: string;
+                                srt: boolean;
+                                srtAddress: string;
+                            };
+                            paths?: {
+                                name: string;
+                                confName: string;
+                                source: {
+                                    id: string;
+                                    type: string;
+                                } | null;
+                                ready: boolean;
+                                readyTime: null | string;
+                                tracks: string[];
+                                bytesReceived: number;
+                                bytesSent: number;
+                                readers: {
+                                    type: string;
+                                    id: string;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/service/path/{:path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get information about a given path */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":path": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            path: {
+                                name: string;
+                                confName: string;
+                                source: {
+                                    id: string;
+                                    type: string;
+                                } | null;
+                                ready: boolean;
+                                readyTime: null | string;
+                                tracks: string[];
+                                bytesReceived: number;
+                                bytesSent: number;
+                                readers: {
+                                    type: string;
+                                    id: string;
+                                }[];
+                            };
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/iconset": {
         parameters: {
             query?: never;
@@ -43742,1281 +45017,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/auth": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Authenticate a request to view a lease */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        user: string;
-                        password: string;
-                        ip: string;
-                        action: "publish" | "read" | "playback" | "api" | "metrics" | "pprof";
-                        path: string;
-                        protocol: string;
-                        id: null | string;
-                        query: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/active": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Return information about an active lease given read credentials
-         *
-         *                 If a user has a valid read URL, the API endpoint will allow an authenticated user
-         *                 to get metadata to agument the video stream itself
-         */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    url: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @description If a lease request is made, is it likely to succeed */
-                            leasable: boolean;
-                            message?: string;
-                            metadata?: {
-                                name: string;
-                                username: null | string;
-                                active: boolean;
-                                watchers: number;
-                                source_id?: null | string;
-                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                                source_model: string;
-                                protocols: {
-                                    rtmp?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    rtsp?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    webrtc?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    hls?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    srt?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                };
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/lease": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List all video leases */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    impersonate?: boolean | string;
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort: "id" | "name" | "created" | "updated" | "username" | "connection" | "layer" | "source_id" | "source_type" | "source_model" | "publish" | "recording" | "share" | "ephemeral" | "channel" | "expiration" | "path" | "stream_user" | "stream_pass" | "read_user" | "read_pass" | "proxy" | "enableRLS";
-                    /** @description No Description */
-                    expired: "true" | "false" | "all";
-                    /** @description No Description */
-                    ephemeral: "true" | "false" | "all";
-                    /** @description Filter results by a human readable name field */
-                    filter: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                id: number;
-                                name: string;
-                                created: string;
-                                updated: string;
-                                username: string | null;
-                                connection: number | null;
-                                layer: number | null;
-                                source_id: string | null;
-                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                                source_model: string;
-                                publish: boolean;
-                                recording: boolean;
-                                share: boolean;
-                                ephemeral: boolean;
-                                channel: null | string;
-                                expiration: null | string;
-                                path: string;
-                                stream_user: string | null;
-                                stream_pass: string | null;
-                                read_user: string | null;
-                                read_pass: string | null;
-                                proxy: null | string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create a new video Lease */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @description Human readable name */
-                        name: string;
-                        /**
-                         * @description CloudTAK View lease - hidden in streaming list
-                         * @default false
-                         */
-                        ephemeral: boolean;
-                        /**
-                         * @description Duration in Seconds
-                         * @default 3600
-                         */
-                        duration: number;
-                        /**
-                         * @description System Admins can create non-expiring leases
-                         * @default false
-                         */
-                        permanent: boolean;
-                        /**
-                         * @description Record streams to disk
-                         * @default false
-                         */
-                        recording: boolean;
-                        /**
-                         * @description Publish stream URL to TAK Server Video Manager
-                         * @default false
-                         */
-                        publish: boolean;
-                        /**
-                         * @description Allow other users to manage lease if they are also members of the channel
-                         * @default false
-                         */
-                        share: boolean;
-                        /**
-                         * @description Increase stream security by enforcing a seperate read and write username/password
-                         * @default false
-                         */
-                        secure: boolean;
-                        source_id?: null | string;
-                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                        source_model?: string;
-                        channel?: null | string;
-                        proxy?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            username: string | null;
-                            connection: number | null;
-                            layer: number | null;
-                            source_id: string | null;
-                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                            source_model: string;
-                            publish: boolean;
-                            recording: boolean;
-                            share: boolean;
-                            ephemeral: boolean;
-                            channel: null | string;
-                            expiration: null | string;
-                            path: string;
-                            stream_user: string | null;
-                            stream_pass: string | null;
-                            read_user: string | null;
-                            read_pass: string | null;
-                            proxy: null | string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/lease/{:lease}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single Video Lease */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number | string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            username: string | null;
-                            connection: number | null;
-                            layer: number | null;
-                            source_id: string | null;
-                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                            source_model: string;
-                            publish: boolean;
-                            recording: boolean;
-                            share: boolean;
-                            ephemeral: boolean;
-                            channel: null | string;
-                            expiration: null | string;
-                            path: string;
-                            stream_user: string | null;
-                            stream_pass: string | null;
-                            read_user: string | null;
-                            read_pass: string | null;
-                            proxy: null | string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete a video Lease */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update a video Lease */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        name?: string;
-                        /**
-                         * @description Duration in Seconds
-                         * @default 3600
-                         */
-                        duration: number;
-                        source_id?: null | string;
-                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                        source_model?: string;
-                        channel?: null | string;
-                        secure?: boolean;
-                        /** @description Record streams to disk */
-                        recording?: boolean;
-                        /** @description Publish stream URL to TAK Server Video Manager */
-                        publish?: boolean;
-                        /** @description Allow other users to manage lease if they are also members of the channel */
-                        share?: boolean;
-                        /** @description System Admins can create non-expiring leases */
-                        permanent?: boolean;
-                        proxy?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            username: string | null;
-                            connection: number | null;
-                            layer: number | null;
-                            source_id: string | null;
-                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                            source_model: string;
-                            publish: boolean;
-                            recording: boolean;
-                            share: boolean;
-                            ephemeral: boolean;
-                            channel: null | string;
-                            expiration: null | string;
-                            path: string;
-                            stream_user: string | null;
-                            stream_pass: string | null;
-                            read_user: string | null;
-                            read_pass: string | null;
-                            proxy: null | string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/video/lease/{:lease}/metadata": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single Video Lease Metadata */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number | string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            path?: {
-                                name: string;
-                                confName: string;
-                                source: {
-                                    id: string;
-                                    type: string;
-                                } | null;
-                                ready: boolean;
-                                readyTime: null | string;
-                                tracks: string[];
-                                bytesReceived: number;
-                                bytesSent: number;
-                                readers: {
-                                    type: string;
-                                    id: string;
-                                }[];
-                            };
-                            protocols: {
-                                rtmp?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                rtsp?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                webrtc?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                hls?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                srt?: {
-                                    name: string;
-                                    url: string;
-                                };
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/service": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Video Service Configuration */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            configured: boolean;
-                            url?: string;
-                            external?: string;
-                            config?: {
-                                api: boolean;
-                                apiAddress: string;
-                                metrics: boolean;
-                                metricsAddress: string;
-                                pprof: boolean;
-                                pprofAddress: string;
-                                playback: boolean;
-                                playbackAddress: string;
-                                rtsp: boolean;
-                                rtspAddress: string;
-                                rtspsAddress: string;
-                                rtspAuthMethods: string[];
-                                rtmp: boolean;
-                                rtmpAddress: string;
-                                rtmpsAddress: string;
-                                hls: boolean;
-                                hlsAddress: string;
-                                webrtc: boolean;
-                                webrtcAddress: string;
-                                srt: boolean;
-                                srtAddress: string;
-                            };
-                            paths?: {
-                                name: string;
-                                confName: string;
-                                source: {
-                                    id: string;
-                                    type: string;
-                                } | null;
-                                ready: boolean;
-                                readyTime: null | string;
-                                tracks: string[];
-                                bytesReceived: number;
-                                bytesSent: number;
-                                readers: {
-                                    type: string;
-                                    id: string;
-                                }[];
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/service/path/{:path}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get information about a given path */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":path": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            path: {
-                                name: string;
-                                confName: string;
-                                source: {
-                                    id: string;
-                                    type: string;
-                                } | null;
-                                ready: boolean;
-                                readyTime: null | string;
-                                tracks: string[];
-                                bytesReceived: number;
-                                bytesSent: number;
-                                readers: {
-                                    type: string;
-                                    id: string;
-                                }[];
-                            };
-                        };
-                    };
                 };
                 /** @description Error Response */
                 400: {

--- a/api/index.ts
+++ b/api/index.ts
@@ -17,24 +17,46 @@ type CliArgs = {
     noevents?: boolean;
     nosinks?: boolean;
     nogeofence?: boolean;
+    noconnections?: boolean;
     postgres?: string;
     env?: string;
 };
 
-const { values: args } = parseArgs({
+const { values: parsedArgs } = parseArgs({
     args: process.argv.slice(2),
     options: {
-        silent: { type: 'boolean' }, // Turn off logging as much as possible
-        nocache: { type: 'boolean' }, // Ignore MemCached
-        noevents: { type: 'boolean' }, // Disable Initialization of Second Level Events
-        nosinks: { type: 'boolean' }, // Disable Push to Sinks
-        nogeofence: { type: 'boolean' }, // Disable Geofence Server Integration
-        postgres: { type: 'string' }, // Postgres Connection String
-        env: { type: 'string' }, // Load a non-default .env file --env local would read .env-local
+        'silent': { type: 'boolean' }, // Turn off logging as much as possible
+        'no-cache': { type: 'boolean' }, // Ignore MemCached
+        'no-events': { type: 'boolean' }, // Disable Initialization of Second Level Events
+        'no-sinks': { type: 'boolean' }, // Disable Push to Sinks
+        'no-geofence': { type: 'boolean' }, // Disable Geofence Server Integration
+        'no-connections': { type: 'boolean' }, // Disable Automatic Initialization of ETL Connections
+        'postgres': { type: 'string' }, // Postgres Connection String
+        'env': { type: 'string' }, // Load a non-default .env file --env local would read .env-local
     },
     allowPositionals: true,
     strict: false,
-}) as { values: CliArgs };
+}) as { values: {
+    'silent'?: boolean;
+    'no-cache'?: boolean;
+    'no-events'?: boolean;
+    'no-sinks'?: boolean;
+    'no-geofence'?: boolean;
+    'no-connections'?: boolean;
+    'postgres'?: string;
+    'env'?: string;
+}; };
+
+const args: CliArgs = {
+    silent: parsedArgs.silent,
+    nocache: parsedArgs['no-cache'],
+    noevents: parsedArgs['no-events'],
+    nosinks: parsedArgs['no-sinks'],
+    nogeofence: parsedArgs['no-geofence'],
+    noconnections: parsedArgs['no-connections'],
+    postgres: parsedArgs.postgres,
+    env: parsedArgs.env,
+};
 
 const pkg = JSON.parse(String(fs.readFileSync(new URL('./package.json', import.meta.url))));
 
@@ -68,6 +90,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         postgres: process.env.POSTGRES || args.postgres || 'postgres://postgres@localhost:5432/tak_ps_etl',
         nosinks: args.nosinks || false,
         nogeofence: args.nogeofence || false,
+        noconnections: args.noconnections || false,
         nocache: args.nocache || false,
     };
 

--- a/api/migrations/0177_session_uuid.sql
+++ b/api/migrations/0177_session_uuid.sql
@@ -1,6 +1,6 @@
 DO $$
 BEGIN
-    IF (SELECT data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'profile_sessions' AND column_name = 'id') != 'uuid' THEN
+    IF (SELECT data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'profile_sessions' AND column_name = 'id') IS DISTINCT FROM 'uuid' THEN
         ALTER TABLE "profile_sessions" DROP CONSTRAINT "profile_sessions_pkey";
         ALTER TABLE "profile_sessions" DROP COLUMN "id";
         ALTER TABLE "profile_sessions" ADD COLUMN "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL;

--- a/api/migrations/0177_session_uuid.sql
+++ b/api/migrations/0177_session_uuid.sql
@@ -1,3 +1,8 @@
-ALTER TABLE "profile_sessions" DROP CONSTRAINT "profile_sessions_pkey";--> statement-breakpoint
-ALTER TABLE "profile_sessions" DROP COLUMN "id";--> statement-breakpoint
-ALTER TABLE "profile_sessions" ADD COLUMN "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL;
+DO $$
+BEGIN
+    IF (SELECT data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'profile_sessions' AND column_name = 'id') != 'uuid' THEN
+        ALTER TABLE "profile_sessions" DROP CONSTRAINT "profile_sessions_pkey";
+        ALTER TABLE "profile_sessions" DROP COLUMN "id";
+        ALTER TABLE "profile_sessions" ADD COLUMN "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL;
+    END IF;
+END $$;

--- a/api/migrations/0183_profile_phone_to_config.sql
+++ b/api/migrations/0183_profile_phone_to_config.sql
@@ -1,6 +1,12 @@
-INSERT INTO "profile_settings" ("username", "key", "value", "updated")
-    SELECT "username", 'tak::phone', "phone", Now()
-        FROM "profile"
-        WHERE "phone" IS NOT NULL AND "phone" != ''
-ON CONFLICT ("username", "key") DO UPDATE SET "value" = EXCLUDED."value", "updated" = EXCLUDED."updated";--> statement-breakpoint
-ALTER TABLE "profile" DROP COLUMN "phone";
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'profile' AND column_name = 'phone') THEN
+        INSERT INTO "profile_settings" ("username", "key", "value", "updated")
+            SELECT "username", 'tak::phone', "phone", Now()
+                FROM "profile"
+                WHERE "phone" IS NOT NULL AND "phone" != ''
+        ON CONFLICT ("username", "key") DO UPDATE SET "value" = EXCLUDED."value", "updated" = EXCLUDED."updated";
+
+        ALTER TABLE "profile" DROP COLUMN "phone";
+    END IF;
+END $$;

--- a/api/migrations/0184_core_event.sql
+++ b/api/migrations/0184_core_event.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "core_event" (
+CREATE TABLE IF NOT EXISTS "core_event" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"created" timestamp with time zone DEFAULT Now() NOT NULL,
 	"updated" timestamp with time zone DEFAULT Now() NOT NULL,
@@ -14,11 +14,19 @@ CREATE TABLE "core_event" (
 	"geometry" GEOMETRY(POINT, 4326) NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "core_event_channel" (
+CREATE TABLE IF NOT EXISTS "core_event_channel" (
 	"event" uuid NOT NULL,
 	"channel" bigint NOT NULL,
 	CONSTRAINT "core_event_channel_event_channel_pk" PRIMARY KEY("event","channel")
 );
 --> statement-breakpoint
-ALTER TABLE "core_event" ADD CONSTRAINT "core_event_username_profile_username_fk" FOREIGN KEY ("username") REFERENCES "public"."profile"("username") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "core_event_channel" ADD CONSTRAINT "core_event_channel_event_core_event_id_fk" FOREIGN KEY ("event") REFERENCES "public"."core_event"("id") ON DELETE cascade ON UPDATE no action;
+DO $$ BEGIN
+ ALTER TABLE "core_event" ADD CONSTRAINT "core_event_username_profile_username_fk" FOREIGN KEY ("username") REFERENCES "public"."profile"("username") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "core_event_channel" ADD CONSTRAINT "core_event_channel_event_core_event_id_fk" FOREIGN KEY ("event") REFERENCES "public"."core_event"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/api/migrations/0185_core_event_connection.sql
+++ b/api/migrations/0185_core_event_connection.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "core_event" ADD COLUMN "connection" integer;--> statement-breakpoint
+ALTER TABLE "core_event" ADD CONSTRAINT "core_event_connection_connections_id_fk" FOREIGN KEY ("connection") REFERENCES "public"."connections"("id") ON DELETE set null ON UPDATE no action;

--- a/api/migrations/0185_core_event_connection.sql
+++ b/api/migrations/0185_core_event_connection.sql
@@ -1,2 +1,6 @@
-ALTER TABLE "core_event" ADD COLUMN "connection" integer;--> statement-breakpoint
-ALTER TABLE "core_event" ADD CONSTRAINT "core_event_connection_connections_id_fk" FOREIGN KEY ("connection") REFERENCES "public"."connections"("id") ON DELETE set null ON UPDATE no action;
+ALTER TABLE "core_event" ADD COLUMN IF NOT EXISTS "connection" integer;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "core_event" ADD CONSTRAINT "core_event_connection_connections_id_fk" FOREIGN KEY ("connection") REFERENCES "public"."connections"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/api/migrations/0186_connection_name_unique.sql
+++ b/api/migrations/0186_connection_name_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "connections" ADD CONSTRAINT "connections_name_unique" UNIQUE("name");

--- a/api/migrations/meta/0185_snapshot.json
+++ b/api/migrations/meta/0185_snapshot.json
@@ -1,0 +1,3918 @@
+{
+  "id": "6acd17b8-940a-4a8e-81cf-ff7d9e92b40a",
+  "prevId": "1304fb99-246d-4cd6-a22a-8fd0df864d59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.basemaps": {
+      "name": "basemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "parent": {
+          "name": "parent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zxy'"
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minzoom": {
+          "name": "minzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxzoom": {
+          "name": "maxzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 16
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'png'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raster'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_enabled": {
+          "name": "sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharing_token": {
+          "name": "sharing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tilesize": {
+          "name": "tilesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 256
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xyz'"
+        },
+        "overlay": {
+          "name": "overlay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tilejson": {
+          "name": "tilejson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "basemaps_username_idx": {
+          "name": "basemaps_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "basemaps_parent_basemaps_id_fk": {
+          "name": "basemaps_parent_basemaps_id_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "parent"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "basemaps_username_profile_username_fk": {
+          "name": "basemaps_username_profile_username_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_raster": {
+      "name": "basemaps_raster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_raster_basemap_basemaps_id_fk": {
+          "name": "basemaps_raster_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_raster",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_raster_basemap_unique": {
+          "name": "basemaps_raster_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_source": {
+      "name": "basemaps_source",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_terrain": {
+      "name": "basemaps_terrain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mapbox'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_terrain_basemap_basemaps_id_fk": {
+          "name": "basemaps_terrain_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_terrain",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_terrain_basemap_unique": {
+          "name": "basemaps_terrain_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_vector": {
+      "name": "basemaps_vector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapping_enabled": {
+          "name": "snapping_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'callsign'"
+        },
+        "snapping_layer": {
+          "name": "snapping_layer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_vector_basemap_basemaps_id_fk": {
+          "name": "basemaps_vector_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_vector",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "basemaps_vector_iconset_iconsets_uid_fk": {
+          "name": "basemaps_vector_iconset_iconsets_uid_fk",
+          "tableFrom": "basemaps_vector",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_vector_basemap_unique": {
+          "name": "basemaps_vector_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "readonly": {
+          "name": "readonly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency": {
+          "name": "agency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "features": {
+          "name": "features",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_username_profile_username_fk": {
+          "name": "connections_username_profile_username_fk",
+          "tableFrom": "connections",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_features": {
+      "name": "connection_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_geofence": {
+          "name": "enabled_geofence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::JSONB"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRYZ, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_features_connection_idx": {
+          "name": "connection_features_connection_idx",
+          "columns": [
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_features_connection_layer_idx": {
+          "name": "connection_features_connection_layer_idx",
+          "columns": [
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_features_layer_layers_id_fk": {
+          "name": "connection_features_layer_layers_id_fk",
+          "tableFrom": "connection_features",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connection_features_connection_connections_id_fk": {
+          "name": "connection_features_connection_connections_id_fk",
+          "tableFrom": "connection_features",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connection_features_connection_id_pk": {
+          "name": "connection_features_connection_id_pk",
+          "columns": [
+            "connection",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_tokens": {
+      "name": "connection_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_tokens_connection_connections_id_fk": {
+          "name": "connection_tokens_connection_connections_id_fk",
+          "tableFrom": "connection_tokens",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_event": {
+      "name": "core_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "ended": {
+          "name": "ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "editable": {
+          "name": "editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "core_event_username_profile_username_fk": {
+          "name": "core_event_username_profile_username_fk",
+          "tableFrom": "core_event",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "core_event_connection_connections_id_fk": {
+          "name": "core_event_connection_connections_id_fk",
+          "tableFrom": "core_event",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_event_channel": {
+      "name": "core_event_channel",
+      "schema": "",
+      "columns": {
+        "event": {
+          "name": "event",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "core_event_channel_event_core_event_id_fk": {
+          "name": "core_event_channel_event_core_event_id_fk",
+          "tableFrom": "core_event_channel",
+          "tableTo": "core_event",
+          "columnsFrom": [
+            "event"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "core_event_channel_event_channel_pk": {
+          "name": "core_event_channel_event_channel_pk",
+          "columns": [
+            "event",
+            "channel"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_incident": {
+      "name": "core_incident",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data": {
+      "name": "data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "mission_sync": {
+          "name": "mission_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_diff": {
+          "name": "mission_diff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_role": {
+          "name": "mission_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MISSION_SUBSCRIBER'"
+        },
+        "mission_token": {
+          "name": "mission_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission_groups": {
+          "name": "mission_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "assets": {
+          "name": "assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::jsonb"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "data_username_profile_username_fk": {
+          "name": "data_username_profile_username_fk",
+          "tableFrom": "data",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "data_connection_connections_id_fk": {
+          "name": "data_connection_connections_id_fk",
+          "tableFrom": "data",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.errors": {
+      "name": "errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace": {
+          "name": "trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "errors_username_profile_username_fk": {
+          "name": "errors_username_profile_username_fk",
+          "tableFrom": "errors",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "errors_session_id_profile_sessions_id_fk": {
+          "name": "errors_session_id_profile_sessions_id_fk",
+          "tableFrom": "errors",
+          "tableTo": "profile_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fusion_type": {
+      "name": "fusion_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.icons": {
+      "name": "icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type2525b": {
+          "name": "type2525b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "icons_iconset_iconsets_uid_fk": {
+          "name": "icons_iconset_iconsets_uid_fk",
+          "tableFrom": "icons",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.iconsets": {
+      "name": "iconsets",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_internal": {
+          "name": "username_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_friendly": {
+          "name": "default_friendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hostile": {
+          "name": "default_hostile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_neutral": {
+          "name": "default_neutral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_unknown": {
+          "name": "default_unknown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_resize": {
+          "name": "skip_resize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spritesheet_data": {
+          "name": "spritesheet_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spritesheet_json": {
+          "name": "spritesheet_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "iconsets_username_idx": {
+          "name": "iconsets_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iconsets_username_profile_username_fk": {
+          "name": "iconsets_username_profile_username_fk",
+          "tableFrom": "iconsets",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imports": {
+      "name": "imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Upload'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "imports_username_profile_username_fk": {
+          "name": "imports_username_profile_username_fk",
+          "tableFrom": "imports",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_result": {
+      "name": "import_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "import": {
+          "name": "import",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_result_import_imports_id_fk": {
+          "name": "import_result_import_imports_id_fk",
+          "tableFrom": "import_result",
+          "tableTo": "imports",
+          "columnsFrom": [
+            "import"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers": {
+      "name": "layers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "template": {
+          "name": "template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logging": {
+          "name": "logging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory": {
+          "name": "memory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 256
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "alarm_period": {
+          "name": "alarm_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "alarm_evals": {
+          "name": "alarm_evals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "alarm_points": {
+          "name": "alarm_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_username_profile_username_fk": {
+          "name": "layers_username_profile_username_fk",
+          "tableFrom": "layers",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_connection_connections_id_fk": {
+          "name": "layers_connection_connections_id_fk",
+          "tableFrom": "layers",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "layers_connection_name_unique": {
+          "name": "layers_connection_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connection",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers_incoming": {
+      "name": "layers_incoming",
+      "schema": "",
+      "columns": {
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhooks": {
+          "name": "webhooks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled_styles": {
+          "name": "enabled_styles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_incoming_layer_layers_id_fk": {
+          "name": "layers_incoming_layer_layers_id_fk",
+          "tableFrom": "layers_incoming",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_incoming_data_data_id_fk": {
+          "name": "layers_incoming_data_data_id_fk",
+          "tableFrom": "layers_incoming",
+          "tableTo": "data",
+          "columnsFrom": [
+            "data"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers_outgoing": {
+      "name": "layers_outgoing",
+      "schema": "",
+      "columns": {
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_outgoing_layer_layers_id_fk": {
+          "name": "layers_outgoing_layer_layers_id_fk",
+          "tableFrom": "layers_outgoing",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_template": {
+      "name": "mission_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_template_log": {
+      "name": "mission_template_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "template": {
+          "name": "template",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mission_template_log_template_mission_template_id_fk": {
+          "name": "mission_template_log_template_mission_template_id_fk",
+          "tableFrom": "mission_template_log",
+          "tableTo": "mission_template",
+          "columnsFrom": [
+            "template"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.palette_feature": {
+      "name": "palette_feature",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "palette_feature_template_mission_template_id_fk": {
+          "name": "palette_feature_template_mission_template_id_fk",
+          "tableFrom": "palette_feature",
+          "tableTo": "mission_template",
+          "columnsFrom": [
+            "template"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Unknown'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "system_admin": {
+          "name": "system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency_admin": {
+          "name": "agency_admin",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_chats": {
+      "name": "profile_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chatroom": {
+          "name": "chatroom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_callsign": {
+          "name": "sender_callsign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_uid": {
+          "name": "sender_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chats_username_profile_username_fk": {
+          "name": "profile_chats_username_profile_username_fk",
+          "tableFrom": "profile_chats",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_chatroom": {
+      "name": "profile_chatroom",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chatroom_username_profile_username_fk": {
+          "name": "profile_chatroom_username_profile_username_fk",
+          "tableFrom": "profile_chatroom",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_features": {
+      "name": "profile_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_geofence": {
+          "name": "enabled_geofence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::JSONB"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRYZ, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_features_username_idx": {
+          "name": "profile_features_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_features_username_profile_username_fk": {
+          "name": "profile_features_username_profile_username_fk",
+          "tableFrom": "profile_features",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_features_username_id_pk": {
+          "name": "profile_features_username_id_pk",
+          "columns": [
+            "username",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_files": {
+      "name": "profile_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_files_username_profile_username_fk": {
+          "name": "profile_files_username_profile_username_fk",
+          "tableFrom": "profile_files",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_files_iconset_iconsets_uid_fk": {
+          "name": "profile_files_iconset_iconsets_uid_fk",
+          "tableFrom": "profile_files",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_file_channel": {
+      "name": "profile_file_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "file": {
+          "name": "file",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_file_channel_file_profile_files_id_fk": {
+          "name": "profile_file_channel_file_profile_files_id_fk",
+          "tableFrom": "profile_file_channel",
+          "tableTo": "profile_files",
+          "columnsFrom": [
+            "file"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_file_channel_file_channel_unique": {
+          "name": "profile_file_channel_file_channel_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file",
+            "channel"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_fusion": {
+      "name": "profile_fusion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fusion": {
+          "name": "fusion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_fusion_username_profile_username_fk": {
+          "name": "profile_fusion_username_profile_username_fk",
+          "tableFrom": "profile_fusion",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_fusion_fusion_fusion_type_id_fk": {
+          "name": "profile_fusion_fusion_fusion_type_id_fk",
+          "tableFrom": "profile_fusion",
+          "tableTo": "fusion_type",
+          "columnsFrom": [
+            "fusion"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_interests": {
+      "name": "profile_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_interests_username_profile_username_fk": {
+          "name": "profile_interests_username_profile_username_fk",
+          "tableFrom": "profile_interests",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_overlays": {
+      "name": "profile_overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "pos": {
+          "name": "pos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vector'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_overlays_username_profile_username_fk": {
+          "name": "profile_overlays_username_profile_username_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_overlays_iconset_iconsets_uid_fk": {
+          "name": "profile_overlays_iconset_iconsets_uid_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_overlays_username_url_unique": {
+          "name": "profile_overlays_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_paging": {
+      "name": "profile_paging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_paging_username_profile_username_fk": {
+          "name": "profile_paging_username_profile_username_fk",
+          "tableFrom": "profile_paging",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_passkeys": {
+      "name": "profile_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_passkeys_username_profile_username_fk": {
+          "name": "profile_passkeys_username_profile_username_fk",
+          "tableFrom": "profile_passkeys",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_passkeys_credential_id_unique": {
+          "name": "profile_passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_passkey_challenges": {
+      "name": "profile_passkey_challenges",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_sessions": {
+      "name": "profile_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_sessions_username_profile_username_fk": {
+          "name": "profile_sessions_username_profile_username_fk",
+          "tableFrom": "profile_sessions",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_settings": {
+      "name": "profile_settings",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_settings_username_profile_username_fk": {
+          "name": "profile_settings_username_profile_username_fk",
+          "tableFrom": "profile_settings",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_settings_username_key_pk": {
+          "name": "profile_settings_username_key_pk",
+          "columns": [
+            "username",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tokens": {
+      "name": "profile_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tokens_username_profile_username_fk": {
+          "name": "profile_tokens_username_profile_username_fk",
+          "tableFrom": "profile_tokens",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_videos": {
+      "name": "profile_videos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "lease": {
+          "name": "lease",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_videos_username_idx": {
+          "name": "profile_videos_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_videos_lease_video_lease_id_fk": {
+          "name": "profile_videos_lease_video_lease_id_fk",
+          "tableFrom": "profile_videos",
+          "tableTo": "video_lease",
+          "columnsFrom": [
+            "lease"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_videos_username_profile_username_fk": {
+          "name": "profile_videos_username_profile_username_fk",
+          "tableFrom": "profile_videos",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server": {
+      "name": "server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "webtak": {
+          "name": "webtak",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spatial_ref_sys": {
+      "name": "spatial_ref_sys",
+      "schema": "",
+      "columns": {
+        "srid": {
+          "name": "srid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_name": {
+          "name": "auth_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_srid": {
+          "name": "auth_srid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "srtext": {
+          "name": "srtext",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proj4text": {
+          "name": "proj4text",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_prefix_unique": {
+          "name": "tasks_prefix_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_lease": {
+      "name": "video_lease",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "source_model": {
+          "name": "source_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "publish": {
+          "name": "publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recording": {
+          "name": "recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share": {
+          "name": "share",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "Now() + INTERVAL 1 HOUR;"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream_user": {
+          "name": "stream_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_pass": {
+          "name": "stream_pass",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_user": {
+          "name": "read_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_pass": {
+          "name": "read_pass",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy": {
+          "name": "proxy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_lease_username_profile_username_fk": {
+          "name": "video_lease_username_profile_username_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_lease_connection_connections_id_fk": {
+          "name": "video_lease_connection_connections_id_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_lease_layer_layers_id_fk": {
+          "name": "video_lease_layer_layers_id_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/migrations/meta/0186_snapshot.json
+++ b/api/migrations/meta/0186_snapshot.json
@@ -1,0 +1,3926 @@
+{
+  "id": "cae93a57-9783-4e9d-8ee9-f8851fdbbb86",
+  "prevId": "6acd17b8-940a-4a8e-81cf-ff7d9e92b40a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.basemaps": {
+      "name": "basemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "parent": {
+          "name": "parent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zxy'"
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minzoom": {
+          "name": "minzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxzoom": {
+          "name": "maxzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 16
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'png'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raster'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_enabled": {
+          "name": "sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharing_token": {
+          "name": "sharing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tilesize": {
+          "name": "tilesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 256
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xyz'"
+        },
+        "overlay": {
+          "name": "overlay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tilejson": {
+          "name": "tilejson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "basemaps_username_idx": {
+          "name": "basemaps_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "basemaps_parent_basemaps_id_fk": {
+          "name": "basemaps_parent_basemaps_id_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "parent"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "basemaps_username_profile_username_fk": {
+          "name": "basemaps_username_profile_username_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_raster": {
+      "name": "basemaps_raster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_raster_basemap_basemaps_id_fk": {
+          "name": "basemaps_raster_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_raster",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_raster_basemap_unique": {
+          "name": "basemaps_raster_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_source": {
+      "name": "basemaps_source",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_terrain": {
+      "name": "basemaps_terrain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mapbox'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_terrain_basemap_basemaps_id_fk": {
+          "name": "basemaps_terrain_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_terrain",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_terrain_basemap_unique": {
+          "name": "basemaps_terrain_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_vector": {
+      "name": "basemaps_vector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapping_enabled": {
+          "name": "snapping_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'callsign'"
+        },
+        "snapping_layer": {
+          "name": "snapping_layer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_vector_basemap_basemaps_id_fk": {
+          "name": "basemaps_vector_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_vector",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "basemaps_vector_iconset_iconsets_uid_fk": {
+          "name": "basemaps_vector_iconset_iconsets_uid_fk",
+          "tableFrom": "basemaps_vector",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_vector_basemap_unique": {
+          "name": "basemaps_vector_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "readonly": {
+          "name": "readonly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency": {
+          "name": "agency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "features": {
+          "name": "features",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_username_profile_username_fk": {
+          "name": "connections_username_profile_username_fk",
+          "tableFrom": "connections",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_name_unique": {
+          "name": "connections_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_features": {
+      "name": "connection_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_geofence": {
+          "name": "enabled_geofence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::JSONB"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRYZ, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_features_connection_idx": {
+          "name": "connection_features_connection_idx",
+          "columns": [
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_features_connection_layer_idx": {
+          "name": "connection_features_connection_layer_idx",
+          "columns": [
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_features_layer_layers_id_fk": {
+          "name": "connection_features_layer_layers_id_fk",
+          "tableFrom": "connection_features",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connection_features_connection_connections_id_fk": {
+          "name": "connection_features_connection_connections_id_fk",
+          "tableFrom": "connection_features",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connection_features_connection_id_pk": {
+          "name": "connection_features_connection_id_pk",
+          "columns": [
+            "connection",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_tokens": {
+      "name": "connection_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_tokens_connection_connections_id_fk": {
+          "name": "connection_tokens_connection_connections_id_fk",
+          "tableFrom": "connection_tokens",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_event": {
+      "name": "core_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "ended": {
+          "name": "ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "editable": {
+          "name": "editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "core_event_username_profile_username_fk": {
+          "name": "core_event_username_profile_username_fk",
+          "tableFrom": "core_event",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "core_event_connection_connections_id_fk": {
+          "name": "core_event_connection_connections_id_fk",
+          "tableFrom": "core_event",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_event_channel": {
+      "name": "core_event_channel",
+      "schema": "",
+      "columns": {
+        "event": {
+          "name": "event",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "core_event_channel_event_core_event_id_fk": {
+          "name": "core_event_channel_event_core_event_id_fk",
+          "tableFrom": "core_event_channel",
+          "tableTo": "core_event",
+          "columnsFrom": [
+            "event"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "core_event_channel_event_channel_pk": {
+          "name": "core_event_channel_event_channel_pk",
+          "columns": [
+            "event",
+            "channel"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_incident": {
+      "name": "core_incident",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data": {
+      "name": "data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "mission_sync": {
+          "name": "mission_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_diff": {
+          "name": "mission_diff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_role": {
+          "name": "mission_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MISSION_SUBSCRIBER'"
+        },
+        "mission_token": {
+          "name": "mission_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission_groups": {
+          "name": "mission_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "assets": {
+          "name": "assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::jsonb"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "data_username_profile_username_fk": {
+          "name": "data_username_profile_username_fk",
+          "tableFrom": "data",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "data_connection_connections_id_fk": {
+          "name": "data_connection_connections_id_fk",
+          "tableFrom": "data",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.errors": {
+      "name": "errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace": {
+          "name": "trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "errors_username_profile_username_fk": {
+          "name": "errors_username_profile_username_fk",
+          "tableFrom": "errors",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "errors_session_id_profile_sessions_id_fk": {
+          "name": "errors_session_id_profile_sessions_id_fk",
+          "tableFrom": "errors",
+          "tableTo": "profile_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fusion_type": {
+      "name": "fusion_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.icons": {
+      "name": "icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type2525b": {
+          "name": "type2525b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "icons_iconset_iconsets_uid_fk": {
+          "name": "icons_iconset_iconsets_uid_fk",
+          "tableFrom": "icons",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.iconsets": {
+      "name": "iconsets",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_internal": {
+          "name": "username_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_friendly": {
+          "name": "default_friendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hostile": {
+          "name": "default_hostile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_neutral": {
+          "name": "default_neutral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_unknown": {
+          "name": "default_unknown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_resize": {
+          "name": "skip_resize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spritesheet_data": {
+          "name": "spritesheet_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spritesheet_json": {
+          "name": "spritesheet_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "iconsets_username_idx": {
+          "name": "iconsets_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iconsets_username_profile_username_fk": {
+          "name": "iconsets_username_profile_username_fk",
+          "tableFrom": "iconsets",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imports": {
+      "name": "imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Upload'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "imports_username_profile_username_fk": {
+          "name": "imports_username_profile_username_fk",
+          "tableFrom": "imports",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_result": {
+      "name": "import_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "import": {
+          "name": "import",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_result_import_imports_id_fk": {
+          "name": "import_result_import_imports_id_fk",
+          "tableFrom": "import_result",
+          "tableTo": "imports",
+          "columnsFrom": [
+            "import"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers": {
+      "name": "layers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "template": {
+          "name": "template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logging": {
+          "name": "logging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory": {
+          "name": "memory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 256
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "alarm_period": {
+          "name": "alarm_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "alarm_evals": {
+          "name": "alarm_evals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "alarm_points": {
+          "name": "alarm_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_username_profile_username_fk": {
+          "name": "layers_username_profile_username_fk",
+          "tableFrom": "layers",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_connection_connections_id_fk": {
+          "name": "layers_connection_connections_id_fk",
+          "tableFrom": "layers",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "layers_connection_name_unique": {
+          "name": "layers_connection_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connection",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers_incoming": {
+      "name": "layers_incoming",
+      "schema": "",
+      "columns": {
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhooks": {
+          "name": "webhooks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled_styles": {
+          "name": "enabled_styles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_incoming_layer_layers_id_fk": {
+          "name": "layers_incoming_layer_layers_id_fk",
+          "tableFrom": "layers_incoming",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_incoming_data_data_id_fk": {
+          "name": "layers_incoming_data_data_id_fk",
+          "tableFrom": "layers_incoming",
+          "tableTo": "data",
+          "columnsFrom": [
+            "data"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers_outgoing": {
+      "name": "layers_outgoing",
+      "schema": "",
+      "columns": {
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_outgoing_layer_layers_id_fk": {
+          "name": "layers_outgoing_layer_layers_id_fk",
+          "tableFrom": "layers_outgoing",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_template": {
+      "name": "mission_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_template_log": {
+      "name": "mission_template_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "template": {
+          "name": "template",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mission_template_log_template_mission_template_id_fk": {
+          "name": "mission_template_log_template_mission_template_id_fk",
+          "tableFrom": "mission_template_log",
+          "tableTo": "mission_template",
+          "columnsFrom": [
+            "template"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.palette_feature": {
+      "name": "palette_feature",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "palette_feature_template_mission_template_id_fk": {
+          "name": "palette_feature_template_mission_template_id_fk",
+          "tableFrom": "palette_feature",
+          "tableTo": "mission_template",
+          "columnsFrom": [
+            "template"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Unknown'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "system_admin": {
+          "name": "system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency_admin": {
+          "name": "agency_admin",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_chats": {
+      "name": "profile_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chatroom": {
+          "name": "chatroom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_callsign": {
+          "name": "sender_callsign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_uid": {
+          "name": "sender_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chats_username_profile_username_fk": {
+          "name": "profile_chats_username_profile_username_fk",
+          "tableFrom": "profile_chats",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_chatroom": {
+      "name": "profile_chatroom",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chatroom_username_profile_username_fk": {
+          "name": "profile_chatroom_username_profile_username_fk",
+          "tableFrom": "profile_chatroom",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_features": {
+      "name": "profile_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_geofence": {
+          "name": "enabled_geofence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::JSONB"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRYZ, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_features_username_idx": {
+          "name": "profile_features_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_features_username_profile_username_fk": {
+          "name": "profile_features_username_profile_username_fk",
+          "tableFrom": "profile_features",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_features_username_id_pk": {
+          "name": "profile_features_username_id_pk",
+          "columns": [
+            "username",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_files": {
+      "name": "profile_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_files_username_profile_username_fk": {
+          "name": "profile_files_username_profile_username_fk",
+          "tableFrom": "profile_files",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_files_iconset_iconsets_uid_fk": {
+          "name": "profile_files_iconset_iconsets_uid_fk",
+          "tableFrom": "profile_files",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_file_channel": {
+      "name": "profile_file_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "file": {
+          "name": "file",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_file_channel_file_profile_files_id_fk": {
+          "name": "profile_file_channel_file_profile_files_id_fk",
+          "tableFrom": "profile_file_channel",
+          "tableTo": "profile_files",
+          "columnsFrom": [
+            "file"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_file_channel_file_channel_unique": {
+          "name": "profile_file_channel_file_channel_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file",
+            "channel"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_fusion": {
+      "name": "profile_fusion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fusion": {
+          "name": "fusion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_fusion_username_profile_username_fk": {
+          "name": "profile_fusion_username_profile_username_fk",
+          "tableFrom": "profile_fusion",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_fusion_fusion_fusion_type_id_fk": {
+          "name": "profile_fusion_fusion_fusion_type_id_fk",
+          "tableFrom": "profile_fusion",
+          "tableTo": "fusion_type",
+          "columnsFrom": [
+            "fusion"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_interests": {
+      "name": "profile_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_interests_username_profile_username_fk": {
+          "name": "profile_interests_username_profile_username_fk",
+          "tableFrom": "profile_interests",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_overlays": {
+      "name": "profile_overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "pos": {
+          "name": "pos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vector'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_overlays_username_profile_username_fk": {
+          "name": "profile_overlays_username_profile_username_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_overlays_iconset_iconsets_uid_fk": {
+          "name": "profile_overlays_iconset_iconsets_uid_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_overlays_username_url_unique": {
+          "name": "profile_overlays_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_paging": {
+      "name": "profile_paging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_paging_username_profile_username_fk": {
+          "name": "profile_paging_username_profile_username_fk",
+          "tableFrom": "profile_paging",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_passkeys": {
+      "name": "profile_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_passkeys_username_profile_username_fk": {
+          "name": "profile_passkeys_username_profile_username_fk",
+          "tableFrom": "profile_passkeys",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_passkeys_credential_id_unique": {
+          "name": "profile_passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_passkey_challenges": {
+      "name": "profile_passkey_challenges",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_sessions": {
+      "name": "profile_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_sessions_username_profile_username_fk": {
+          "name": "profile_sessions_username_profile_username_fk",
+          "tableFrom": "profile_sessions",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_settings": {
+      "name": "profile_settings",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_settings_username_profile_username_fk": {
+          "name": "profile_settings_username_profile_username_fk",
+          "tableFrom": "profile_settings",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_settings_username_key_pk": {
+          "name": "profile_settings_username_key_pk",
+          "columns": [
+            "username",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tokens": {
+      "name": "profile_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tokens_username_profile_username_fk": {
+          "name": "profile_tokens_username_profile_username_fk",
+          "tableFrom": "profile_tokens",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_videos": {
+      "name": "profile_videos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "lease": {
+          "name": "lease",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_videos_username_idx": {
+          "name": "profile_videos_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_videos_lease_video_lease_id_fk": {
+          "name": "profile_videos_lease_video_lease_id_fk",
+          "tableFrom": "profile_videos",
+          "tableTo": "video_lease",
+          "columnsFrom": [
+            "lease"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_videos_username_profile_username_fk": {
+          "name": "profile_videos_username_profile_username_fk",
+          "tableFrom": "profile_videos",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server": {
+      "name": "server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "webtak": {
+          "name": "webtak",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spatial_ref_sys": {
+      "name": "spatial_ref_sys",
+      "schema": "",
+      "columns": {
+        "srid": {
+          "name": "srid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_name": {
+          "name": "auth_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_srid": {
+          "name": "auth_srid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "srtext": {
+          "name": "srtext",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proj4text": {
+          "name": "proj4text",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_prefix_unique": {
+          "name": "tasks_prefix_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_lease": {
+      "name": "video_lease",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "source_model": {
+          "name": "source_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "publish": {
+          "name": "publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recording": {
+          "name": "recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share": {
+          "name": "share",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "Now() + INTERVAL 1 HOUR;"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream_user": {
+          "name": "stream_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_pass": {
+          "name": "stream_pass",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_user": {
+          "name": "read_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_pass": {
+          "name": "read_pass",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy": {
+          "name": "proxy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_lease_username_profile_username_fk": {
+          "name": "video_lease_username_profile_username_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_lease_connection_connections_id_fk": {
+          "name": "video_lease_connection_connections_id_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_lease_layer_layers_id_fk": {
+          "name": "video_lease_layer_layers_id_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -1296,6 +1296,13 @@
       "when": 1784062863357,
       "tag": "0185_core_event_connection",
       "breakpoints": true
+    },
+    {
+      "idx": 186,
+      "version": "7",
+      "when": 1784125616037,
+      "tag": "0186_connection_name_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -1289,6 +1289,13 @@
       "when": 1784056370116,
       "tag": "0184_core_event",
       "breakpoints": true
+    },
+    {
+      "idx": 185,
+      "version": "7",
+      "when": 1784062863357,
+      "tag": "0185_core_event_connection",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -35,7 +35,7 @@
                 "@tak-ps/etl": "^10.0.0",
                 "@tak-ps/node-cot": "^14.45.0",
                 "@tak-ps/node-safeurl": "^1.5.0",
-                "@tak-ps/node-tak": "^12.18.2",
+                "@tak-ps/node-tak": "^12.22.0",
                 "@turf/bbox": "^7.1.0",
                 "@turf/bbox-polygon": "^7.2.0",
                 "@turf/meta": "^7.0.0",
@@ -3064,9 +3064,9 @@
             }
         },
         "node_modules/@tak-ps/node-tak": {
-            "version": "12.20.1",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-tak/-/node-tak-12.20.1.tgz",
-            "integrity": "sha512-flFlS28n+Oj2fGuHc2MZ+4SwQ1yBwiKhmwSN5SxdVHRqlQ0pt16797cPaxoHw8jkhN0BMd7utZ1WZiKn0tH6NA==",
+            "version": "12.22.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-tak/-/node-tak-12.22.0.tgz",
+            "integrity": "sha512-j6dnXkPbmABYRXrNGyYXNPx3qG40lL4LMdikuOyUP4m77PHnKR2GXvuDyhG+LEcHU9UQhm6lfIEpcLiuqltK8A==",
             "license": "MIT",
             "dependencies": {
                 "@openaddresses/batch-error": "^2.12.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.api",
-    "version": "13.44.0",
+    "version": "13.46.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.api",
-            "version": "13.44.0",
+            "version": "13.46.0",
             "license": "ISC",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -162,15 +162,15 @@
             }
         },
         "node_modules/@aws-sdk/checksums": {
-            "version": "3.1000.16",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
-            "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+            "version": "3.1000.17",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.17.tgz",
+            "integrity": "sha512-k45iXM7w8Pyknnz/vTXSS/IkLDNFdgnBQI7Hmq+uhsrW7NGT/BiUJGlv20QSKzihmH1XDvSCRILICaKi57/35w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -178,18 +178,18 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1086.0.tgz",
-            "integrity": "sha512-TU5V6Aiot6iMoj7uqRgLZRpwsDARUoCk9aaPmLexErgdqUqRBIYszR3rfh7IZm3ZLpEdmaaA6mnou2GPR3eJoA==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1087.0.tgz",
+            "integrity": "sha512-YE9T3ATXX/wqC8klvIIuUo3rswTLWHYpndii0oGnwchbtI3e/R4xovnWIdxY+gmAF+wScMO/gaSQkqnFjZrcsQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -197,19 +197,19 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1086.0.tgz",
-            "integrity": "sha512-8VyQr9ElfX3JsV3L4lGy2HtCkoudZlBjnqOjoor5Jhdf1+wpJA35AXR/0KRqEfViVTRTvWs0jvZ1dA7Xb0lJrw==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1087.0.tgz",
+            "integrity": "sha512-UTDttmkkxUbQ+GkCkp0AnA0ZF2Yni/1FcvbBJ6AgGNbyb1t8QlAK14j+xVPoUOTprft5PD1Coal5hN+0FKBjcw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/middleware-compression": "^4.5.7",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/middleware-compression": "^4.5.8",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -217,18 +217,18 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1086.0.tgz",
-            "integrity": "sha512-t8XBQDrmSlnfLzJYRISvqNZkZ4q7VDDJ7D1ZxW91rzw2gTakspsaebe/SQtrA/oOve7GMNIrhxTikGFfNzK3YA==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1087.0.tgz",
+            "integrity": "sha512-xRTs7auUkM3ABhXHtg2JCMjKIVo6HBZgkvKuuH/Jd0XZzJEP1yIi6nZnvc1fuKszjjWTqj8tYaKrgD2eXrXxpg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -236,18 +236,18 @@
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1086.0.tgz",
-            "integrity": "sha512-B4mp9qrXI3B2kOVk6QWBDnbwD+jqoWYZu03EgSfLahSgqpDCoxOv0G0zz9pLMCuq0SJ/D2ViOfbNQ/323ejfPA==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1087.0.tgz",
+            "integrity": "sha512-D4kbh4MPuRyDAdEsvQT+5/whz18m0kxdimxPvYrnTd/y7dc6DKQp7KB0dba47Y4dhp+c2a0eKfamFGnqsPYZqQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -255,18 +255,18 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1086.0.tgz",
-            "integrity": "sha512-IxsHC4BM1nrSBhJJvZe9ELpPmEl8ZeSZLKoc7sACU2icKqMMF1X06Q78s7NSSoafuTI8xRnFKh7BRHfaGNLvGA==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1087.0.tgz",
+            "integrity": "sha512-qZVBwoJjdphfnvTpDoeg7vCF16tGmP5B15f7hcGJm7J2mQGRPXA+II16b9jguORgud3y6CHHjsBfcg8o5cHNew==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -274,21 +274,21 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1086.0.tgz",
-            "integrity": "sha512-6+7mVMPKetZmmF2L1yRJ+rN9b1OwVgc5sju2mj8ixdxuGjtVZ0ekFlcWGBFMQT9gpFk55PPLBng/XRYO3qah5A==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1087.0.tgz",
+            "integrity": "sha512-44ua5vo5JiFFSnG3oeeWTMfSjOtblQSoJiGbf37s0W4Lr7IY9NmIVkBHIfD4hBI1VEKdvJhDmvuJawwTfi2pvw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/checksums": "^3.1000.16",
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/middleware-sdk-s3": "^3.972.62",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/checksums": "^3.1000.17",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.63",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.40",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -296,18 +296,18 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1086.0.tgz",
-            "integrity": "sha512-Vi8bvnKaINxQ0HQNupvbE+R765YEhgvxrtUEhz/tjQAw8PSFuGh9y2Wgil3vDoO+v8C0jhoQS7YpKDE02ogonA==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1087.0.tgz",
+            "integrity": "sha512-muY3Z3S8iFUIum2ir97iwGSW4xsRtzfgI74xmfDibuvkaUb4YnBKcJ+V5OOwoiZCKa9rFrR6gXjFfEN3zvbmPA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -315,19 +315,19 @@
             }
         },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1086.0.tgz",
-            "integrity": "sha512-F8eNXxu44l7FqlMOTHSD9KFrMKSAqTFO7BySGYUPLdbkJYtBRPV24EuNTQsOlvwlbgSydvB3CuRzamW8QQjS4w==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1087.0.tgz",
+            "integrity": "sha512-pejcGuwvPrPcKLJiQKsQE7jycoognZrJS5OjxeYC4Qx4ePzx5gRkaagxyE1tRIp4PBdRbz3vOMpLjsruE73wuQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/middleware-sdk-sqs": "^3.972.35",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/middleware-sdk-sqs": "^3.972.36",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -335,19 +335,19 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1086.0.tgz",
-            "integrity": "sha512-mnqELpXqvZvq8AyNrHavBYZ6BgBs+ny/+W8Rwv0JHtCKuVPC7f4y8iP9e6z69RYEiw0Et46vYAiZQVVi4AC7AQ==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1087.0.tgz",
+            "integrity": "sha512-yU/2IFQO2HqjCPDYd8mJxRyZKVZDFQrupn67JURtHW75SpeAkm6vJSQQJtLzeOSJyj5Zu/2KRreMQV/KRTe4kA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-node": "^3.972.67",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-node": "^3.972.68",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.40",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -355,17 +355,17 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.975.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-            "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+            "version": "3.975.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.2.tgz",
+            "integrity": "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.0",
-                "@aws-sdk/xml-builder": "^3.972.34",
+                "@aws-sdk/types": "^3.974.1",
+                "@aws-sdk/xml-builder": "^3.972.35",
                 "@aws/lambda-invoke-store": "^0.3.0",
-                "@smithy/core": "^3.29.2",
+                "@smithy/core": "^3.29.3",
                 "@smithy/signature-v4": "^5.6.3",
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -374,15 +374,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.57",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-            "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+            "version": "3.972.58",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.58.tgz",
+            "integrity": "sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -390,17 +390,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.59",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-            "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+            "version": "3.972.60",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.60.tgz",
+            "integrity": "sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -408,23 +408,23 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-            "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+            "version": "3.973.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.2.tgz",
+            "integrity": "sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/credential-provider-env": "^3.972.57",
-                "@aws-sdk/credential-provider-http": "^3.972.59",
-                "@aws-sdk/credential-provider-login": "^3.972.63",
-                "@aws-sdk/credential-provider-process": "^3.972.57",
-                "@aws-sdk/credential-provider-sso": "^3.973.1",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-                "@aws-sdk/nested-clients": "^3.997.31",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/credential-provider-env": "^3.972.58",
+                "@aws-sdk/credential-provider-http": "^3.972.60",
+                "@aws-sdk/credential-provider-login": "^3.972.64",
+                "@aws-sdk/credential-provider-process": "^3.972.58",
+                "@aws-sdk/credential-provider-sso": "^3.973.2",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.64",
+                "@aws-sdk/nested-clients": "^3.997.32",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
                 "@smithy/credential-provider-imds": "^4.4.7",
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -432,16 +432,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.63",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-            "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+            "version": "3.972.64",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.64.tgz",
+            "integrity": "sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/nested-clients": "^3.997.31",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/nested-clients": "^3.997.32",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -449,21 +449,21 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.67",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
-            "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
+            "version": "3.972.68",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.68.tgz",
+            "integrity": "sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.57",
-                "@aws-sdk/credential-provider-http": "^3.972.59",
-                "@aws-sdk/credential-provider-ini": "^3.973.1",
-                "@aws-sdk/credential-provider-process": "^3.972.57",
-                "@aws-sdk/credential-provider-sso": "^3.973.1",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
+                "@aws-sdk/credential-provider-env": "^3.972.58",
+                "@aws-sdk/credential-provider-http": "^3.972.60",
+                "@aws-sdk/credential-provider-ini": "^3.973.2",
+                "@aws-sdk/credential-provider-process": "^3.972.58",
+                "@aws-sdk/credential-provider-sso": "^3.973.2",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.64",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
                 "@smithy/credential-provider-imds": "^4.4.7",
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -471,15 +471,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.57",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-            "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+            "version": "3.972.58",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.58.tgz",
+            "integrity": "sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -487,17 +487,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-            "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+            "version": "3.973.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.2.tgz",
+            "integrity": "sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/nested-clients": "^3.997.31",
-                "@aws-sdk/token-providers": "3.1083.0",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/nested-clients": "^3.997.32",
+                "@aws-sdk/token-providers": "3.1087.0",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -505,16 +505,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.63",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-            "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+            "version": "3.972.64",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.64.tgz",
+            "integrity": "sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/nested-clients": "^3.997.31",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/nested-clients": "^3.997.32",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -522,13 +522,13 @@
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.1086.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1086.0.tgz",
-            "integrity": "sha512-mjuWMFIBPiZIKwGZovqb4kBCRD0wg1LpfH7hme6/m9WEDNrBnerJuA/h1yUwEL4dZbUlhT1aDUb6OQUE/E7nYw==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1087.0.tgz",
+            "integrity": "sha512-ptS+BZ4CpzHagElZ//ISf/Bw4gCGAus1UhVnnUy8ZpnsvNlPR7ibWPUUQDH+U2WIxwIwIOUZe0AWi1HfJ0oqKA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "buffer": "5.6.0",
                 "events": "3.3.0",
                 "stream-browserify": "3.0.0",
@@ -538,20 +538,20 @@
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.1086.0"
+                "@aws-sdk/client-s3": "^3.1087.0"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.62",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
-            "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+            "version": "3.972.63",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.63.tgz",
+            "integrity": "sha512-EklitJscj/Aq2Pk8nz0xSxvL+VMSP29iFqouQU0Ow05JKn5y/OhI81ujkfVS72MjD1yeoU9uIdT8c/W6vhktQw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.40",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -559,14 +559,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.972.35",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.35.tgz",
-            "integrity": "sha512-J1u7OABwjjBB7sUJiET05dPVAfjFeR6vfM5//DInKuPzc7PhPVNEviC7RqbsIsBdZi8xICVnHemFrTuvGmhySA==",
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.36.tgz",
+            "integrity": "sha512-A3y33ETRHygvS4yZAM92NowTKZVAfsCNOeJuuOPgJO4vUS/rHDu7u+CDzrSq+W+T1bF7f4LMO9PxnEbo4ZaQuA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -574,18 +574,18 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.31",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-            "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+            "version": "3.997.32",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.32.tgz",
+            "integrity": "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/fetch-http-handler": "^5.6.4",
-                "@smithy/node-http-handler": "^4.9.4",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.40",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/fetch-http-handler": "^5.6.5",
+                "@smithy/node-http-handler": "^4.9.5",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -593,14 +593,14 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.996.39",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-            "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+            "version": "3.996.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.40.tgz",
+            "integrity": "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.0",
+                "@aws-sdk/types": "^3.974.1",
                 "@smithy/signature-v4": "^5.6.3",
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -608,16 +608,16 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1083.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-            "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+            "version": "3.1087.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1087.0.tgz",
+            "integrity": "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.975.1",
-                "@aws-sdk/nested-clients": "^3.997.31",
-                "@aws-sdk/types": "^3.974.0",
-                "@smithy/core": "^3.29.2",
-                "@smithy/types": "^4.16.0",
+                "@aws-sdk/core": "^3.975.2",
+                "@aws-sdk/nested-clients": "^3.997.32",
+                "@aws-sdk/types": "^3.974.1",
+                "@smithy/core": "^3.29.3",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -625,12 +625,12 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.974.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-            "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+            "version": "3.974.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.1.tgz",
+            "integrity": "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -638,12 +638,12 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.34",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-            "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.35.tgz",
+            "integrity": "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.16.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2380,9 +2380,9 @@
             }
         },
         "node_modules/@maplibre/maplibre-gl-style-spec": {
-            "version": "26.0.0",
-            "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.0.0.tgz",
-            "integrity": "sha512-9bhNGJqUmU9glG4KrKqW+iC2uz1XLzulj1B7CASKogP1opU4U70I3RYfeXzGwYd2aCZ+p8oLjRzjQjkg/OpFLQ==",
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.1.0.tgz",
+            "integrity": "sha512-JaVj0XqDWFb2xfaRFCvF2Gi7qSpCYXXJlVghDDfRUV2dks61YsQKDjlZKT3H+oVwFBxX7CjErz9zjdGTEP/Lug==",
             "license": "ISC",
             "dependencies": {
                 "@mapbox/jsonlint-lines-primitives": "^2.0.3",
@@ -3001,9 +3001,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "14.44.3",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.44.3.tgz",
-            "integrity": "sha512-OwloMd5jnp/eg50NedXnNUE0bDY+ORHYB6/9s/+H6AShM77cyte1NFCANUEQp6gz3qOX1dVee2GBt+wwzpdlCg==",
+            "version": "14.45.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.45.0.tgz",
+            "integrity": "sha512-40jcWZpDAIxPaDpabp51Ei8agss3N9ketqaa1aOR7XbUuSCWqO8PjUT1XEUPmB+t03L7h7fiJYle1gJFHcE/+g==",
             "license": "MIT",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -3026,8 +3026,7 @@
                 "milstandard-e": "^0.2.14",
                 "milsymbol": "^3.0.2",
                 "node-stream-zip": "^1.15.0",
-                "protobufjs": "^8.0.0",
-                "uuid": "^14.0.0"
+                "protobufjs": "^8.0.0"
             },
             "bin": {
                 "cot": "cli.ts"
@@ -9023,16 +9022,6 @@
                 "node": ">=0.6"
             }
         },
-        "node_modules/request/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "license": "MIT",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11068,16 +11057,13 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-            "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "license": "MIT",
             "bin": {
-                "uuid": "dist-node/bin/uuid"
+                "uuid": "bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
@@ -11361,9 +11347,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -56,7 +56,7 @@
         "@tak-ps/etl": "^10.0.0",
         "@tak-ps/node-cot": "^14.45.0",
         "@tak-ps/node-safeurl": "^1.5.0",
-        "@tak-ps/node-tak": "^12.18.2",
+        "@tak-ps/node-tak": "^12.22.0",
         "@turf/bbox": "^7.1.0",
         "@turf/bbox-polygon": "^7.2.0",
         "@turf/meta": "^7.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
         "migratedb-custom": "npm run migratedb-pre && tsx ./node_modules/.bin/drizzle-kit generate --custom && npm run migratedb-commit",
         "migratedb-pre": "npm run lint && git stash && tsc --outDir .",
         "migratedb-commit": "git add migrations/* && git commit -m 'Custom DB Migration'",
-        "dev": "tsx watch --ignore web/ index.ts --noevents --nosinks --nogeofence",
+        "dev": "tsx watch --ignore web/ index.ts --no-events --no-sinks --no-geofence --no-connections",
         "prod": "NODE_OPTIONS='--max-old-space-size=6144' node dist/index.js"
     },
     "engines": {

--- a/api/stateful/lib/connection-pool.ts
+++ b/api/stateful/lib/connection-pool.ts
@@ -250,10 +250,12 @@ export default class ConnectionPool extends Map<number | string, ConnectionClien
             );
         }
 
-        const ConnectionModel = new Modeler(this.config.pg, Connection);
-        for await (const conn of ConnectionModel.iter()) {
-            if (conn.enabled) {
-                conns.push(this.add(new MachineConnConfig(this.config, conn)));
+        if (!this.config.noconnections) {
+            const ConnectionModel = new Modeler(this.config.pg, Connection);
+            for await (const conn of ConnectionModel.iter()) {
+                if (conn.enabled) {
+                    conns.push(this.add(new MachineConnConfig(this.config, conn)));
+                }
             }
         }
 

--- a/api/stateless/routes/connection.ts
+++ b/api/stateless/routes/connection.ts
@@ -154,7 +154,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 ...conn,
             });
         } catch (err) {
-            Err.respond(err, res);
+            if (String(err).includes('duplicate key value violates unique constraint')) {
+                Err.respond(new Err(400, err instanceof Error ? err : new Error(String(err)), 'A connection with this name already exists'), res);
+            } else {
+                Err.respond(err, res);
+            }
         }
     });
 
@@ -252,7 +256,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 ...conn,
             });
         } catch (err) {
-            Err.respond(err, res);
+            if (String(err).includes('duplicate key value violates unique constraint')) {
+                Err.respond(new Err(400, err instanceof Error ? err : new Error(String(err)), 'A connection with this name already exists'), res);
+            } else {
+                Err.respond(err, res);
+            }
         }
     });
 

--- a/api/stateless/routes/connection.ts
+++ b/api/stateless/routes/connection.ts
@@ -26,7 +26,7 @@ function isDuplicateNameError(err: unknown): boolean {
         } else {
             parts.push(String(current));
         }
-        if (current && typeof current === 'object' && 'safe' in current) {
+        if (typeof current === 'object' && 'safe' in current) {
             parts.push(String((current as { safe?: unknown }).safe));
         }
 

--- a/api/stateless/routes/connection.ts
+++ b/api/stateless/routes/connection.ts
@@ -12,6 +12,39 @@ import Schema from '@openaddresses/batch-schema';
 import * as Default from '../lib/limits.js';
 import { generateClientP12, generateTrustP12 } from '../lib/certificate.js';
 
+/**
+ * Detect a Postgres unique-constraint violation on the connection name across the
+ * DrizzleQueryError cause chain, as the wrapped error's top-level message does not
+ * always include the underlying Postgres text.
+ */
+function isDuplicateNameError(err: unknown): boolean {
+    let current: unknown = err;
+    while (current) {
+        const parts: string[] = [];
+        if (current instanceof Error) {
+            parts.push(current.message);
+        } else {
+            parts.push(String(current));
+        }
+        if (current && typeof current === 'object' && 'safe' in current) {
+            parts.push(String((current as { safe?: unknown }).safe));
+        }
+
+        for (const message of parts) {
+            if (
+                message.includes('duplicate key value violates unique constraint')
+                || message.includes('connections_name_unique')
+                || /Key \(name\)=.* already exists/.test(message)
+            ) {
+                return true;
+            }
+        }
+
+        current = current instanceof Error ? current.cause : undefined;
+    }
+    return false;
+}
+
 export default async function router(schema: Schema, config: ConfigStateless) {
     await schema.get('/connection', {
         name: 'List Connections',
@@ -154,7 +187,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 ...conn,
             });
         } catch (err) {
-            if (String(err).includes('duplicate key value violates unique constraint')) {
+            if (isDuplicateNameError(err)) {
                 Err.respond(new Err(400, err instanceof Error ? err : new Error(String(err)), 'A connection with this name already exists'), res);
             } else {
                 Err.respond(err, res);
@@ -256,7 +289,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 ...conn,
             });
         } catch (err) {
-            if (String(err).includes('duplicate key value violates unique constraint')) {
+            if (isDuplicateNameError(err)) {
                 Err.respond(new Err(400, err instanceof Error ? err : new Error(String(err)), 'A connection with this name already exists'), res);
             } else {
                 Err.respond(err, res);

--- a/api/stateless/routes/core-event.ts
+++ b/api/stateless/routes/core-event.ts
@@ -3,7 +3,7 @@ import { StandardResponse, CoreEventResponse, GeoJSONFeatureGeometryPoint } from
 import { sql, eq } from 'drizzle-orm';
 import Schema from '@openaddresses/batch-schema';
 import Err from '@openaddresses/batch-error';
-import Auth, { AuthUser } from '../../common/auth.js';
+import Auth, { AuthUser, AuthResource, AuthResourceAccess } from '../../common/auth.js';
 import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 import { CoreEvent, CoreEventChannel } from '../../common/schema.js';
 import { CoreEvent_Priority } from '../../common/enums.js';
@@ -19,16 +19,48 @@ export default async function router(schema: Schema, config: ConfigStateless) {
     }
 
     /**
-     * An Event is visible to its creator, System Admins, and any user with an
-     * active channel the Event has been shared with
+     * Resolve the Connection a Connection or Layer resource token belongs to
      */
-    async function ensureEventAccess(user: AuthUser, event: Static<typeof CoreEventResponse>): Promise<void> {
-        if (user.is_admin() || event.username === user.email) return;
+    async function resourceConnection(auth: AuthResource): Promise<number> {
+        if (auth.access === AuthResourceAccess.LAYER) {
+            if (auth.id === undefined) throw new Err(401, null, 'Layer Resource Token must contain a Layer ID');
+            const layer = await config.models.Layer.from(auth.id);
+            if (layer.connection === null) throw new Err(401, null, 'Layer is not associated with a Connection');
+            return layer.connection;
+        } else {
+            if (auth.id === undefined) throw new Err(401, null, 'Connection Resource Token must contain a Connection ID');
+            const connection = await config.models.Connection.from(auth.id);
+            return connection.id;
+        }
+    }
 
-        const shared = (event.channels || []).map(c => Number(c));
-        if (shared.length) {
-            const active = await userChannels(user.email);
-            if (shared.some(c => active.has(c))) return;
+    /**
+     * Is the requester the creator of the Event - the user that created it,
+     * a System Admin, or a Connection/Layer token belonging to the Connection
+     * that created it
+     */
+    function isEventCreator(auth: AuthUser | AuthResource, event: Static<typeof CoreEventResponse>, connection: number | null): boolean {
+        if (auth instanceof AuthUser) {
+            return auth.is_admin() || event.username === auth.email;
+        } else {
+            return connection !== null && event.connection === connection;
+        }
+    }
+
+    /**
+     * An Event is visible to its creator, System Admins, any user with an
+     * active channel the Event has been shared with, and Connection/Layer
+     * tokens belonging to the Connection that created it
+     */
+    async function ensureEventAccess(auth: AuthUser | AuthResource, event: Static<typeof CoreEventResponse>, connection: number | null): Promise<void> {
+        if (isEventCreator(auth, event, connection)) return;
+
+        if (auth instanceof AuthUser) {
+            const shared = (event.channels || []).map(c => Number(c));
+            if (shared.length) {
+                const active = await userChannels(auth.email);
+                if (shared.some(c => active.has(c))) return;
+            }
         }
 
         throw new Err(403, null, 'You do not have permission to access this Event');
@@ -54,12 +86,25 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }),
     }, async (req, res) => {
         try {
-            const user = await Auth.as_user(config, req);
+            const auth = await Auth.is_auth(config, req, {
+                resources: [
+                    { access: AuthResourceAccess.CONNECTION },
+                    { access: AuthResourceAccess.LAYER },
+                ],
+            });
 
             let where;
-            if (user.is_admin()) {
+            if (auth instanceof AuthResource) {
+                const connection = await resourceConnection(auth);
+
+                where = sql`
+                    name ~* ${req.query.filter}
+                    AND connection = ${connection}
+                `;
+            } else if (auth.is_admin()) {
                 where = sql`name ~* ${req.query.filter}`;
             } else {
+                const user = auth;
                 const channels = [...await userChannels(user.email)];
 
                 where = channels.length
@@ -107,11 +152,18 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         res: CoreEventResponse,
     }, async (req, res) => {
         try {
-            const user = await Auth.as_user(config, req);
+            const auth = await Auth.is_auth(config, req, {
+                resources: [
+                    { access: AuthResourceAccess.CONNECTION },
+                    { access: AuthResourceAccess.LAYER },
+                ],
+            });
+
+            const connection = auth instanceof AuthResource ? await resourceConnection(auth) : null;
 
             const event = await config.models.CoreEvent.augmented_from(req.params.event);
 
-            await ensureEventAccess(user, event);
+            await ensureEventAccess(auth, event, connection);
 
             res.json(event);
         } catch (err) {
@@ -160,13 +212,19 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         res: CoreEventResponse,
     }, async (req, res) => {
         try {
-            const user = await Auth.as_user(config, req);
+            const auth = await Auth.is_auth(config, req, {
+                resources: [
+                    { access: AuthResourceAccess.CONNECTION },
+                    { access: AuthResourceAccess.LAYER },
+                ],
+            });
 
             const { channels, ...body } = req.body;
 
             const event = await config.models.CoreEvent.generate({
                 ...body,
-                username: user.email,
+                username: auth instanceof AuthUser ? auth.email : null,
+                connection: auth instanceof AuthResource ? await resourceConnection(auth) : null,
             });
 
             if (channels.length > 0) {
@@ -209,15 +267,22 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         res: CoreEventResponse,
     }, async (req, res) => {
         try {
-            const user = await Auth.as_user(config, req);
+            const auth = await Auth.is_auth(config, req, {
+                resources: [
+                    { access: AuthResourceAccess.CONNECTION },
+                    { access: AuthResourceAccess.LAYER },
+                ],
+            });
+
+            const connection = auth instanceof AuthResource ? await resourceConnection(auth) : null;
 
             const event = await config.models.CoreEvent.augmented_from(req.params.event);
 
-            await ensureEventAccess(user, event);
+            await ensureEventAccess(auth, event, connection);
 
             const { channels, ...body } = req.body;
 
-            const creator = user.is_admin() || event.username === user.email;
+            const creator = isEventCreator(auth, event, connection);
 
             if (channels !== undefined && !creator) {
                 throw new Err(403, null, 'Only the Event creator can modify sharing');

--- a/api/stateless/routes/marti-mission.ts
+++ b/api/stateless/routes/marti-mission.ts
@@ -537,6 +537,44 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
+    await schema.put('/marti/missions/:name/role', {
+        name: 'Set Mission Role',
+        group: 'MartiMissions',
+        params: Type.Object({
+            name: Type.String(),
+        }),
+        description: 'Change the role of an existing mission subscriber',
+        body: Type.Object({
+            clientUid: Type.String(),
+            username: Type.String(),
+            role: Type.Enum(MissionSubscriberRole),
+        }),
+        res: StandardResponse,
+    }, async (req, res) => {
+        try {
+            const user = await Auth.as_user(config, req);
+            const auth = (await config.models.Profile.from(user.email)).auth;
+            const api = await TAKAPI.init(new URL(String(config.server.api)), new APIAuthCertificate(auth.cert, auth.key));
+
+            const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
+                ? { token: String(req.headers['missionauthorization']) }
+                : await profileControl.subscription(user.email, req.params.name);
+
+            await api.Mission.setRole(
+                req.params.name,
+                req.body,
+                opts,
+            );
+
+            res.json({
+                status: 200,
+                message: 'Role Updated',
+            });
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
     await schema.get('/marti/missions/:name/contacts', {
         name: 'Mission Contacts',
         group: 'MartiMissions',

--- a/api/stateless/routes/marti-mission.ts
+++ b/api/stateless/routes/marti-mission.ts
@@ -562,7 +562,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             await api.Mission.setRole(
                 req.params.name,
-                req.body,
+                {
+                    clientUid: req.body.clientUid,
+                    username: req.body.username,
+                    role: req.body.role,
+                },
                 opts,
             );
 

--- a/api/test/connection.srv.test.ts
+++ b/api/test/connection.srv.test.ts
@@ -293,6 +293,30 @@ test('Creating Enabled Connection', async () => {
     }
 });
 
+test('POST: api/connection - Duplicate name handled gracefully', async () => {
+    try {
+        const res = await flight.fetch('/api/connection', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                name: 'Test Connection',
+                description: 'Duplicate name connection',
+                auth: {
+                    key: String(fs.readFileSync('/tmp/cloudtak-test-alice.key')),
+                    cert: String(fs.readFileSync('/tmp/cloudtak-test-alice.cert')),
+                },
+            },
+        }, false);
+
+        assert.equal(res.status, 400);
+        assert.equal(res.body.message, 'A connection with this name already exists');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
 test('GET: api/connection - Admin with connections', async () => {
     try {
         const res = await flight.fetch('/api/connection', {
@@ -434,6 +458,25 @@ test('PATCH: api/connection/:connectionid - Invalid X509 Certificate', async () 
 
         assert.equal(res.status, 400);
         assert.equal(res.body.message, 'Invalid X509 Certificate Provided');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('PATCH: api/connection/:connectionid - Duplicate name handled gracefully', async () => {
+    try {
+        const res = await flight.fetch(`/api/connection/${enabledConnId}`, {
+            method: 'PATCH',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                name: 'Readonly Connection',
+            },
+        }, false);
+
+        assert.equal(res.status, 400);
+        assert.equal(res.body.message, 'A connection with this name already exists');
     } catch (err) {
         assert.ifError(err);
     }

--- a/api/test/core-event.srv.test.ts
+++ b/api/test/core-event.srv.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
+import jwt from 'jsonwebtoken';
 import Flight from './flight.js';
 
 const flight = new Flight();
@@ -8,6 +9,8 @@ flight.init({ takserver: true });
 flight.takeoff();
 flight.user();
 flight.user({ username: 'user', admin: false });
+
+flight.connection();
 
 let eventId: string;
 
@@ -60,6 +63,7 @@ test('POST: api/core/event', async () => {
 
         assert.deepEqual(res.body, {
             username: 'admin@example.com',
+            connection: null,
             priority: 'high',
             type: '10031000001213000000',
             name: 'Wildfire Report',
@@ -225,6 +229,190 @@ test('PATCH: api/core/event/:event - clear channels', async () => {
         }, true);
 
         assert.deepEqual(res.body.channels, []);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+let connectionToken: string;
+let machineEventId: string;
+
+test('POST: api/connection/1/token - create machine token', async () => {
+    try {
+        const res = await flight.fetch('/api/connection/1/token', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                name: 'Core Event Token',
+            },
+        }, true);
+
+        assert.ok(res.body.token, 'has token');
+        connectionToken = res.body.token;
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('POST: api/core/event - connection token', async () => {
+    try {
+        const res = await flight.fetch('/api/core/event', {
+            method: 'POST',
+            auth: {
+                bearer: connectionToken,
+            },
+            body: {
+                name: 'Sensor Alert',
+                type: '10031000001213000000',
+                priority: 'low',
+                external_id: 'SENSOR-1',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-104.9903, 39.7392],
+                },
+                channels: [7],
+            },
+        }, true);
+
+        assert.ok(res.body.id, 'has id');
+        machineEventId = res.body.id;
+
+        assert.equal(res.body.username, null);
+        assert.equal(res.body.connection, 1);
+        assert.equal(res.body.name, 'Sensor Alert');
+        assert.deepEqual(res.body.channels, [7]);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('GET: api/core/event - connection token scoped to own events', async () => {
+    try {
+        const res = await flight.fetch('/api/core/event', {
+            method: 'GET',
+            auth: {
+                bearer: connectionToken,
+            },
+        }, true);
+
+        assert.equal(res.body.total, 1);
+        assert.equal(res.body.items[0].id, machineEventId);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('GET: api/core/event/:event - connection token', async () => {
+    try {
+        const res = await flight.fetch(`/api/core/event/${machineEventId}`, {
+            method: 'GET',
+            auth: {
+                bearer: connectionToken,
+            },
+        }, true);
+
+        assert.equal(res.body.id, machineEventId);
+        assert.equal(res.body.connection, 1);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('GET: api/core/event/:event - 403 for connection token on user event', async () => {
+    try {
+        const res = await flight.fetch(`/api/core/event/${eventId}`, {
+            method: 'GET',
+            auth: {
+                bearer: connectionToken,
+            },
+        }, false);
+
+        assert.equal(res.status, 403);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('PATCH: api/core/event/:event - connection token edits own event', async () => {
+    try {
+        const res = await flight.fetch(`/api/core/event/${machineEventId}`, {
+            method: 'PATCH',
+            auth: {
+                bearer: connectionToken,
+            },
+            body: {
+                priority: 'high',
+                remarks: 'Sensor reading has increased',
+                ended: '2026-07-14T12:00:00.000Z',
+                channels: [7, 9],
+            },
+        }, true);
+
+        assert.equal(res.body.priority, 'high');
+        assert.equal(res.body.remarks, 'Sensor reading has increased');
+        assert.ok(res.body.ended, 'has ended');
+        assert.deepEqual(res.body.channels, [7, 9]);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('PATCH: api/core/event/:event - 403 for connection token on user event', async () => {
+    try {
+        const res = await flight.fetch(`/api/core/event/${eventId}`, {
+            method: 'PATCH',
+            auth: {
+                bearer: connectionToken,
+            },
+            body: {
+                remarks: 'Machine Edit',
+            },
+        }, false);
+
+        assert.equal(res.status, 403);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('PATCH: api/core/event/:event - layer token from same connection', async () => {
+    try {
+        await flight.config!.models.Layer.generate({
+            name: 'Core Event Layer',
+            task: 'test-task-v1.0.0',
+            connection: 1,
+        });
+
+        const layerToken = 'etl.' + jwt.sign({ access: 'layer', id: 1, internal: true }, 'coe-wildland-fire');
+
+        const res = await flight.fetch(`/api/core/event/${machineEventId}`, {
+            method: 'PATCH',
+            auth: {
+                bearer: layerToken,
+            },
+            body: {
+                remarks: 'Layer Edit',
+            },
+        }, true);
+
+        assert.equal(res.body.remarks, 'Layer Edit');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('DELETE: api/core/event/:event - resource token cannot delete', async () => {
+    try {
+        const res = await flight.fetch(`/api/core/event/${machineEventId}`, {
+            method: 'DELETE',
+            auth: {
+                bearer: connectionToken,
+            },
+        }, false);
+
+        assert.equal(res.status, 403);
     } catch (err) {
         assert.ifError(err);
     }

--- a/api/test/fixtures/get_schema.json
+++ b/api/test/fixtures/get_schema.json
@@ -534,71 +534,6 @@
         "query": false,
         "res": true
     },
-    "GET /import": {
-        "body": false,
-        "query": true,
-        "res": true
-    },
-    "POST /import": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "PUT /import/:import": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "PUT /import": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "GET /import/:import": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "GET /import/:import/raw": {
-        "body": false,
-        "query": true,
-        "res": false
-    },
-    "POST /import/:import/result": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "PATCH /import/:import": {
-        "body": true,
-        "query": false,
-        "res": true
-    },
-    "POST /import/:import/retry": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "DELETE /import/:import": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "GET /layer": {
-        "body": false,
-        "query": true,
-        "res": true
-    },
-    "GET /data/:dataid": {
-        "body": false,
-        "query": false,
-        "res": true
-    },
-    "GET /layer/:layerid": {
-        "body": false,
-        "query": true,
-        "res": true
-    },
     "GET /iconset": {
         "body": false,
         "query": true,
@@ -663,6 +598,71 @@
         "body": false,
         "query": true,
         "res": false
+    },
+    "GET /import": {
+        "body": false,
+        "query": true,
+        "res": true
+    },
+    "POST /import": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "PUT /import/:import": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "PUT /import": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "GET /import/:import": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "GET /import/:import/raw": {
+        "body": false,
+        "query": true,
+        "res": false
+    },
+    "POST /import/:import/result": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "PATCH /import/:import": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
+    "POST /import/:import/retry": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "DELETE /import/:import": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "GET /layer": {
+        "body": false,
+        "query": true,
+        "res": true
+    },
+    "GET /data/:dataid": {
+        "body": false,
+        "query": false,
+        "res": true
+    },
+    "GET /layer/:layerid": {
+        "body": false,
+        "query": true,
+        "res": true
     },
     "GET /template": {
         "body": false,
@@ -871,6 +871,11 @@
     },
     "GET /marti/missions/:name/subscriptions/roles": {
         "body": false,
+        "query": false,
+        "res": true
+    },
+    "PUT /marti/missions/:name/role": {
+        "body": true,
         "query": false,
         "res": true
     },
@@ -1314,6 +1319,11 @@
         "query": true,
         "res": true
     },
+    "POST /retention": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
     "GET /server/repeater": {
         "body": false,
         "query": false,
@@ -1321,11 +1331,6 @@
     },
     "DELETE /server/repeater/:uid": {
         "body": false,
-        "query": false,
-        "res": true
-    },
-    "POST /retention": {
-        "body": true,
         "query": false,
         "res": true
     },

--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -62,7 +62,7 @@
                 "hls.js": "^1.6.5",
                 "imask": "^6.0.0",
                 "jsonata": "^2.0.4",
-                "maplibre-gl": "v6.0.0-21",
+                "maplibre-gl": "v6.0.0-22",
                 "milsymbol": "^3.0.2",
                 "openapi-fetch": "^0.17.0",
                 "phone": "^3.1.59",
@@ -223,66 +223,66 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.4.tgz",
-            "integrity": "sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+            "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^8.0.0-rc.4",
-                "@babel/types": "^8.0.0-rc.4",
+                "@babel/parser": "^8.0.0",
+                "@babel/types": "^8.0.0",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "@types/jsesc": "^2.5.0",
                 "jsesc": "^3.0.2"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.4.tgz",
-            "integrity": "sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+            "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
             "license": "MIT",
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.4.tgz",
-            "integrity": "sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "license": "MIT",
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/parser": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.4.tgz",
-            "integrity": "sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+            "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^8.0.0-rc.4"
+                "@babel/types": "^8.0.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/types": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.4.tgz",
-            "integrity": "sha512-bw30DV880P/VYtsjWWdoWmJpb9S2Vn1/PqayyccTELzRQ/HslIO7+BD9rNoZ4AAFOAjC1vrNeBCkAsyh6Ibfww==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^8.0.0-rc.4",
-                "@babel/helper-validator-identifier": "^8.0.0-rc.4"
+                "@babel/helper-string-parser": "^8.0.0",
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -406,18 +406,18 @@
             }
         },
         "node_modules/@capacitor/app": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
-            "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+            "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": ">=8.0.0"
             }
         },
         "node_modules/@capacitor/browser": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
-            "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.4.tgz",
+            "integrity": "sha512-ORZ4u/y+7aMuu6yVuk6SP529fUZyqcbnuHB1q5McpA3o2SYfVoi28iB8rsQjI2ad1qlKJd29ZUuGtspXLBDlWg==",
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": ">=8.0.0"
@@ -532,9 +532,9 @@
             }
         },
         "node_modules/@capacitor/status-bar": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
-            "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.3.tgz",
+            "integrity": "sha512-csSpfNeN49Hx9JaQBSJEIiEbOLtXg3kcc2IpScq2fu5L520h3AWEvsxoH8Srk1jxfRKepaJ4S4sqSC3foI4AgA==",
             "license": "MIT",
             "peerDependencies": {
                 "@capacitor/core": ">=8.0.0"
@@ -2041,9 +2041,9 @@
             }
         },
         "node_modules/@maplibre/maplibre-gl-style-spec": {
-            "version": "25.0.2",
-            "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-25.0.2.tgz",
-            "integrity": "sha512-hTNlIVG1gaLKz6UvOV23PYcT8wVS69LLMK9jbGT2hDWzs6hlTbMejeMyQsAF0rebj9czVp77Vhp4KRaUHHUp9g==",
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.1.0.tgz",
+            "integrity": "sha512-JaVj0XqDWFb2xfaRFCvF2Gi7qSpCYXXJlVghDDfRUV2dks61YsQKDjlZKT3H+oVwFBxX7CjErz9zjdGTEP/Lug==",
             "license": "ISC",
             "dependencies": {
                 "@mapbox/jsonlint-lines-primitives": "^2.0.3",
@@ -7625,9 +7625,9 @@
             }
         },
         "node_modules/maplibre-gl": {
-            "version": "6.0.0-21",
-            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.0.0-21.tgz",
-            "integrity": "sha512-opPjFahBtFn6WUgC3Rij2Sek76N00b8IT4XjZdSRUPkOgvc4bBNjiIHNY4g8xycRir81KOyqDm2zAoKs5B9UZg==",
+            "version": "6.0.0-22",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.0.0-22.tgz",
+            "integrity": "sha512-DzguQewO4cU5sqy7Ppxfrp3DvbDEe1tTJfXNbU4uOpcd0RtnkhsnnuWkOn/AuxcxgU4d6SXCna58nUeGCr5glw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@mapbox/point-geometry": "^1.1.0",
@@ -7635,7 +7635,7 @@
                 "@mapbox/unitbezier": "^1.0.0",
                 "@mapbox/vector-tile": "^3.0.0",
                 "@maplibre/geojson-vt": "^6.1.1",
-                "@maplibre/maplibre-gl-style-spec": "^25.0.2",
+                "@maplibre/maplibre-gl-style-spec": "^26.1.0",
                 "@maplibre/mlt": "^1.1.12",
                 "@maplibre/vt-pbf": "^4.3.2",
                 "@types/geojson": "^7946.0.16",
@@ -7643,7 +7643,7 @@
                 "gl-matrix": "^3.4.4",
                 "kdbush": "^4.1.0",
                 "murmurhash-js": "^1.0.0",
-                "pbf": "^5.1.0",
+                "pbf": "^5.1.2",
                 "potpack": "^2.1.0",
                 "quickselect": "^3.0.0",
                 "tinyqueue": "^3.0.0"
@@ -8289,9 +8289,9 @@
             }
         },
         "node_modules/pinia": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.0.tgz",
-            "integrity": "sha512-Vz1oL2/pyb0J9nZzwBXseyF7EySQYCIY0ZyWSAnzBdWC+j5BRXkzTJl71dqXVZtfDBwTch/SJsDmw8davC8chg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/pinia/-/pinia-4.0.2.tgz",
+            "integrity": "sha512-yKVVA7bSj5oRZFp/Ab9wLlmyb5gPUYEiIm4ryiWTe/xe7PtkRdMVOp1X1ggvq0c6Uj7Q0Du1HnV2mtAwM0Ks1g==",
             "license": "MIT",
             "dependencies": {
                 "nostics": "^1.1.4"
@@ -10287,27 +10287,28 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.1.0.tgz",
-            "integrity": "sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.2.0.tgz",
+            "integrity": "sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/generator": "^8.0.0-rc.4",
-                "@vue-macros/common": "^3.1.1",
-                "@vue/devtools-api": "^8.1.2",
+                "@babel/generator": "^8.0.0",
+                "@vue-macros/common": "^3.1.3",
+                "@vue/devtools-api": "^8.1.5",
                 "ast-walker-scope": "^0.9.0",
                 "chokidar": "^5.0.0",
                 "json5": "^2.2.3",
-                "local-pkg": "^1.1.2",
+                "local-pkg": "^1.2.1",
                 "magic-string": "^0.30.21",
                 "mlly": "^1.8.2",
                 "muggle-string": "^0.4.1",
+                "nostics": "^1.1.4",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.5",
                 "scule": "^1.3.0",
-                "tinyglobby": "^0.2.16",
-                "unplugin": "^3.0.0",
-                "unplugin-utils": "^0.3.1",
+                "tinyglobby": "^0.2.17",
+                "unplugin": "^3.3.0",
+                "unplugin-utils": "^0.3.2",
                 "yaml": "^2.9.0"
             },
             "funding": {
@@ -10315,10 +10316,10 @@
             },
             "peerDependencies": {
                 "@pinia/colada": ">=0.21.2",
-                "@vue/compiler-sfc": "^3.5.34",
-                "pinia": "^3.0.4",
-                "vite": "^7.0.0 || ^8.0.0",
-                "vue": "^3.5.34"
+                "@vue/compiler-sfc": "^3.5.34 || ^4.0.0",
+                "pinia": "^3.0.4 || ^4.0.2",
+                "vite": "^7.3.0 || ^8.0.0",
+                "vue": "^3.5.34 || ^4.0.0"
             },
             "peerDependenciesMeta": {
                 "@pinia/colada": {

--- a/api/web/package.json
+++ b/api/web/package.json
@@ -84,7 +84,7 @@
         "hls.js": "^1.6.5",
         "imask": "^6.0.0",
         "jsonata": "^2.0.4",
-        "maplibre-gl": "v6.0.0-21",
+        "maplibre-gl": "v6.0.0-22",
         "milsymbol": "^3.0.2",
         "openapi-fetch": "^0.17.0",
         "phone": "^3.1.59",

--- a/api/web/src/base/subscription.ts
+++ b/api/web/src/base/subscription.ts
@@ -10,6 +10,7 @@ import MissionTemplate from './mission-template.ts';
 import type {
     Mission,
     MissionRole,
+    MissionRoleType,
     MissionList,
     MissionSubscriptions,
     MissionInvite
@@ -490,6 +491,22 @@ export default class Subscription {
         });
 
         if (error) throw new Error('Failed to invite user to mission');
+    }
+
+    async changeRole(sub: { clientUid: string, username: string }, role: MissionRoleType): Promise<void> {
+        const { error } = await server.PUT('/api/marti/missions/{:name}/role', {
+            params: {
+                path: { ':name': this.guid }
+            },
+            headers: Subscription.headers(this.missiontoken),
+            body: {
+                clientUid: sub.clientUid,
+                username: sub.username,
+                role
+            }
+        });
+
+        if (error) throw new Error('Failed to change user role');
     }
 
     async invites(): Promise<MissionInvite[]> {

--- a/api/web/src/components/Admin/AdminLayers.vue
+++ b/api/web/src/components/Admin/AdminLayers.vue
@@ -52,10 +52,9 @@
                     />
                 </div>
                 <div class='col-md-3 px-2'>
-                    <TablerEnum
+                    <TaskSelect
                         v-model='paging.task'
-                        default='All Tasks'
-                        :options='taskTypes'
+                        :tasks='list.tasks'
                     />
                 </div>
                 <div class='col-md-3 px-2'>
@@ -177,7 +176,7 @@
 </template>
 
 <script setup lang='ts'>
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router';
 import { openSecondaryView } from '../../base/capacitor.ts';
 import { server } from '../../std.ts';
@@ -185,6 +184,7 @@ import type { ETLLayerList, ETLLayer } from '../../types.ts';
 import TableHeader from '../util/TableHeader.vue'
 import TableFooter from '../util/TableFooter.vue'
 import Status from '../ETL/Layer/utils/StatusDot.vue';
+import TaskSelect from './TaskSelect.vue';
 import {
     TablerNone,
     TablerInput,
@@ -229,10 +229,6 @@ const list = ref<ETLLayerList>({
     },
     tasks: [],
     items: []
-});
-
-const taskTypes = computed(() => {
-    return ["All Tasks"].concat(list.value.tasks)
 });
 
 watch(paging.value, async () => {

--- a/api/web/src/components/Admin/TaskSelect.vue
+++ b/api/web/src/components/Admin/TaskSelect.vue
@@ -3,45 +3,45 @@
         class='task-select w-100'
         position='bottom-start'
     >
-            <template #default>
-                <div class='form-select d-flex align-items-center cursor-pointer user-select-none w-100'>
-                    <span class='text-truncate flex-fill'>{{ modelValue }}</span>
+        <template #default>
+            <div class='form-select d-flex align-items-center cursor-pointer user-select-none w-100'>
+                <span class='text-truncate flex-fill'>{{ modelValue }}</span>
+            </div>
+        </template>
+        <template #dropdown>
+            <div style='min-width: 250px;'>
+                <div class='px-3 py-2 border-bottom'>
+                    <TablerInput
+                        v-model='search'
+                        placeholder='Search Tasks...'
+                        icon='search'
+                        :autofocus='true'
+                        class='mb-0'
+                        @click.stop
+                    />
                 </div>
-            </template>
-            <template #dropdown>
-                <div style='min-width: 250px;'>
-                    <div class='px-3 py-2 border-bottom'>
-                        <TablerInput
-                            v-model='search'
-                            placeholder='Search Tasks...'
-                            icon='search'
-                            :autofocus='true'
-                            class='mb-0'
-                            @click.stop
-                        />
-                    </div>
+                <div
+                    class='overflow-auto px-2 py-2'
+                    style='max-height: 300px;'
+                >
                     <div
-                        class='overflow-auto px-2 py-2'
-                        style='max-height: 300px;'
-                    >
-                        <div
-                            v-for='task in filteredTasks'
-                            :key='task'
-                            class='col-12 py-1 px-2 cloudtak-hover cursor-pointer user-select-none rounded'
-                            :class='{ "fw-bold": task === modelValue }'
-                            @click='select(task)'
-                            v-text='task'
-                        />
-                        <TablerNone
-                            v-if='!filteredTasks.length'
-                            :compact='true'
-                            :create='false'
-                            label='No Tasks'
-                        />
-                    </div>
+                        v-for='task in filteredTasks'
+                        :key='task'
+                        class='col-12 py-1 px-2 cloudtak-hover cursor-pointer user-select-none rounded'
+                        :class='{ "fw-bold": task === modelValue }'
+                        @click='select(task)'
+                        v-text='task'
+                    />
+                    <TablerNone
+                        v-if='!filteredTasks.length'
+                        :compact='true'
+                        :create='false'
+                        label='No Tasks'
+                    />
                 </div>
-            </template>
-        </TablerDropdown>
+            </div>
+        </template>
+    </TablerDropdown>
 </template>
 
 <script setup lang='ts'>

--- a/api/web/src/components/Admin/TaskSelect.vue
+++ b/api/web/src/components/Admin/TaskSelect.vue
@@ -1,6 +1,6 @@
 <template>
     <TablerDropdown
-        style='display: block; width: 100%;'
+        class='task-select w-100'
         position='bottom-start'
     >
             <template #default>
@@ -73,3 +73,14 @@ function select(task: string): void {
     search.value = '';
 }
 </script>
+
+<style scoped>
+.task-select {
+    display: flex !important;
+    width: 100%;
+}
+
+.task-select :deep(> div) {
+    width: 100%;
+}
+</style>

--- a/api/web/src/components/Admin/TaskSelect.vue
+++ b/api/web/src/components/Admin/TaskSelect.vue
@@ -1,0 +1,75 @@
+<template>
+    <TablerDropdown
+        style='display: block; width: 100%;'
+        position='bottom-start'
+    >
+            <template #default>
+                <div class='form-select d-flex align-items-center cursor-pointer user-select-none w-100'>
+                    <span class='text-truncate flex-fill'>{{ modelValue }}</span>
+                </div>
+            </template>
+            <template #dropdown>
+                <div style='min-width: 250px;'>
+                    <div class='px-3 py-2 border-bottom'>
+                        <TablerInput
+                            v-model='search'
+                            placeholder='Search Tasks...'
+                            icon='search'
+                            :autofocus='true'
+                            class='mb-0'
+                            @click.stop
+                        />
+                    </div>
+                    <div
+                        class='overflow-auto px-2 py-2'
+                        style='max-height: 300px;'
+                    >
+                        <div
+                            v-for='task in filteredTasks'
+                            :key='task'
+                            class='col-12 py-1 px-2 cloudtak-hover cursor-pointer user-select-none rounded'
+                            :class='{ "fw-bold": task === modelValue }'
+                            @click='select(task)'
+                            v-text='task'
+                        />
+                        <TablerNone
+                            v-if='!filteredTasks.length'
+                            :compact='true'
+                            :create='false'
+                            label='No Tasks'
+                        />
+                    </div>
+                </div>
+            </template>
+        </TablerDropdown>
+</template>
+
+<script setup lang='ts'>
+import { ref, computed } from 'vue';
+import { TablerInput, TablerNone, TablerDropdown } from '@tak-ps/vue-tabler';
+
+const props = defineProps<{
+    modelValue: string;
+    tasks: string[];
+}>();
+
+const emit = defineEmits<{
+    'update:modelValue': [value: string];
+}>();
+
+const ALL_TASKS = 'All Tasks';
+
+const search = ref('');
+
+const filteredTasks = computed(() => {
+    const q = search.value.trim().toLowerCase();
+    const all = [ALL_TASKS, ...props.tasks];
+    if (!q) return all;
+    return all.filter((t) => t.toLowerCase().includes(q));
+});
+
+function select(task: string): void {
+    emit('update:modelValue', task);
+    search.value = '';
+}
+</script>

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionUsers.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionUsers.vue
@@ -135,14 +135,47 @@
                     @chat='router.push(`/menu/chats/new?callsign=${$event.callsign}&uid=${$event.uid}`)'
                 >
                     <template
-                        v-if='canInvite'
+                        v-if='canManageRoles'
                         #actions
                     >
-                        <TablerDelete
-                            label='Remove User'
-                            displaytype='icon'
-                            @delete='removeUser(sub)'
-                        />
+                        <TablerIconButton
+                            title='Edit User'
+                            @click.stop='toggleEdit(sub.clientUid)'
+                        >
+                            <IconPencil
+                                :size='20'
+                                stroke='1'
+                            />
+                        </TablerIconButton>
+                    </template>
+
+                    <template
+                        v-if='canManageRoles && editingUid === sub.clientUid'
+                        #expanded
+                    >
+                        <div class='d-flex align-items-center gap-2'>
+                            <select
+                                class='form-select form-select-sm'
+                                style='width: auto;'
+                                :value='sub.role.type'
+                                @change='changeRole(sub, ($event.target as HTMLSelectElement).value as MissionRoleType)'
+                            >
+                                <option value='MISSION_OWNER'>
+                                    Owner
+                                </option>
+                                <option value='MISSION_SUBSCRIBER'>
+                                    Subscriber
+                                </option>
+                                <option value='MISSION_READONLY_SUBSCRIBER'>
+                                    Read Only
+                                </option>
+                            </select>
+                            <TablerDelete
+                                label='Remove User'
+                                displaytype='icon'
+                                @delete='removeUser(sub)'
+                            />
+                        </div>
                     </template>
                 </Contact>
             </div>
@@ -154,8 +187,8 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { TablerBadge, TablerNone, TablerInput, TablerDropdown, TablerIconButton, TablerDelete } from '@tak-ps/vue-tabler';
-import { IconPlus, IconMail, IconChevronDown, IconChevronUp } from '@tabler/icons-vue';
-import type { MissionSubscriptions, Contact as ContactType, MissionInvite } from '../../../../types.ts';
+import { IconPlus, IconMail, IconChevronDown, IconChevronUp, IconPencil } from '@tabler/icons-vue';
+import type { MissionSubscriptions, Contact as ContactType, MissionInvite, MissionRoleType } from '../../../../types.ts';
 import Subscription from '../../../../base/subscription.ts';
 import MenuTemplate from '../../util/MenuTemplate.vue';
 import StandardItem from '../../util/StandardItem.vue';
@@ -176,6 +209,7 @@ const subscriptions = ref<MissionSubscriptions>([])
 const invites = ref<MissionInvite[]>([]);
 const inviteUsername = ref('');
 const showInvites = ref(false);
+const editingUid = ref<string | null>(null);
 
 const isOffline = computed(() => !deviceStore.network.isOnline);
 
@@ -183,6 +217,12 @@ const canInvite = computed(() => {
     if (!props.subscription.role) return false;
     return props.subscription.role.type === 'MISSION_OWNER'
         || props.subscription.role.permissions.includes('MISSION_WRITE');
+});
+
+const canManageRoles = computed(() => {
+    if (!props.subscription.role) return false;
+    return props.subscription.role.type === 'MISSION_OWNER'
+        || props.subscription.role.permissions.includes('MISSION_SET_ROLE');
 });
 
 const filteredSubscriptions = computed(() => {
@@ -206,8 +246,19 @@ async function inviteUser(selection?: { callsign: string } | ContactType) {
     await fetchSubscriptions();
 }
 
+function toggleEdit(clientUid: string) {
+    editingUid.value = editingUid.value === clientUid ? null : clientUid;
+}
+
 async function removeUser(sub: MissionSubscriptions[number]) {
     await props.subscription.removeUser(sub.clientUid);
+    if (editingUid.value === sub.clientUid) editingUid.value = null;
+    await fetchSubscriptions();
+}
+
+async function changeRole(sub: MissionSubscriptions[number], role: MissionRoleType) {
+    if (role === sub.role.type) return;
+    await props.subscription.changeRole(sub, role);
     await fetchSubscriptions();
 }
 

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionUsers.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionUsers.vue
@@ -135,18 +135,27 @@
                     @chat='router.push(`/menu/chats/new?callsign=${$event.callsign}&uid=${$event.uid}`)'
                 >
                     <template
-                        v-if='canManageRoles'
+                        v-if='canInvite || canManageRoles'
                         #actions
                     >
-                        <TablerIconButton
-                            title='Edit User'
-                            @click.stop='toggleEdit(sub.clientUid)'
-                        >
-                            <IconPencil
-                                :size='20'
-                                stroke='1'
+                        <div class='d-flex align-items-center gap-2'>
+                            <TablerIconButton
+                                v-if='canManageRoles'
+                                title='Edit User'
+                                @click.stop='toggleEdit(sub.clientUid)'
+                            >
+                                <IconPencil
+                                    :size='20'
+                                    stroke='1'
+                                />
+                            </TablerIconButton>
+                            <TablerDelete
+                                v-if='canInvite'
+                                label='Remove User'
+                                displaytype='icon'
+                                @delete='removeUser(sub)'
                             />
-                        </TablerIconButton>
+                        </div>
                     </template>
 
                     <template
@@ -170,11 +179,6 @@
                                     Read Only
                                 </option>
                             </select>
-                            <TablerDelete
-                                label='Remove User'
-                                displaytype='icon'
-                                @delete='removeUser(sub)'
-                            />
                         </div>
                     </template>
                 </Contact>

--- a/api/web/src/components/CloudTAK/util/Contact.vue
+++ b/api/web/src/components/CloudTAK/util/Contact.vue
@@ -1,67 +1,81 @@
 <template>
     <StandardItem
-        class='d-flex flex-row gap-3 mb-2 align-items-center'
+        class='d-flex flex-column mb-2'
         :class='{
-            "cursor-pointer": zoomable,
-            "cursor-default": !zoomable,
             "cloudtak-hover": hover,
-            "contact-card--no-notes": !contact.notes || !contact.notes.trim()
         }'
         :hover='hover'
         @click='flyTo(contact)'
     >
-        <div class='icon-wrapper ms-2 d-flex align-items-center justify-content-center rounded-circle'>
-            <IconCheck
-                v-if='selected'
-                :size='compact ? 20 : 32'
-                stroke='1'
-            />
-            <ContactPuck
-                v-else
-                :team='contact.team'
-                :size='compact ? 20 : 32'
-            />
-        </div>
-
         <div
-            class='flex-grow-1 d-flex flex-column gap-1'
+            class='d-flex flex-row gap-3 align-items-center'
             :class='{
-                "py-2": !compact,
-                "justify-content-center": !contact.notes || !contact.notes.trim()
+                "cursor-pointer": zoomable,
+                "cursor-default": !zoomable,
+                "contact-card--no-notes": !contact.notes || !contact.notes.trim()
             }'
         >
-            <div class='d-flex flex-wrap align-items-center gap-2'>
-                <span
-                    class='fw-semibold text-break'
-                    v-text='contact.callsign'
+            <div class='icon-wrapper ms-2 d-flex align-items-center justify-content-center rounded-circle'>
+                <IconCheck
+                    v-if='selected'
+                    :size='compact ? 20 : 32'
+                    stroke='1'
+                />
+                <ContactPuck
+                    v-else
+                    :team='contact.team'
+                    :size='compact ? 20 : 32'
                 />
             </div>
+
             <div
-                v-if='contact.notes && contact.notes.trim()'
-                class='text-break subheader user-select-none'
-                v-text='contact.notes.trim()'
-            />
+                class='flex-grow-1 d-flex flex-column gap-1'
+                :class='{
+                    "py-2": !compact,
+                    "justify-content-center": !contact.notes || !contact.notes.trim()
+                }'
+            >
+                <div class='d-flex flex-wrap align-items-center gap-2'>
+                    <span
+                        class='fw-semibold text-break'
+                        v-text='contact.callsign'
+                    />
+                </div>
+                <div
+                    v-if='contact.notes && contact.notes.trim()'
+                    class='text-break subheader user-select-none'
+                    v-text='contact.notes.trim()'
+                />
+            </div>
+
+            <div
+                v-if='props.buttonChat'
+                class='align-self-center me-2'
+            >
+                <IconMessage
+                    v-if='props.buttonChat && chatable'
+                    v-tooltip='"Start Chat"'
+                    :size='compact ? 20 : 32'
+                    stroke='1'
+                    class='cursor-pointer'
+                    @click.stop='emit("chat", contact)'
+                />
+            </div>
+
+            <div
+                v-if='$slots.actions'
+                class='align-self-center me-2'
+            >
+                <slot name='actions' />
+            </div>
         </div>
 
         <div
-            v-if='props.buttonChat'
-            class='align-self-center me-2'
+            v-if='$slots.expanded'
+            class='px-2 pb-2'
+            @click.stop
         >
-            <IconMessage
-                v-if='props.buttonChat && chatable'
-                v-tooltip='"Start Chat"'
-                :size='compact ? 20 : 32'
-                stroke='1'
-                class='cursor-pointer'
-                @click.stop='emit("chat", contact)'
-            />
-        </div>
-
-        <div
-            v-if='$slots.actions'
-            class='align-self-center me-2'
-        >
-            <slot name='actions' />
+            <slot name='expanded' />
         </div>
     </StandardItem>
 </template>

--- a/api/web/src/components/util/TaskFilter.vue
+++ b/api/web/src/components/util/TaskFilter.vue
@@ -1,0 +1,94 @@
+<template>
+    <TablerDropdown
+        position='bottom-start'
+        width='100%'
+    >
+        <template #default>
+            <button
+                type='button'
+                class='form-control d-flex align-items-center cursor-pointer text-start'
+            >
+                <span class='flex-fill text-truncate'>{{ modelValue || 'All Tasks' }}</span>
+                <IconChevronDown
+                    :size='16'
+                    stroke='1'
+                    class='ms-2 flex-shrink-0 text-muted'
+                />
+            </button>
+        </template>
+        <template #dropdown>
+            <div style='min-width: 260px;'>
+                <div class='px-2 py-2 border-bottom'>
+                    <TablerInput
+                        v-model='search'
+                        placeholder='Search Tasks...'
+                        :autofocus='true'
+                        class='mb-0'
+                        @click.stop
+                    />
+                </div>
+                <div
+                    class='overflow-auto'
+                    style='max-height: 300px;'
+                >
+                    <div
+                        class='px-3 py-2 cursor-pointer cloudtak-hover user-select-none'
+                        :class='{ "fw-bold": !modelValue || modelValue === "All Tasks" }'
+                        @click='select(undefined)'
+                    >
+                        All Tasks
+                    </div>
+                    <div
+                        v-for='task in filtered'
+                        :key='task'
+                        class='px-3 py-2 cursor-pointer cloudtak-hover user-select-none text-truncate'
+                        :class='{ "fw-bold": modelValue === task }'
+                        @click='select(task)'
+                    >
+                        {{ task }}
+                    </div>
+                    <TablerNone
+                        v-if='!filtered.length && search'
+                        :compact='true'
+                        :create='false'
+                        label='No Tasks'
+                    />
+                </div>
+            </div>
+        </template>
+    </TablerDropdown>
+</template>
+
+<script setup lang='ts'>
+import { ref, computed } from 'vue';
+import { IconChevronDown } from '@tabler/icons-vue';
+import {
+    TablerInput,
+    TablerDropdown,
+    TablerNone,
+} from '@tak-ps/vue-tabler';
+
+const props = withDefaults(defineProps<{
+    modelValue?: string;
+    tasks: string[];
+}>(), {
+    modelValue: undefined,
+});
+
+const emit = defineEmits<{
+    (e: 'update:modelValue', value: string | undefined): void;
+}>();
+
+const search = ref('');
+
+const filtered = computed<string[]>(() => {
+    const query = search.value.trim().toLowerCase();
+    if (!query) return props.tasks;
+    return props.tasks.filter((task) => task.toLowerCase().includes(query));
+});
+
+function select(task: string | undefined): void {
+    search.value = '';
+    emit('update:modelValue', task);
+}
+</script>

--- a/api/web/src/types.ts
+++ b/api/web/src/types.ts
@@ -62,6 +62,7 @@ export type MissionList = paths["/api/marti/mission"]["get"]["responses"]["200"]
 export type MissionInvite = paths["/api/marti/mission"]["get"]["responses"]["200"]["content"]["application/json"]["invites"][0];
 
 export type MissionRole = paths["/api/marti/missions/{:name}/role"]["get"]["responses"]["200"]["content"]["application/json"];
+export type MissionRoleType = MissionRole["type"];
 
 export type MissionLog = paths["/api/marti/missions/{:name}/log/{:logid}"]["patch"]["responses"]["200"]["content"]["application/json"]["data"];
 export type MissionLogList = paths["/api/marti/missions/{:name}/log"]["get"]["responses"]["200"]["content"]["application/json"];

--- a/api/web/tsconfig.json
+++ b/api/web/tsconfig.json
@@ -26,10 +26,7 @@
     "moduleResolution": "bundler",
     "paths": {
       "@tak-ps/cloudtak": ["./plugin.ts"],
-      "@cloudtak/api-types": ["../derived-types.d.ts"],
-      // pinia@4.0.0 ships an `exports` map without a `types` condition, which
-      // hides its bundled `dist/pinia.d.ts` from TypeScript. Remove once fixed upstream.
-      "pinia": ["./node_modules/pinia/dist/pinia.d.ts"]
+      "@cloudtak/api-types": ["../derived-types.d.ts"]
     },
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
### Context

- :tada: Ability to change Mission Sync role
- :tada: Allow Connection/Layers to create Core Events
- :rocket: Rename `--no-<type>` flags for consistently
- :tada: Add `--no-connections` dev flag to disable connecting TAK with ETL connections
- :rocket: Throw human readable name on unique constraint in connection name - Closes: https://github.com/dfpc-coe/CloudTAK/issues/619
- :rocket: Custom Task Type dropdown that supports search