### PR TITLE
Video Wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 
 ### Pending Release
 
+- :tada: Implement the Video Wall - a full-page grid of a user's saved video streams with drag & drop re-ordering, dynamic resizing & removal
+- :tada: Add a "Push to Video Wall" button to the Floating Video Pane which saves the stream to the wall & opens (or notifies) the Video Wall tab
+- :tada: Persist Video Wall placement in the `profile_videos` table via a new `position` column & `PATCH /api/profile/video/:id` endpoint
+- :tada: `POST /api/profile/video` now accepts a raw stream `url` - resolving it to an existing Video Lease or creating a user-owned proxy lease
+- :rocket: Extract a unified `VideoPlayer` component (hls.js) shared by the Floating Video Pane & the Video Wall
+- :white_check_mark: Add tests covering Profile Video creation from leases & URLs, placement updates & deletion
+
 ### v13.50.0 - 2026-07-17
 
 - :bug: Delete Connection Features related to a layer if the layer is deleted - Closes: https://github.com/dfpc-coe/CloudTAK/issues/1594

--- a/api/common/schema.ts
+++ b/api/common/schema.ts
@@ -224,6 +224,14 @@ export const ProfileVideo = pgTable('profile_videos', {
     updated: timestamp({ withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),
     lease: integer().notNull().references(() => VideoLease.id),
     username: text().notNull().references(() => Profile.username),
+
+    // Video Wall grid placement - x/y in grid units on a 12 column grid, w/h in grid units
+    position: jsonb().$type<{
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+    }>().notNull().default({ x: 0, y: 0, w: 4, h: 6 }),
 }, (table) => {
     return {
         username_idx: index('profile_videos_username_idx').on(table.username),

--- a/api/common/schema.ts
+++ b/api/common/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { primaryKey } from 'drizzle-orm/pg-core';
 import { Static } from '@sinclair/typebox';
+import type { ProfileVideoPosition } from './types.js';
 import type { StyleContainer } from './style.js';
 import type { FilterContainer } from './filter.js';
 import type { PaletteFeatureStyle } from '../stateless/lib/palette.js';
@@ -225,13 +226,7 @@ export const ProfileVideo = pgTable('profile_videos', {
     lease: integer().notNull().references(() => VideoLease.id),
     username: text().notNull().references(() => Profile.username),
 
-    // Video Wall grid placement - x/y in grid units on a 12 column grid, w/h in grid units
-    position: jsonb().$type<{
-        x: number;
-        y: number;
-        w: number;
-        h: number;
-    }>().notNull().default({ x: 0, y: 0, w: 4, h: 6 }),
+    position: jsonb().$type<Static<typeof ProfileVideoPosition>>().notNull().default({ x: 0, y: 0, w: 4, h: 6 }),
 }, (table) => {
     return {
         username_idx: index('profile_videos_username_idx').on(table.username),

--- a/api/common/types.ts
+++ b/api/common/types.ts
@@ -342,8 +342,16 @@ export const ProfilePagingResponse = Type.Object({
     updated: Type.String(),
 });
 
+export const ProfileVideoPosition = Type.Object({
+    x: Type.Integer({ minimum: 0, description: 'Column position on a 12 column grid' }),
+    y: Type.Integer({ minimum: 0, description: 'Row position in grid units' }),
+    w: Type.Integer({ minimum: 1, maximum: 12, description: 'Width in grid columns' }),
+    h: Type.Integer({ minimum: 1, description: 'Height in grid rows' }),
+});
+
 export const ProfileVideoResponse = createSelectSchema(schemas.ProfileVideo, {
     lease: Type.Integer(),
+    position: ProfileVideoPosition,
 });
 
 export const FeatureResponse = Type.Composite([Feature.Feature, Type.Object({

--- a/api/derived-types.d.ts
+++ b/api/derived-types.d.ts
@@ -10303,7 +10303,10 @@ export interface paths {
         /** Get the logs related to the given task */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description No Description */
+                    limit?: number;
+                };
                 header?: never;
                 path: {
                     /** @description No Description */
@@ -24245,216 +24248,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/manifest.webmanifest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Return the Web Manifest for PWA Use */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            name: string;
-                            short_name: string;
-                            description: string;
-                            start_url: string;
-                            display: string;
-                            background_color: string;
-                            theme_color: string;
-                            lang: string;
-                            scope: string;
-                            icons: {
-                                src: string;
-                                sizes: string;
-                                type: string;
-                            }[];
-                            orientation: string;
-                            categories: string[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/manifest.webmanifest/logos/{:size}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Return a resized PNG logo for PWA use */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Logo size in pixels */
-                    ":size": number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/marti/api/files/{:hash}": {
         parameters: {
             query?: never;
@@ -28894,6 +28687,216 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/manifest.webmanifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return the Web Manifest for PWA Use */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            name: string;
+                            short_name: string;
+                            description: string;
+                            start_url: string;
+                            display: string;
+                            background_color: string;
+                            theme_color: string;
+                            lang: string;
+                            scope: string;
+                            icons: {
+                                src: string;
+                                sizes: string;
+                                type: string;
+                            }[];
+                            orientation: string;
+                            categories: string[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/manifest.webmanifest/logos/{:size}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return a resized PNG logo for PWA use */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Logo size in pixels */
+                    ":size": number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -38751,6 +38754,16 @@ export interface paths {
                                 updated: string;
                                 lease: number;
                                 username: string;
+                                position: {
+                                    /** @description Column position on a 12 column grid */
+                                    x: number;
+                                    /** @description Row position in grid units */
+                                    y: number;
+                                    /** @description Width in grid columns */
+                                    w: number;
+                                    /** @description Height in grid rows */
+                                    h: number;
+                                };
                             }[];
                         };
                     };
@@ -38818,7 +38831,13 @@ export interface paths {
             };
         };
         put?: never;
-        /** Push a new Profile Video to the database */
+        /**
+         * Push a new Profile Video to the Video Wall
+         *
+         *                 Either an existing Video Lease ID or a Stream URL must be provided.
+         *                 If a URL is provided it is resolved to an existing lease where possible,
+         *                 otherwise a proxy lease is created on behalf of the user.
+         */
         post: {
             parameters: {
                 query?: never;
@@ -38829,7 +38848,22 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        lease: number;
+                        /** @description Existing Video Lease ID */
+                        lease?: number;
+                        /** @description Video Stream URL */
+                        url?: string;
+                        /** @description Human readable name - used if a new proxy lease is created */
+                        name?: string;
+                        position?: {
+                            /** @description Column position on a 12 column grid */
+                            x: number;
+                            /** @description Row position in grid units */
+                            y: number;
+                            /** @description Width in grid columns */
+                            w: number;
+                            /** @description Height in grid rows */
+                            h: number;
+                        };
                     };
                 };
             };
@@ -38847,6 +38881,16 @@ export interface paths {
                             updated: string;
                             lease: number;
                             username: string;
+                            position: {
+                                /** @description Column position on a 12 column grid */
+                                x: number;
+                                /** @description Row position in grid units */
+                                y: number;
+                                /** @description Width in grid columns */
+                                w: number;
+                                /** @description Height in grid rows */
+                                h: number;
+                            };
                         };
                     };
                 };
@@ -38951,6 +38995,16 @@ export interface paths {
                             updated: string;
                             lease: number;
                             username: string;
+                            position: {
+                                /** @description Column position on a 12 column grid */
+                                x: number;
+                                /** @description Row position in grid units */
+                                y: number;
+                                /** @description Width in grid columns */
+                                w: number;
+                                /** @description Height in grid rows */
+                                h: number;
+                            };
                         };
                     };
                 };
@@ -39107,7 +39161,122 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update a Profile Video - used to persist Video Wall placement */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":id": string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        position?: {
+                            /** @description Column position on a 12 column grid */
+                            x: number;
+                            /** @description Row position in grid units */
+                            y: number;
+                            /** @description Width in grid columns */
+                            w: number;
+                            /** @description Height in grid rows */
+                            h: number;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uuid */
+                            id: string;
+                            created: string;
+                            updated: string;
+                            lease: number;
+                            username: string;
+                            position: {
+                                /** @description Column position on a 12 column grid */
+                                x: number;
+                                /** @description Row position in grid units */
+                                y: number;
+                                /** @description Width in grid columns */
+                                w: number;
+                                /** @description Height in grid rows */
+                                h: number;
+                            };
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/api/profile": {
@@ -39816,114 +39985,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/retention": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Run a retention action */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        action: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            name: string;
-                            status: "success" | "error";
-                            deleted: number;
-                            duration: number;
-                            message?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/server/repeater": {
         parameters: {
             query?: never;
@@ -40127,6 +40188,114 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/retention": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run a retention action */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        action: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            name: string;
+                            status: "success" | "error";
+                            deleted: number;
+                            duration: number;
+                            message?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -42398,1281 +42567,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/video/auth": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Authenticate a request to view a lease */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        user: string;
-                        password: string;
-                        ip: string;
-                        action: "publish" | "read" | "playback" | "api" | "metrics" | "pprof";
-                        path: string;
-                        protocol: string;
-                        id: null | string;
-                        query: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/active": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Return information about an active lease given read credentials
-         *
-         *                 If a user has a valid read URL, the API endpoint will allow an authenticated user
-         *                 to get metadata to agument the video stream itself
-         */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    url: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @description If a lease request is made, is it likely to succeed */
-                            leasable: boolean;
-                            message?: string;
-                            metadata?: {
-                                name: string;
-                                username: null | string;
-                                active: boolean;
-                                watchers: number;
-                                source_id?: null | string;
-                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                                source_model: string;
-                                protocols: {
-                                    rtmp?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    rtsp?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    webrtc?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    hls?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                    srt?: {
-                                        name: string;
-                                        url: string;
-                                    };
-                                };
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/lease": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List all video leases */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    impersonate?: boolean | string;
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort: "id" | "name" | "created" | "updated" | "username" | "connection" | "layer" | "source_id" | "source_type" | "source_model" | "publish" | "recording" | "share" | "ephemeral" | "channel" | "expiration" | "path" | "stream_user" | "stream_pass" | "read_user" | "read_pass" | "proxy" | "enableRLS";
-                    /** @description No Description */
-                    expired: "true" | "false" | "all";
-                    /** @description No Description */
-                    ephemeral: "true" | "false" | "all";
-                    /** @description Filter results by a human readable name field */
-                    filter: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                id: number;
-                                name: string;
-                                created: string;
-                                updated: string;
-                                username: string | null;
-                                connection: number | null;
-                                layer: number | null;
-                                source_id: string | null;
-                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                                source_model: string;
-                                publish: boolean;
-                                recording: boolean;
-                                share: boolean;
-                                ephemeral: boolean;
-                                channel: null | string;
-                                expiration: null | string;
-                                path: string;
-                                stream_user: string | null;
-                                stream_pass: string | null;
-                                read_user: string | null;
-                                read_pass: string | null;
-                                proxy: null | string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create a new video Lease */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @description Human readable name */
-                        name: string;
-                        /**
-                         * @description CloudTAK View lease - hidden in streaming list
-                         * @default false
-                         */
-                        ephemeral: boolean;
-                        /**
-                         * @description Duration in Seconds
-                         * @default 3600
-                         */
-                        duration: number;
-                        /**
-                         * @description System Admins can create non-expiring leases
-                         * @default false
-                         */
-                        permanent: boolean;
-                        /**
-                         * @description Record streams to disk
-                         * @default false
-                         */
-                        recording: boolean;
-                        /**
-                         * @description Publish stream URL to TAK Server Video Manager
-                         * @default false
-                         */
-                        publish: boolean;
-                        /**
-                         * @description Allow other users to manage lease if they are also members of the channel
-                         * @default false
-                         */
-                        share: boolean;
-                        /**
-                         * @description Increase stream security by enforcing a seperate read and write username/password
-                         * @default false
-                         */
-                        secure: boolean;
-                        source_id?: null | string;
-                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                        source_model?: string;
-                        channel?: null | string;
-                        proxy?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            username: string | null;
-                            connection: number | null;
-                            layer: number | null;
-                            source_id: string | null;
-                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                            source_model: string;
-                            publish: boolean;
-                            recording: boolean;
-                            share: boolean;
-                            ephemeral: boolean;
-                            channel: null | string;
-                            expiration: null | string;
-                            path: string;
-                            stream_user: string | null;
-                            stream_pass: string | null;
-                            read_user: string | null;
-                            read_pass: string | null;
-                            proxy: null | string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/lease/{:lease}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single Video Lease */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number | string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            username: string | null;
-                            connection: number | null;
-                            layer: number | null;
-                            source_id: string | null;
-                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                            source_model: string;
-                            publish: boolean;
-                            recording: boolean;
-                            share: boolean;
-                            ephemeral: boolean;
-                            channel: null | string;
-                            expiration: null | string;
-                            path: string;
-                            stream_user: string | null;
-                            stream_pass: string | null;
-                            read_user: string | null;
-                            read_pass: string | null;
-                            proxy: null | string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete a video Lease */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update a video Lease */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        name?: string;
-                        /**
-                         * @description Duration in Seconds
-                         * @default 3600
-                         */
-                        duration: number;
-                        source_id?: null | string;
-                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                        source_model?: string;
-                        channel?: null | string;
-                        secure?: boolean;
-                        /** @description Record streams to disk */
-                        recording?: boolean;
-                        /** @description Publish stream URL to TAK Server Video Manager */
-                        publish?: boolean;
-                        /** @description Allow other users to manage lease if they are also members of the channel */
-                        share?: boolean;
-                        /** @description System Admins can create non-expiring leases */
-                        permanent?: boolean;
-                        proxy?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            name: string;
-                            created: string;
-                            updated: string;
-                            username: string | null;
-                            connection: number | null;
-                            layer: number | null;
-                            source_id: string | null;
-                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
-                            source_model: string;
-                            publish: boolean;
-                            recording: boolean;
-                            share: boolean;
-                            ephemeral: boolean;
-                            channel: null | string;
-                            expiration: null | string;
-                            path: string;
-                            stream_user: string | null;
-                            stream_pass: string | null;
-                            read_user: string | null;
-                            read_pass: string | null;
-                            proxy: null | string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/video/lease/{:lease}/metadata": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single Video Lease Metadata */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":lease": number | string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            path?: {
-                                name: string;
-                                confName: string;
-                                source: {
-                                    id: string;
-                                    type: string;
-                                } | null;
-                                ready: boolean;
-                                readyTime: null | string;
-                                tracks: string[];
-                                bytesReceived: number;
-                                bytesSent: number;
-                                readers: {
-                                    type: string;
-                                    id: string;
-                                }[];
-                            };
-                            protocols: {
-                                rtmp?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                rtsp?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                webrtc?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                hls?: {
-                                    name: string;
-                                    url: string;
-                                };
-                                srt?: {
-                                    name: string;
-                                    url: string;
-                                };
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/service": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Video Service Configuration */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            configured: boolean;
-                            url?: string;
-                            external?: string;
-                            config?: {
-                                api: boolean;
-                                apiAddress: string;
-                                metrics: boolean;
-                                metricsAddress: string;
-                                pprof: boolean;
-                                pprofAddress: string;
-                                playback: boolean;
-                                playbackAddress: string;
-                                rtsp: boolean;
-                                rtspAddress: string;
-                                rtspsAddress: string;
-                                rtspAuthMethods: string[];
-                                rtmp: boolean;
-                                rtmpAddress: string;
-                                rtmpsAddress: string;
-                                hls: boolean;
-                                hlsAddress: string;
-                                webrtc: boolean;
-                                webrtcAddress: string;
-                                srt: boolean;
-                                srtAddress: string;
-                            };
-                            paths?: {
-                                name: string;
-                                confName: string;
-                                source: {
-                                    id: string;
-                                    type: string;
-                                } | null;
-                                ready: boolean;
-                                readyTime: null | string;
-                                tracks: string[];
-                                bytesReceived: number;
-                                bytesSent: number;
-                                readers: {
-                                    type: string;
-                                    id: string;
-                                }[];
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/video/service/path/{:path}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get information about a given path */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":path": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            path: {
-                                name: string;
-                                confName: string;
-                                source: {
-                                    id: string;
-                                    type: string;
-                                } | null;
-                                ready: boolean;
-                                readyTime: null | string;
-                                tracks: string[];
-                                bytesReceived: number;
-                                bytesSent: number;
-                                readers: {
-                                    type: string;
-                                    id: string;
-                                }[];
-                            };
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/iconset": {
         parameters: {
             query?: never;
@@ -45017,6 +43911,1281 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Authenticate a request to view a lease */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        user: string;
+                        password: string;
+                        ip: string;
+                        action: "publish" | "read" | "playback" | "api" | "metrics" | "pprof";
+                        path: string;
+                        protocol: string;
+                        id: null | string;
+                        query: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Return information about an active lease given read credentials
+         *
+         *                 If a user has a valid read URL, the API endpoint will allow an authenticated user
+         *                 to get metadata to agument the video stream itself
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    url: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description If a lease request is made, is it likely to succeed */
+                            leasable: boolean;
+                            message?: string;
+                            metadata?: {
+                                name: string;
+                                username: null | string;
+                                active: boolean;
+                                watchers: number;
+                                source_id?: null | string;
+                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                                source_model: string;
+                                protocols: {
+                                    rtmp?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    rtsp?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    webrtc?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    hls?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                    srt?: {
+                                        name: string;
+                                        url: string;
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/lease": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all video leases */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    impersonate?: boolean | string;
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort: "id" | "name" | "created" | "updated" | "username" | "connection" | "layer" | "source_id" | "source_type" | "source_model" | "publish" | "recording" | "share" | "ephemeral" | "channel" | "expiration" | "path" | "stream_user" | "stream_pass" | "read_user" | "read_pass" | "proxy" | "enableRLS";
+                    /** @description No Description */
+                    expired: "true" | "false" | "all";
+                    /** @description No Description */
+                    ephemeral: "true" | "false" | "all";
+                    /** @description Filter results by a human readable name field */
+                    filter: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                id: number;
+                                name: string;
+                                created: string;
+                                updated: string;
+                                username: string | null;
+                                connection: number | null;
+                                layer: number | null;
+                                source_id: string | null;
+                                source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                                source_model: string;
+                                publish: boolean;
+                                recording: boolean;
+                                share: boolean;
+                                ephemeral: boolean;
+                                channel: null | string;
+                                expiration: null | string;
+                                path: string;
+                                stream_user: string | null;
+                                stream_pass: string | null;
+                                read_user: string | null;
+                                read_pass: string | null;
+                                proxy: null | string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a new video Lease */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Human readable name */
+                        name: string;
+                        /**
+                         * @description CloudTAK View lease - hidden in streaming list
+                         * @default false
+                         */
+                        ephemeral: boolean;
+                        /**
+                         * @description Duration in Seconds
+                         * @default 3600
+                         */
+                        duration: number;
+                        /**
+                         * @description System Admins can create non-expiring leases
+                         * @default false
+                         */
+                        permanent: boolean;
+                        /**
+                         * @description Record streams to disk
+                         * @default false
+                         */
+                        recording: boolean;
+                        /**
+                         * @description Publish stream URL to TAK Server Video Manager
+                         * @default false
+                         */
+                        publish: boolean;
+                        /**
+                         * @description Allow other users to manage lease if they are also members of the channel
+                         * @default false
+                         */
+                        share: boolean;
+                        /**
+                         * @description Increase stream security by enforcing a seperate read and write username/password
+                         * @default false
+                         */
+                        secure: boolean;
+                        source_id?: null | string;
+                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                        source_model?: string;
+                        channel?: null | string;
+                        proxy?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            name: string;
+                            created: string;
+                            updated: string;
+                            username: string | null;
+                            connection: number | null;
+                            layer: number | null;
+                            source_id: string | null;
+                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                            source_model: string;
+                            publish: boolean;
+                            recording: boolean;
+                            share: boolean;
+                            ephemeral: boolean;
+                            channel: null | string;
+                            expiration: null | string;
+                            path: string;
+                            stream_user: string | null;
+                            stream_pass: string | null;
+                            read_user: string | null;
+                            read_pass: string | null;
+                            proxy: null | string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/lease/{:lease}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single Video Lease */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number | string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            name: string;
+                            created: string;
+                            updated: string;
+                            username: string | null;
+                            connection: number | null;
+                            layer: number | null;
+                            source_id: string | null;
+                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                            source_model: string;
+                            publish: boolean;
+                            recording: boolean;
+                            share: boolean;
+                            ephemeral: boolean;
+                            channel: null | string;
+                            expiration: null | string;
+                            path: string;
+                            stream_user: string | null;
+                            stream_pass: string | null;
+                            read_user: string | null;
+                            read_pass: string | null;
+                            proxy: null | string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete a video Lease */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update a video Lease */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        /**
+                         * @description Duration in Seconds
+                         * @default 3600
+                         */
+                        duration: number;
+                        source_id?: null | string;
+                        source_type?: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                        source_model?: string;
+                        channel?: null | string;
+                        secure?: boolean;
+                        /** @description Record streams to disk */
+                        recording?: boolean;
+                        /** @description Publish stream URL to TAK Server Video Manager */
+                        publish?: boolean;
+                        /** @description Allow other users to manage lease if they are also members of the channel */
+                        share?: boolean;
+                        /** @description System Admins can create non-expiring leases */
+                        permanent?: boolean;
+                        proxy?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            name: string;
+                            created: string;
+                            updated: string;
+                            username: string | null;
+                            connection: number | null;
+                            layer: number | null;
+                            source_id: string | null;
+                            source_type: "unknown" | "fixed" | "vehicle" | "screenshare" | "personal" | "rotor" | "fixedwing" | "uas-rotor" | "uas-fixedwing";
+                            source_model: string;
+                            publish: boolean;
+                            recording: boolean;
+                            share: boolean;
+                            ephemeral: boolean;
+                            channel: null | string;
+                            expiration: null | string;
+                            path: string;
+                            stream_user: string | null;
+                            stream_pass: string | null;
+                            read_user: string | null;
+                            read_pass: string | null;
+                            proxy: null | string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/video/lease/{:lease}/metadata": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single Video Lease Metadata */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":lease": number | string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            path?: {
+                                name: string;
+                                confName: string;
+                                source: {
+                                    id: string;
+                                    type: string;
+                                } | null;
+                                ready: boolean;
+                                readyTime: null | string;
+                                tracks: string[];
+                                bytesReceived: number;
+                                bytesSent: number;
+                                readers: {
+                                    type: string;
+                                    id: string;
+                                }[];
+                            };
+                            protocols: {
+                                rtmp?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                rtsp?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                webrtc?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                hls?: {
+                                    name: string;
+                                    url: string;
+                                };
+                                srt?: {
+                                    name: string;
+                                    url: string;
+                                };
+                            };
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/service": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Video Service Configuration */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            configured: boolean;
+                            url?: string;
+                            external?: string;
+                            config?: {
+                                api: boolean;
+                                apiAddress: string;
+                                metrics: boolean;
+                                metricsAddress: string;
+                                pprof: boolean;
+                                pprofAddress: string;
+                                playback: boolean;
+                                playbackAddress: string;
+                                rtsp: boolean;
+                                rtspAddress: string;
+                                rtspsAddress: string;
+                                rtspAuthMethods: string[];
+                                rtmp: boolean;
+                                rtmpAddress: string;
+                                rtmpsAddress: string;
+                                hls: boolean;
+                                hlsAddress: string;
+                                webrtc: boolean;
+                                webrtcAddress: string;
+                                srt: boolean;
+                                srtAddress: string;
+                            };
+                            paths?: {
+                                name: string;
+                                confName: string;
+                                source: {
+                                    id: string;
+                                    type: string;
+                                } | null;
+                                ready: boolean;
+                                readyTime: null | string;
+                                tracks: string[];
+                                bytesReceived: number;
+                                bytesSent: number;
+                                readers: {
+                                    type: string;
+                                    id: string;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/video/service/path/{:path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get information about a given path */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":path": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            path: {
+                                name: string;
+                                confName: string;
+                                source: {
+                                    id: string;
+                                    type: string;
+                                } | null;
+                                ready: boolean;
+                                readyTime: null | string;
+                                tracks: string[];
+                                bytesReceived: number;
+                                bytesSent: number;
+                                readers: {
+                                    type: string;
+                                    id: string;
+                                }[];
+                            };
+                        };
+                    };
                 };
                 /** @description Error Response */
                 400: {

--- a/api/migrations/0187_flowery_ogun.sql
+++ b/api/migrations/0187_flowery_ogun.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "profile_videos" ADD COLUMN "position" jsonb DEFAULT '{"x":0,"y":0,"w":4,"h":6}'::jsonb NOT NULL;
+ALTER TABLE "profile_videos" ADD COLUMN IF NOT EXISTS "position" jsonb DEFAULT '{"x":0,"y":0,"w":4,"h":6}'::jsonb NOT NULL;

--- a/api/migrations/0187_flowery_ogun.sql
+++ b/api/migrations/0187_flowery_ogun.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "profile_videos" ADD COLUMN "position" jsonb DEFAULT '{"x":0,"y":0,"w":4,"h":6}'::jsonb NOT NULL;

--- a/api/migrations/meta/0187_snapshot.json
+++ b/api/migrations/meta/0187_snapshot.json
@@ -1,0 +1,3933 @@
+{
+  "id": "0d3aa533-3a75-4f6f-b24d-9e966ff9879c",
+  "prevId": "cae93a57-9783-4e9d-8ee9-f8851fdbbb86",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.basemaps": {
+      "name": "basemaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "parent": {
+          "name": "parent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zxy'"
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minzoom": {
+          "name": "minzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxzoom": {
+          "name": "maxzoom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 16
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'png'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'raster'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_enabled": {
+          "name": "sharing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharing_token": {
+          "name": "sharing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tilesize": {
+          "name": "tilesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 256
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'xyz'"
+        },
+        "overlay": {
+          "name": "overlay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tilejson": {
+          "name": "tilejson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "basemaps_username_idx": {
+          "name": "basemaps_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "basemaps_parent_basemaps_id_fk": {
+          "name": "basemaps_parent_basemaps_id_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "parent"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "basemaps_username_profile_username_fk": {
+          "name": "basemaps_username_profile_username_fk",
+          "tableFrom": "basemaps",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_raster": {
+      "name": "basemaps_raster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_raster_basemap_basemaps_id_fk": {
+          "name": "basemaps_raster_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_raster",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_raster_basemap_unique": {
+          "name": "basemaps_raster_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_source": {
+      "name": "basemaps_source",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_terrain": {
+      "name": "basemaps_terrain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mapbox'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_terrain_basemap_basemaps_id_fk": {
+          "name": "basemaps_terrain_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_terrain",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_terrain_basemap_unique": {
+          "name": "basemaps_terrain_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.basemaps_vector": {
+      "name": "basemaps_vector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "basemap": {
+          "name": "basemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapping_enabled": {
+          "name": "snapping_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'callsign'"
+        },
+        "snapping_layer": {
+          "name": "snapping_layer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "basemaps_vector_basemap_basemaps_id_fk": {
+          "name": "basemaps_vector_basemap_basemaps_id_fk",
+          "tableFrom": "basemaps_vector",
+          "tableTo": "basemaps",
+          "columnsFrom": [
+            "basemap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "basemaps_vector_iconset_iconsets_uid_fk": {
+          "name": "basemaps_vector_iconset_iconsets_uid_fk",
+          "tableFrom": "basemaps_vector",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basemaps_vector_basemap_unique": {
+          "name": "basemaps_vector_basemap_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "basemap"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "readonly": {
+          "name": "readonly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency": {
+          "name": "agency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "features": {
+          "name": "features",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connections_username_profile_username_fk": {
+          "name": "connections_username_profile_username_fk",
+          "tableFrom": "connections",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_name_unique": {
+          "name": "connections_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_features": {
+      "name": "connection_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled_geofence": {
+          "name": "enabled_geofence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::JSONB"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRYZ, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_features_connection_idx": {
+          "name": "connection_features_connection_idx",
+          "columns": [
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connection_features_connection_layer_idx": {
+          "name": "connection_features_connection_layer_idx",
+          "columns": [
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_features_layer_layers_id_fk": {
+          "name": "connection_features_layer_layers_id_fk",
+          "tableFrom": "connection_features",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connection_features_connection_connections_id_fk": {
+          "name": "connection_features_connection_connections_id_fk",
+          "tableFrom": "connection_features",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connection_features_connection_id_pk": {
+          "name": "connection_features_connection_id_pk",
+          "columns": [
+            "connection",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_tokens": {
+      "name": "connection_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connection_tokens_connection_connections_id_fk": {
+          "name": "connection_tokens_connection_connections_id_fk",
+          "tableFrom": "connection_tokens",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_event": {
+      "name": "core_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "ended": {
+          "name": "ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "editable": {
+          "name": "editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "core_event_username_profile_username_fk": {
+          "name": "core_event_username_profile_username_fk",
+          "tableFrom": "core_event",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "core_event_connection_connections_id_fk": {
+          "name": "core_event_connection_connections_id_fk",
+          "tableFrom": "core_event",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_event_channel": {
+      "name": "core_event_channel",
+      "schema": "",
+      "columns": {
+        "event": {
+          "name": "event",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "core_event_channel_event_core_event_id_fk": {
+          "name": "core_event_channel_event_core_event_id_fk",
+          "tableFrom": "core_event_channel",
+          "tableTo": "core_event",
+          "columnsFrom": [
+            "event"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "core_event_channel_event_channel_pk": {
+          "name": "core_event_channel_event_channel_pk",
+          "columns": [
+            "event",
+            "channel"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_incident": {
+      "name": "core_incident",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "center": {
+          "name": "center",
+          "type": "GEOMETRY(POINT, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data": {
+      "name": "data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "mission_sync": {
+          "name": "mission_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_diff": {
+          "name": "mission_diff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mission_role": {
+          "name": "mission_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MISSION_SUBSCRIBER'"
+        },
+        "mission_token": {
+          "name": "mission_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission_groups": {
+          "name": "mission_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "assets": {
+          "name": "assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"*\"]'::jsonb"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "data_username_profile_username_fk": {
+          "name": "data_username_profile_username_fk",
+          "tableFrom": "data",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "data_connection_connections_id_fk": {
+          "name": "data_connection_connections_id_fk",
+          "tableFrom": "data",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.errors": {
+      "name": "errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace": {
+          "name": "trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "errors_username_profile_username_fk": {
+          "name": "errors_username_profile_username_fk",
+          "tableFrom": "errors",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "errors_session_id_profile_sessions_id_fk": {
+          "name": "errors_session_id_profile_sessions_id_fk",
+          "tableFrom": "errors",
+          "tableTo": "profile_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fusion_type": {
+      "name": "fusion_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.icons": {
+      "name": "icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type2525b": {
+          "name": "type2525b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "icons_iconset_iconsets_uid_fk": {
+          "name": "icons_iconset_iconsets_uid_fk",
+          "tableFrom": "icons",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.iconsets": {
+      "name": "iconsets",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_internal": {
+          "name": "username_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_friendly": {
+          "name": "default_friendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_hostile": {
+          "name": "default_hostile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_neutral": {
+          "name": "default_neutral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_unknown": {
+          "name": "default_unknown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_resize": {
+          "name": "skip_resize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spritesheet_data": {
+          "name": "spritesheet_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spritesheet_json": {
+          "name": "spritesheet_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "iconsets_username_idx": {
+          "name": "iconsets_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iconsets_username_profile_username_fk": {
+          "name": "iconsets_username_profile_username_fk",
+          "tableFrom": "iconsets",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imports": {
+      "name": "imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Upload'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "imports_username_profile_username_fk": {
+          "name": "imports_username_profile_username_fk",
+          "tableFrom": "imports",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_result": {
+      "name": "import_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "import": {
+          "name": "import",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_result_import_imports_id_fk": {
+          "name": "import_result_import_imports_id_fk",
+          "tableFrom": "import_result",
+          "tableTo": "imports",
+          "columnsFrom": [
+            "import"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers": {
+      "name": "layers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "template": {
+          "name": "template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logging": {
+          "name": "logging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory": {
+          "name": "memory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 256
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "alarm_period": {
+          "name": "alarm_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "alarm_evals": {
+          "name": "alarm_evals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "alarm_points": {
+          "name": "alarm_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_username_profile_username_fk": {
+          "name": "layers_username_profile_username_fk",
+          "tableFrom": "layers",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_connection_connections_id_fk": {
+          "name": "layers_connection_connections_id_fk",
+          "tableFrom": "layers",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "layers_connection_name_unique": {
+          "name": "layers_connection_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connection",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers_incoming": {
+      "name": "layers_incoming",
+      "schema": "",
+      "columns": {
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhooks": {
+          "name": "webhooks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled_styles": {
+          "name": "enabled_styles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_incoming_layer_layers_id_fk": {
+          "name": "layers_incoming_layer_layers_id_fk",
+          "tableFrom": "layers_incoming",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "layers_incoming_data_data_id_fk": {
+          "name": "layers_incoming_data_data_id_fk",
+          "tableFrom": "layers_incoming",
+          "tableTo": "data",
+          "columnsFrom": [
+            "data"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layers_outgoing": {
+      "name": "layers_outgoing",
+      "schema": "",
+      "columns": {
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "layers_outgoing_layer_layers_id_fk": {
+          "name": "layers_outgoing_layer_layers_id_fk",
+          "tableFrom": "layers_outgoing",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_template": {
+      "name": "mission_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mission_template_log": {
+      "name": "mission_template_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "template": {
+          "name": "template",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mission_template_log_template_mission_template_id_fk": {
+          "name": "mission_template_log_template_mission_template_id_fk",
+          "tableFrom": "mission_template_log",
+          "tableTo": "mission_template",
+          "columnsFrom": [
+            "template"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.palette_feature": {
+      "name": "palette_feature",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "palette_feature_template_mission_template_id_fk": {
+          "name": "palette_feature_template_mission_template_id_fk",
+          "tableFrom": "palette_feature",
+          "tableTo": "mission_template",
+          "columnsFrom": [
+            "template"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Unknown'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "system_admin": {
+          "name": "system_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agency_admin": {
+          "name": "agency_admin",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_chats": {
+      "name": "profile_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chatroom": {
+          "name": "chatroom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_callsign": {
+          "name": "sender_callsign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_uid": {
+          "name": "sender_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chats_username_profile_username_fk": {
+          "name": "profile_chats_username_profile_username_fk",
+          "tableFrom": "profile_chats",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_chatroom": {
+      "name": "profile_chatroom",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_chatroom_username_profile_username_fk": {
+          "name": "profile_chatroom_username_profile_username_fk",
+          "tableFrom": "profile_chatroom",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_features": {
+      "name": "profile_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_geofence": {
+          "name": "enabled_geofence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::JSONB"
+        },
+        "geometry": {
+          "name": "geometry",
+          "type": "GEOMETRY(GEOMETRYZ, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_features_username_idx": {
+          "name": "profile_features_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_features_username_profile_username_fk": {
+          "name": "profile_features_username_profile_username_fk",
+          "tableFrom": "profile_features",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_features_username_id_pk": {
+          "name": "profile_features_username_id_pk",
+          "columns": [
+            "username",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_files": {
+      "name": "profile_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_files_username_profile_username_fk": {
+          "name": "profile_files_username_profile_username_fk",
+          "tableFrom": "profile_files",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_files_iconset_iconsets_uid_fk": {
+          "name": "profile_files_iconset_iconsets_uid_fk",
+          "tableFrom": "profile_files",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_file_channel": {
+      "name": "profile_file_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "file": {
+          "name": "file",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_file_channel_file_profile_files_id_fk": {
+          "name": "profile_file_channel_file_profile_files_id_fk",
+          "tableFrom": "profile_file_channel",
+          "tableTo": "profile_files",
+          "columnsFrom": [
+            "file"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_file_channel_file_channel_unique": {
+          "name": "profile_file_channel_file_channel_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file",
+            "channel"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_fusion": {
+      "name": "profile_fusion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fusion": {
+          "name": "fusion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_fusion_username_profile_username_fk": {
+          "name": "profile_fusion_username_profile_username_fk",
+          "tableFrom": "profile_fusion",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_fusion_fusion_fusion_type_id_fk": {
+          "name": "profile_fusion_fusion_fusion_type_id_fk",
+          "tableFrom": "profile_fusion",
+          "tableTo": "fusion_type",
+          "columnsFrom": [
+            "fusion"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_interests": {
+      "name": "profile_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "GEOMETRY(POLYGON, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_interests_username_profile_username_fk": {
+          "name": "profile_interests_username_profile_username_fk",
+          "tableFrom": "profile_interests",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_overlays": {
+      "name": "profile_overlays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "pos": {
+          "name": "pos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vector'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconset": {
+          "name": "iconset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_overlays_username_profile_username_fk": {
+          "name": "profile_overlays_username_profile_username_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_overlays_iconset_iconsets_uid_fk": {
+          "name": "profile_overlays_iconset_iconsets_uid_fk",
+          "tableFrom": "profile_overlays",
+          "tableTo": "iconsets",
+          "columnsFrom": [
+            "iconset"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_overlays_username_url_unique": {
+          "name": "profile_overlays_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_paging": {
+      "name": "profile_paging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_paging_username_profile_username_fk": {
+          "name": "profile_paging_username_profile_username_fk",
+          "tableFrom": "profile_paging",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_passkeys": {
+      "name": "profile_passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_passkeys_username_profile_username_fk": {
+          "name": "profile_passkeys_username_profile_username_fk",
+          "tableFrom": "profile_passkeys",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_passkeys_credential_id_unique": {
+          "name": "profile_passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_passkey_challenges": {
+      "name": "profile_passkey_challenges",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_sessions": {
+      "name": "profile_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_sessions_username_profile_username_fk": {
+          "name": "profile_sessions_username_profile_username_fk",
+          "tableFrom": "profile_sessions",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_settings": {
+      "name": "profile_settings",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_settings_username_profile_username_fk": {
+          "name": "profile_settings_username_profile_username_fk",
+          "tableFrom": "profile_settings",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_settings_username_key_pk": {
+          "name": "profile_settings_username_key_pk",
+          "columns": [
+            "username",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_tokens": {
+      "name": "profile_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_tokens_username_profile_username_fk": {
+          "name": "profile_tokens_username_profile_username_fk",
+          "tableFrom": "profile_tokens",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_videos": {
+      "name": "profile_videos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "lease": {
+          "name": "lease",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"x\":0,\"y\":0,\"w\":4,\"h\":6}'::jsonb"
+        }
+      },
+      "indexes": {
+        "profile_videos_username_idx": {
+          "name": "profile_videos_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_videos_lease_video_lease_id_fk": {
+          "name": "profile_videos_lease_video_lease_id_fk",
+          "tableFrom": "profile_videos",
+          "tableTo": "video_lease",
+          "columnsFrom": [
+            "lease"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_videos_username_profile_username_fk": {
+          "name": "profile_videos_username_profile_username_fk",
+          "tableFrom": "profile_videos",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server": {
+      "name": "server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "webtak": {
+          "name": "webtak",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "connection": {
+          "name": "connection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spatial_ref_sys": {
+      "name": "spatial_ref_sys",
+      "schema": "",
+      "columns": {
+        "srid": {
+          "name": "srid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_name": {
+          "name": "auth_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_srid": {
+          "name": "auth_srid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "srtext": {
+          "name": "srtext",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proj4text": {
+          "name": "proj4text",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme": {
+          "name": "readme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_prefix_unique": {
+          "name": "tasks_prefix_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_lease": {
+      "name": "video_lease",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "Now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layer": {
+          "name": "layer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "source_model": {
+          "name": "source_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "publish": {
+          "name": "publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recording": {
+          "name": "recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share": {
+          "name": "share",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "Now() + INTERVAL 1 HOUR;"
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream_user": {
+          "name": "stream_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_pass": {
+          "name": "stream_pass",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_user": {
+          "name": "read_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_pass": {
+          "name": "read_pass",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy": {
+          "name": "proxy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_lease_username_profile_username_fk": {
+          "name": "video_lease_username_profile_username_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "username"
+          ],
+          "columnsTo": [
+            "username"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_lease_connection_connections_id_fk": {
+          "name": "video_lease_connection_connections_id_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "connections",
+          "columnsFrom": [
+            "connection"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_lease_layer_layers_id_fk": {
+          "name": "video_lease_layer_layers_id_fk",
+          "tableFrom": "video_lease",
+          "tableTo": "layers",
+          "columnsFrom": [
+            "layer"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -1303,6 +1303,13 @@
       "when": 1784125616037,
       "tag": "0186_connection_name_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 187,
+      "version": "7",
+      "when": 1784322389049,
+      "tag": "0187_flowery_ogun",
+      "breakpoints": true
     }
   ]
 }

--- a/api/stateless/routes/profile-videos.ts
+++ b/api/stateless/routes/profile-videos.ts
@@ -1,16 +1,22 @@
 import { Type } from '@sinclair/typebox';
+import type { Static } from '@sinclair/typebox';
+import moment from 'moment';
 import type ConfigStateless from '../config.js';
 import Schema from '@openaddresses/batch-schema';
 import Err from '@openaddresses/batch-error';
-import Auth from '../../common/auth.js';
-import { StandardResponse, ProfileVideoResponse } from '../../common/types.js';
+import Auth, { AuthUserAccess } from '../../common/auth.js';
+import { StandardResponse, ProfileVideoResponse, ProfileVideoPosition } from '../../common/types.js';
 import { sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import ECSVideoControl from '../lib/control/video-service.js';
 import * as Default from '../lib/limits.js';
 
 export default async function router(schema: Schema, config: ConfigStateless) {
+    const videoControl = new ECSVideoControl(config);
+
     await schema.get('/profile/video', {
         name: 'Get Videos',
-        group: 'ProfileVidoe',
+        group: 'ProfileVideo',
         description: `
             Return a list of Profile Videos
         `,
@@ -47,22 +53,144 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         name: 'Create Video',
         group: 'ProfileVideo',
         description: `
-            Push a new Profile Video to the database
+            Push a new Profile Video to the Video Wall
+
+            Either an existing Video Lease ID or a Stream URL must be provided.
+            If a URL is provided it is resolved to an existing lease where possible,
+            otherwise a proxy lease is created on behalf of the user.
         `,
         body: Type.Object({
-            lease: Type.Integer(),
+            lease: Type.Optional(Type.Integer({ description: 'Existing Video Lease ID' })),
+            url: Type.Optional(Type.String({ description: 'Video Stream URL' })),
+            name: Type.Optional(Type.String({ description: 'Human readable name - used if a new proxy lease is created' })),
+            position: Type.Optional(ProfileVideoPosition),
+        }),
+        res: ProfileVideoResponse,
+    }, async (req, res) => {
+        try {
+            const user = await Auth.as_user(config, req);
+            const admin = user.access === AuthUserAccess.ADMIN;
+
+            let lease: number | undefined = undefined;
+
+            if (req.body.lease !== undefined) {
+                lease = (await videoControl.from(req.body.lease, {
+                    username: user.email,
+                    admin,
+                })).id;
+            } else if (req.body.url !== undefined) {
+                let requested: URL;
+                try {
+                    requested = new URL(req.body.url);
+                } catch (err) {
+                    throw new Err(400, err instanceof Error ? err : new Error(String(err)), 'Invalid Video Stream URL');
+                }
+
+                const media = await videoControl.url();
+                const uuid = requested.pathname.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/);
+
+                if (media && media.hostname === requested.hostname && uuid && uuid[0]) {
+                    try {
+                        lease = (await videoControl.from(uuid[0], {
+                            username: user.email,
+                            admin,
+                        })).id;
+                    } catch (err) {
+                        if (!(err instanceof Err)) throw err;
+                        // The URL points at a lease the user cannot access directly
+                        // Fall through and create a user owned proxy lease
+                    }
+                }
+
+                if (lease === undefined) {
+                    lease = (await videoControl.generate({
+                        name: req.body.name || 'Video Wall Stream',
+                        ephemeral: true,
+                        expiration: moment().add(24, 'hours').toISOString(),
+                        source_id: null,
+                        path: randomUUID(),
+                        username: user.email,
+                        recording: false,
+                        publish: false,
+                        secure: false,
+                        share: false,
+                        proxy: req.body.url,
+                    })).id;
+                }
+            } else {
+                throw new Err(400, null, 'Either a lease or url must be provided');
+            }
+
+            const existing = await config.models.ProfileVideo.list({
+                where: sql`
+                    username = ${user.email}
+                    AND lease = ${lease}
+                `,
+            });
+
+            if (existing.total > 0) {
+                res.json(existing.items[0]);
+                return;
+            }
+
+            let position: Static<typeof ProfileVideoPosition> | undefined = req.body.position;
+
+            if (!position) {
+                const videos = await config.models.ProfileVideo.list({
+                    limit: 1000,
+                    where: sql`
+                        username = ${user.email}
+                    `,
+                });
+
+                // Place new videos at the bottom of the wall
+                let y = 0;
+                for (const video of videos.items) {
+                    y = Math.max(y, video.position.y + video.position.h);
+                }
+
+                position = { x: 0, y, w: 4, h: 6 };
+            }
+
+            const video = await config.models.ProfileVideo.generate({
+                lease,
+                position,
+                username: user.email,
+            });
+
+            res.json(video);
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.patch('/profile/video/:id', {
+        name: 'Update Video',
+        group: 'ProfileVideo',
+        description: `
+            Update a Profile Video - used to persist Video Wall placement
+        `,
+        params: Type.Object({
+            id: Type.String(),
+        }),
+        body: Type.Object({
+            position: Type.Optional(ProfileVideoPosition),
         }),
         res: ProfileVideoResponse,
     }, async (req, res) => {
         try {
             const user = await Auth.as_user(config, req);
 
-            const video = await config.models.ProfileVideo.generate({
+            const video = await config.models.ProfileVideo.from(sql`
+                id = ${req.params.id} AND username = ${user.email}
+            `);
+
+            const updated = await config.models.ProfileVideo.commit(video.id, {
                 ...req.body,
-                username: user.email,
+                updated: sql`Now()`,
             });
 
-            res.json(video);
+            res.json(updated);
         } catch (err) {
             Err.respond(err, res);
         }

--- a/api/test/fixtures/get_schema.json
+++ b/api/test/fixtures/get_schema.json
@@ -1284,6 +1284,11 @@
         "query": false,
         "res": true
     },
+    "PATCH /profile/video/:id": {
+        "body": true,
+        "query": false,
+        "res": true
+    },
     "GET /profile/video/:id": {
         "body": false,
         "query": false,

--- a/api/test/profile-video.srv.test.ts
+++ b/api/test/profile-video.srv.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import Flight from './flight.js';
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
 
 const flight = new Flight();
 
@@ -24,6 +25,299 @@ test('GET: api/profile/video', async () => {
     } catch (err) {
         assert.ifError(err);
     }
+});
+
+test('POST: api/profile/video - no lease or url', async () => {
+    const res = await flight.fetch('/api/profile/video', {
+        method: 'POST',
+        auth: {
+            bearer: flight.token.admin,
+        },
+        body: {},
+    }, false);
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.message, 'Either a lease or url must be provided');
+});
+
+test('POST: api/profile/video - url without media server', async () => {
+    const res = await flight.fetch('/api/profile/video', {
+        method: 'POST',
+        auth: {
+            bearer: flight.token.admin,
+        },
+        body: {
+            url: 'rtsp://example.com:8554/stream',
+        },
+    }, false);
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.message, 'Media Integration is not configured');
+});
+
+let agent: MockAgent;
+let originalDispatcher: any;
+let leaseId: number;
+let leasePath: string;
+let videoId: string;
+let proxyVideoId: string;
+
+test('Mock Media Server Start', async () => {
+    originalDispatcher = getGlobalDispatcher();
+    agent = new MockAgent();
+    agent.disableNetConnect();
+    agent.enableNetConnect(new URL(flight.base).host);
+    setGlobalDispatcher(agent);
+
+    const mediaClient = agent.get('http://media-server:9997');
+    mediaClient.intercept({
+        path: '/path',
+        method: 'POST',
+    }).reply(200, {}).persist();
+
+    mediaClient.intercept({
+        path: '/v3/config/global/get',
+        method: 'GET',
+    }).reply(200, {
+        api: true,
+        apiAddress: ':9997',
+        metrics: true,
+        metricsAddress: ':9998',
+        pprof: false,
+        pprofAddress: '',
+        playback: false,
+        playbackAddress: '',
+        rtsp: true,
+        rtspAddress: ':8554',
+        rtspsAddress: '',
+        rtspAuthMethods: [],
+        rtmp: true,
+        rtmpAddress: ':1935',
+        rtmpsAddress: '',
+        hls: true,
+        hlsAddress: ':8888',
+        webrtc: false,
+        webrtcAddress: '',
+        srt: false,
+        srtAddress: '',
+    }).persist();
+
+    mediaClient.intercept({
+        path: '/path',
+        method: 'GET',
+    }).reply(200, {
+        pageCount: 0,
+        itemCount: 0,
+        items: [],
+    }).persist();
+
+    try {
+        await flight.config!.models.Setting.generate({
+            key: 'media::url',
+            value: 'http://media-server',
+        });
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('POST: api/video/lease - Create Lease', async () => {
+    try {
+        const res = await flight.fetch('/api/video/lease', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                name: 'Wall Lease',
+                duration: 3600,
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        leaseId = res.body.id;
+        leasePath = res.body.path;
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('POST: api/profile/video - from lease', async () => {
+    try {
+        const res = await flight.fetch('/api/profile/video', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                lease: leaseId,
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        assert.ok(res.body.id, 'Video ID returned');
+        assert.equal(res.body.lease, leaseId, 'Lease matches');
+        assert.equal(res.body.username, 'admin@example.com', 'Username matches');
+        assert.deepEqual(res.body.position, { x: 0, y: 0, w: 4, h: 6 }, 'Default Position');
+
+        videoId = res.body.id;
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('POST: api/profile/video - duplicate lease returns existing', async () => {
+    try {
+        const res = await flight.fetch('/api/profile/video', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                lease: leaseId,
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        assert.equal(res.body.id, videoId, 'Existing Video returned');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('POST: api/profile/video - url resolving to existing lease', async () => {
+    try {
+        const res = await flight.fetch('/api/profile/video', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                url: `http://media-server:8888/${leasePath}/index.m3u8`,
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        assert.equal(res.body.id, videoId, 'Existing Video returned');
+        assert.equal(res.body.lease, leaseId, 'Lease matches');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('POST: api/profile/video - external url creates proxy lease', async () => {
+    try {
+        const res = await flight.fetch('/api/profile/video', {
+            method: 'POST',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                url: 'rtsp://example.com:8554/external-stream',
+                name: 'External Camera',
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        assert.ok(res.body.id, 'Video ID returned');
+        assert.notEqual(res.body.lease, leaseId, 'New Lease created');
+        assert.deepEqual(res.body.position, { x: 0, y: 6, w: 4, h: 6 }, 'Placed below existing videos');
+
+        proxyVideoId = res.body.id;
+
+        const lease = await flight.fetch(`/api/video/lease/${res.body.lease}`, {
+            method: 'GET',
+            auth: {
+                bearer: flight.token.admin,
+            },
+        }, true);
+
+        assert.equal(lease.body.name, 'External Camera', 'Lease Name from body');
+        assert.equal(lease.body.proxy, 'rtsp://example.com:8554/external-stream', 'Lease proxies the URL');
+        assert.equal(lease.body.ephemeral, true, 'Lease is ephemeral');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('PATCH: api/profile/video/:id - update position', async () => {
+    try {
+        const res = await flight.fetch(`/api/profile/video/${videoId}`, {
+            method: 'PATCH',
+            auth: {
+                bearer: flight.token.admin,
+            },
+            body: {
+                position: { x: 4, y: 0, w: 8, h: 8 },
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        assert.deepEqual(res.body.position, { x: 4, y: 0, w: 8, h: 8 }, 'Position updated');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('GET: api/profile/video/:id', async () => {
+    try {
+        const res = await flight.fetch(`/api/profile/video/${videoId}`, {
+            method: 'GET',
+            auth: {
+                bearer: flight.token.admin,
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+        assert.equal(res.body.lease, leaseId, 'Lease matches');
+        assert.deepEqual(res.body.position, { x: 4, y: 0, w: 8, h: 8 }, 'Position persisted');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('GET: api/profile/video - list', async () => {
+    try {
+        const res = await flight.fetch('/api/profile/video', {
+            method: 'GET',
+            auth: {
+                bearer: flight.token.admin,
+            },
+        }, true);
+
+        assert.equal(res.body.total, 2, 'Two Videos');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('DELETE: api/profile/video/:id', async () => {
+    try {
+        const res = await flight.fetch(`/api/profile/video/${proxyVideoId}`, {
+            method: 'DELETE',
+            auth: {
+                bearer: flight.token.admin,
+            },
+        }, true);
+
+        assert.equal(res.status, 200, 'Status 200');
+
+        const list = await flight.fetch('/api/profile/video', {
+            method: 'GET',
+            auth: {
+                bearer: flight.token.admin,
+            },
+        }, true);
+
+        assert.equal(list.body.total, 1, 'One Video remains');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('Mock Media Server Stop', async () => {
+    setGlobalDispatcher(originalDispatcher);
+    await agent.close();
 });
 
 flight.landing();

--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -58,6 +58,7 @@
                 "floating-vue": "^2.0.0-beta.17",
                 "geo-coordinates-parser": "^1.7.4",
                 "geomagnetism": "^0.2.0",
+                "grid-layout-plus": "^1.1.1",
                 "handlebars": "^4.7.9",
                 "hls.js": "^1.6.5",
                 "imask": "^6.0.0",
@@ -1663,6 +1664,12 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@interactjs/types": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
+            "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
+            "license": "MIT"
+        },
         "node_modules/@ionic/cli-framework-output": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
@@ -1971,6 +1978,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+            "license": "Apache-2.0"
         },
         "node_modules/@kurkle/color": {
             "version": "0.3.4",
@@ -4141,6 +4154,36 @@
             "engines": {
                 "node": ">=20"
             }
+        },
+        "node_modules/@vexip-ui/hooks": {
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@vexip-ui/hooks/-/hooks-2.9.4.tgz",
+            "integrity": "sha512-dGUiBAeHIsnSVigGSPHcuHBVqrSGW8LV+zGohvOpBfXs8Ynn5ZcSmybIWJ3G826NsicPu9rqwcJG8uvSgG4k4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.7.0",
+                "@juggle/resize-observer": "^3.4.0",
+                "@vexip-ui/utils": "2.16.4"
+            },
+            "peerDependencies": {
+                "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vexip-ui/hooks/node_modules/@floating-ui/dom": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/core": "^1.8.0",
+                "@floating-ui/utils": "^0.2.12"
+            }
+        },
+        "node_modules/@vexip-ui/utils": {
+            "version": "2.16.4",
+            "resolved": "https://registry.npmjs.org/@vexip-ui/utils/-/utils-2.16.4.tgz",
+            "integrity": "sha512-KX+Q4EsuwDp6ZlRJ7OAkiYxu52D5CVM8zpqQz/FXYV+JUtzl9T3dvxgtA8gQ0wm5Sh/xT6jp8Wo4X7tLAzRh/A==",
+            "license": "MIT"
         },
         "node_modules/@vitejs/plugin-vue": {
             "version": "6.0.8",
@@ -6370,6 +6413,20 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/grid-layout-plus": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/grid-layout-plus/-/grid-layout-plus-1.1.1.tgz",
+            "integrity": "sha512-7CWehJubrVC8Ps5QFUlnDsp0kiREvKfi3Pdjp21EyY8BNzSusqI3Utcxvu1Y9UUKe3YExvbhJzIxHK6rorbRaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vexip-ui/hooks": "^2.8.0",
+                "@vexip-ui/utils": "^2.16.1",
+                "interactjs": "^1.10.27"
+            },
+            "peerDependencies": {
+                "vue": "^3.0.0"
+            }
+        },
         "node_modules/handlebars": {
             "version": "4.7.9",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -6581,6 +6638,15 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/interactjs": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
+            "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
+            "license": "MIT",
+            "dependencies": {
+                "@interactjs/types": "1.10.27"
+            }
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",

--- a/api/web/package.json
+++ b/api/web/package.json
@@ -80,6 +80,7 @@
         "floating-vue": "^2.0.0-beta.17",
         "geo-coordinates-parser": "^1.7.4",
         "geomagnetism": "^0.2.0",
+        "grid-layout-plus": "^1.1.1",
         "handlebars": "^4.7.9",
         "hls.js": "^1.6.5",
         "imask": "^6.0.0",

--- a/api/web/src/base/events.ts
+++ b/api/web/src/base/events.ts
@@ -38,6 +38,10 @@ export enum WorkerMessageType {
     Sync_Update = 'cloudtak:sync:update',
 
     Iconset_Change = 'cloudtak:iconset:change',
+
+    VideoWall_Ping = 'cloudtak:videowall:ping',
+    VideoWall_Pong = 'cloudtak:videowall:pong',
+    VideoWall_Refresh = 'cloudtak:videowall:refresh',
 }
 
 export type WorkerMessage = {

--- a/api/web/src/components/CloudTAK/util/FloatingVideo.vue
+++ b/api/web/src/components/CloudTAK/util/FloatingVideo.vue
@@ -51,21 +51,23 @@
                 />
             </span>
 
-            <TablerIconButton
-                v-if='!pushing'
-                title='Push to Video Wall'
-                @click='pushToWall'
-            >
-                <IconCast
-                    :size='24'
-                    stroke='1'
+            <template v-if='!isNativePlatform()'>
+                <TablerIconButton
+                    v-if='!pushing'
+                    title='Push to Video Wall'
+                    @click='pushToWall'
+                >
+                    <IconCast
+                        :size='24'
+                        stroke='1'
+                    />
+                </TablerIconButton>
+                <TablerLoading
+                    v-else
+                    :inline='true'
+                    desc='Pushing'
                 />
-            </TablerIconButton>
-            <TablerLoading
-                v-else
-                :inline='true'
-                desc='Pushing'
-            />
+            </template>
         </template>
 
         <div class='h-100 w-100 d-flex flex-column'>
@@ -99,6 +101,7 @@ import FloatingPane from './FloatingPane.vue';
 import VideoPlayer from '../../util/VideoPlayer.vue';
 import type { VideoPlayerMetadata } from '../../util/VideoPlayer.vue';
 import { notifyVideoWall } from '../../../lib/video-wall.ts';
+import { isNativePlatform } from '../../../base/capacitor.ts';
 import { useFloatStore } from '../../../stores/float.ts';
 import type { Pane, PaneVideoConfig } from '../../../stores/float.ts';
 import {

--- a/api/web/src/components/CloudTAK/util/FloatingVideo.vue
+++ b/api/web/src/components/CloudTAK/util/FloatingVideo.vue
@@ -6,16 +6,16 @@
     >
         <template #header>
             <StatusDot
-                v-if='active && active.metadata'
-                :status='active.metadata.active ? "success" : "unknown"'
+                v-if='metadata'
+                :status='metadata.active ? "success" : "unknown"'
                 :dark='true'
-                :title='active.metadata.active ? "Streaming" : "Unknown"'
+                :title='metadata.active ? "Streaming" : "Unknown"'
                 :size='24'
             />
 
             <VideoLeaseSourceType
-                v-if='active && active.metadata'
-                :source-type='active.metadata.source_type'
+                v-if='metadata && metadata.source_type'
+                :source-type='metadata.source_type'
                 :size='24'
             />
 
@@ -28,127 +28,87 @@
                     v-text='title'
                 />
                 <div
-                    v-if='active && active.metadata && active.metadata.source_model'
+                    v-if='metadata && metadata.source_model'
                     class='subheader'
-                    v-text='active.metadata.source_model'
+                    v-text='metadata.source_model'
                 />
             </div>
         </template>
 
         <template #actions>
             <span
-                v-if='active && active.metadata'
+                v-if='metadata'
                 class='watchers-info'
             >
                 <IconUsersGroup
                     :size='24'
                     stroke='1'
                 />
-                <span v-text='active.metadata.watchers + 1' />
+                <span v-text='metadata.watchers + 1' />
                 <span
                     class='ms-1 watcher-text'
-                    v-text='active.metadata.watchers + 1 > 1 ? "Watchers" : "Watcher"'
+                    v-text='metadata.watchers + 1 > 1 ? "Watchers" : "Watcher"'
                 />
             </span>
+
+            <TablerIconButton
+                v-if='!pushing'
+                title='Push to Video Wall'
+                @click='pushToWall'
+            >
+                <IconCast
+                    :size='24'
+                    stroke='1'
+                />
+            </TablerIconButton>
+            <TablerLoading
+                v-else
+                :inline='true'
+                desc='Pushing'
+            />
         </template>
 
-        <div
-            class='h-100 w-100'
-            :class='{ "modal-body--error": !!error }'
-        >
-            <div
-                v-if='loading'
-                class='col-12 d-flex align-items-center justify-content-center h-100'
-            >
-                <TablerLoading label='Loading Stream' />
-            </div>
-            <template v-else-if='error'>
-                <div class='error-state d-flex flex-column align-items-center justify-content-center text-center gap-3 h-100 w-100'>
-                    <div class='row g-2 w-100'>
-                        <TablerAlert
-                            class='error-alert w-100'
-                            title='Video Error'
-                            :compact='true'
-                            :err='error'
-                        />
-                    </div>
-
-                    <div class='row g-2 w-100 error-actions'>
-                        <div class='col-md-6'>
-                            <TablerButton
-                                class='w-100'
-                                @click='$emit("close")'
-                            >
-                                Close Player
-                            </TablerButton>
-                        </div>
-                        <div class='col-md-6'>
-                            <TablerButton
-                                class='w-100'
-                                @click='requestLease'
-                            >
-                                Retry
-                            </TablerButton>
-                        </div>
-                    </div>
-                </div>
-            </template>
-            <template v-else-if='!video || !videoProtocols || !videoProtocols.hls'>
-                <TablerNone
-                    label='No HLS Streaming Protocol'
-                    :create='false'
-                />
-            </template>
-            <template v-else>
-                <div class='position-relative w-100 h-100'>
-                    <video
-                        ref='videoTag'
-                        class='w-100 h-100 live-video'
-                        controls
-                        autoplay
-                        muted
-                    />
-                    
-                    <div
-                        v-if='isBuffering'
-                        class='buffering-overlay'
-                    >
-                        <div class='buffering-icon'>
-                            <IconPlayerPauseFilled :size='64' />
-                            <div class='mt-2 fw-bold'>
-                                Buffering...
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </template>
+        <div class='h-100 w-100 d-flex flex-column'>
+            <TablerAlert
+                v-if='pushError'
+                class='w-100 mb-0'
+                title='Video Wall Error'
+                :compact='true'
+                :err='pushError'
+            />
+            <VideoPlayer
+                class='flex-grow-1'
+                :url='video.config.url'
+                @metadata='metadata = $event'
+            />
         </div>
     </FloatingPane>
 </template>
 
 <script setup lang='ts'>
 /**
- * FloatingVideo - draggable, resizable HLS live-stream player with retry and muxer-restart recovery.
+ * FloatingVideo - draggable, resizable pane wrapping the unified VideoPlayer
+ * with stream metadata and push-to-Video-Wall support.
  */
 
-import { ref, computed, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
-import { std, stdurl } from '../../../../src/std.ts';
+import { ref, computed } from 'vue'
+import { std } from '../../../../src/std.ts';
 import StatusDot from './../../util/StatusDot.vue';
 import VideoLeaseSourceType from './VideoLeaseSourceType.vue';
 import FloatingPane from './FloatingPane.vue';
-import type { VideoLeaseResponse, VideoLeaseMetadata } from '../../../types.ts';
-import Hls from 'hls.js'
+import VideoPlayer from '../../util/VideoPlayer.vue';
+import type { VideoPlayerMetadata } from '../../util/VideoPlayer.vue';
+import { notifyVideoWall } from '../../../lib/video-wall.ts';
 import { useFloatStore } from '../../../stores/float.ts';
 import type { Pane, PaneVideoConfig } from '../../../stores/float.ts';
 import {
+    IconCast,
     IconUsersGroup,
-    IconPlayerPauseFilled
 } from '@tabler/icons-vue';
 import {
-    TablerNone,
     TablerAlert,
     TablerLoading,
-    TablerButton,
+    TablerIconButton,
 } from '@tak-ps/vue-tabler';
 
 const floatStore = useFloatStore();
@@ -164,400 +124,49 @@ const props = defineProps({
     }
 });
 
-const videoTag = useTemplateRef<HTMLVideoElement>('videoTag');
-
 const emit = defineEmits(['close']);
 
-const loading = ref(true);
-const error = ref<Error | undefined>();
-
-const retryCount = ref(0);
-const maxRetries = ref(3);
-
-const player = ref<Hls | undefined>()
-
 const video = ref(floatStore.panes.get(props.uid) as Pane<PaneVideoConfig>);
-const videoLease = ref<VideoLeaseResponse | undefined>();
-const videoProtocols = ref<VideoLeaseMetadata["protocols"] | undefined>();
 
-const active = ref();
+const metadata = ref<VideoPlayerMetadata | undefined>();
 
-const isBuffering = ref(false);
-const bufferCheckInterval = ref<number | undefined>();
-const bufferRecoveryTimeout = ref<number | undefined>();
-
-const BUFFER_LOW_THRESHOLD = 2;
-const BUFFER_RECOVERY_THRESHOLD = 5;
-const BUFFER_CHECK_INTERVAL_MS = 500;
-const BUFFER_RECOVERY_TIMEOUT_MS = 10000;
+const pushing = ref(false);
+const pushError = ref<Error | undefined>();
 
 const title = computed(() => {
-    if (active.value && active.value.metadata) {
-        return active.value.metadata.name;
+    if (metadata.value) {
+        return metadata.value.name;
     } else {
-        return props.title;
+        return video.value.name || props.title;
     }
 });
 
 /**
- * Monitor video buffer levels and pause/resume playback as needed
- * Prevents reaching the end of buffer which causes refresh loops
+ * Save the stream to the user's Video Wall & focus the wall - opening
+ * a new tab if no wall is currently open
  */
-function monitorBuffer(): void {
-    const video = videoTag.value;
-    if (!video) return;
+async function pushToWall(): Promise<void> {
+    if (pushing.value) return;
+
+    pushing.value = true;
+    pushError.value = undefined;
 
     try {
-        const buffered = video.buffered;
-        if (buffered.length === 0) {
-            if (isBuffering.value && !video.ended) return;
-            return;
-        }
-
-        const currentTime = video.currentTime;
-        const bufferedEnd = buffered.end(buffered.length - 1);
-        const bufferAhead = bufferedEnd - currentTime;
-
-        if (bufferAhead < BUFFER_LOW_THRESHOLD && !isBuffering.value && !video.ended) {
-            console.log(`Buffer running low (${bufferAhead.toFixed(2)}s), waiting for more data...`);
-            setBuffering(true);
-        }
-
-        if (bufferAhead > BUFFER_RECOVERY_THRESHOLD && isBuffering.value) {
-            console.log(`Buffer recovered (${bufferAhead.toFixed(2)}s), resuming playback...`);
-            setBuffering(false);
-
-            if (video.paused && !video.ended) {
-                video.play().catch(e => console.error("Failed to resume video playback after buffering:", e));
-            }
-        }
-    } catch (err) {
-        console.error('Error monitoring buffer:', err);
-    }
-}
-
-function clearBufferRecoveryTimeout(): void {
-    if (bufferRecoveryTimeout.value) {
-        clearTimeout(bufferRecoveryTimeout.value);
-        bufferRecoveryTimeout.value = undefined;
-    }
-}
-
-function setBuffering(buffering: boolean): void {
-    isBuffering.value = buffering;
-
-    if (!buffering) {
-        clearBufferRecoveryTimeout();
-        return;
-    }
-
-    clearBufferRecoveryTimeout();
-    bufferRecoveryTimeout.value = window.setTimeout(() => {
-        if (!isBuffering.value) return;
-
-        console.warn('Buffering did not recover in time, attempting stream restart');
-        handleStreamRestart();
-    }, BUFFER_RECOVERY_TIMEOUT_MS);
-}
-
-function clearBufferMonitoring(): void {
-    if (bufferCheckInterval.value) {
-        clearInterval(bufferCheckInterval.value);
-        bufferCheckInterval.value = undefined;
-    }
-
-    clearBufferRecoveryTimeout();
-    isBuffering.value = false;
-}
-
-function startBufferMonitoring(): void {
-    clearBufferMonitoring();
-    bufferCheckInterval.value = window.setInterval(monitorBuffer, BUFFER_CHECK_INTERVAL_MS);
-}
-
-function attachVideoEventHandlers(): void {
-    const video = videoTag.value;
-    if (!video) return;
-
-    video.onwaiting = () => {
-        if (!video.ended) setBuffering(true);
-    };
-
-    video.onstalled = () => {
-        if (!video.ended) setBuffering(true);
-    };
-
-    video.onplaying = () => {
-        setBuffering(false);
-    };
-
-    video.oncanplay = () => {
-        if (isBuffering.value) setBuffering(false);
-    };
-
-    video.onerror = () => {
-        setBuffering(false);
-    };
-}
-
-onUnmounted(async () => {
-    clearBufferMonitoring();
-
-    if (player.value) {
-        player.value.destroy();
-    }
-
-    await deleteLease();
-});
-
-onMounted(async () => {
-    await requestLease();
-});
-
-/**
- * Clean up video lease from CloudTAK server when component is destroyed
- */
-async function deleteLease(): Promise<void> {
-    if (!videoLease.value) return;
-
-    try {
-        await std(`/api/video/lease/${videoLease.value.id}`, {
-            method: 'DELETE',
-        });
-
-        loading.value = false;
-    } catch (err) {
-        loading.value = false;
-        error.value = err instanceof Error ? err : new Error(String(err));
-    }
-}
-
-/**
- * Create and configure HLS.js player with resilient settings for live streaming
- */
-async function createPlayer(): Promise<void> {
-    try {
-        const url = new URL(videoProtocols.value!.hls!.url);
-
-        attachVideoEventHandlers();
-
-        player.value = new Hls({
-            enableWorker: true,
-            lowLatencyMode: false, // More forgiving for stream restarts
-            debug: false,
-            backBufferLength: 90, // Keep more buffer for smoother playback
-            maxBufferLength: 30, // Larger buffer for resilience
-            maxMaxBufferLength: 600,
-            liveSyncDurationCount: 3, // More tolerant of discontinuities
-            liveMaxLatencyDurationCount: 10,
-            xhrSetup: (xhr: XMLHttpRequest) => {
-                if (url.username && url.password) {
-                    xhr.setRequestHeader('Authorization', 'Basic ' + btoa(`${url.username}:${url.password}`));
-                }
+        await std('/api/profile/video', {
+            method: 'POST',
+            body: {
+                url: video.value.config.url,
+                name: title.value
             }
         });
 
-        player.value.attachMedia(videoTag.value!);
+        await notifyVideoWall();
 
-        player.value.on(Hls.Events.MEDIA_ATTACHED, async () => {
-            if (player.value) player.value.loadSource(url.toString());
-        });
-
-        player.value.on(Hls.Events.MANIFEST_PARSED, async () => {
-            try {
-                if (videoTag.value) await videoTag.value.play();
-                
-                startBufferMonitoring();
-            } catch (err) {
-                console.error("Error playing video:", err);
-            }
-        });
-
-        // Enhanced error handling for MediaMTX muxer restarts and network issues
-        player.value.on(Hls.Events.ERROR, (event, data) => {
-            console.log("HLS Error:", data);
-
-            switch (data.type) {
-                case Hls.ErrorTypes.NETWORK_ERROR:
-                    if (!data.fatal) {
-                        setBuffering(true);
-
-                        if (player.value) {
-                            player.value.startLoad();
-                        }
-
-                        break;
-                    } else {
-                        console.log("Fatal network error:", data);
-                        handleStreamError(data.error);
-                        break;
-                    }
-                case Hls.ErrorTypes.MEDIA_ERROR:
-                    if (!data.fatal) {
-                        setBuffering(true);
-
-                        if (player.value) {
-                            try {
-                                player.value.recoverMediaError();
-                            } catch (err) {
-                                console.error('Failed to recover non-fatal media error:', err);
-                            }
-                        }
-
-                        break;
-                    } else {
-                        console.log("Fatal media error:", data);
-
-                        if (data.details === 'bufferAddCodecError' && data.error instanceof Error && data.error.name === 'NotSupportedError') {
-                            error.value = new Error(`Your browser does not support the required video codec for this stream (${data.mimeType}`);
-                        } else if (player.value) {
-                            try {
-                                player.value.recoverMediaError();
-                            } catch {
-                                handleStreamError(data.error);
-                            }
-                        } else {
-                            handleStreamError(data.error);
-                        }
-
-                        break;
-                    }
-                default:
-                    if (!data.fatal) return;
-
-                    handleStreamError(data.error);
-                    break;
-            }
-        })
+        emit('close');
     } catch (err) {
-        error.value = err instanceof Error ? err : new Error(String(err));
-    }
-}
-
-/**
- * Handle MediaMTX muxer restarts gracefully
- * This occurs when MediaMTX creates new segment naming due to source hiccups
- */
- function handleStreamRestart(): void {
-    const hls = player.value;
-    if (!hls || !videoProtocols.value?.hls) return;
-
-    console.log('Handling HLS stream restart (muxer restart detected)');
-
-    clearBufferMonitoring();
-
-    try {
-        hls.recoverMediaError();
-        hls.stopLoad();
-        hls.loadSource(hls.url!); 
-
-        const videoElement = hls.media;
-        if (videoElement) {
-            hls.once(Hls.Events.LEVEL_LOADED, () => {
-                // Seek to the end (live edge) to bypass the stalled gap
-                if (Number.isFinite(videoElement.duration) && videoElement.duration > 0) {
-                    videoElement.currentTime = videoElement.duration;
-                }
-
-                hls.startLoad();
-                videoElement.play().catch(e => console.error("Play failed", e));
-                startBufferMonitoring();
-            });
-
-            setBuffering(true);
-        }
-    } catch (err) {
-        console.error('Error handling stream restart:', err);
-        handleStreamError(err instanceof Error ? err : new Error(String(err)));
-    }
-}
-
-/**
- * Handle stream errors with exponential backoff retry logic
- */
-function handleStreamError(streamError: Error): void {
-    clearBufferMonitoring();
-
-    if (retryCount.value < maxRetries.value) {
-        const delay = 1000 * Math.pow(2, retryCount.value); // 1s, 2s, 4s
-        console.log(`Retrying stream in ${delay}ms (attempt ${retryCount.value + 1}/${maxRetries.value})`);
-
-        retryCount.value++;
-
-        setTimeout(() => {
-            if (player.value) {
-                player.value.destroy();
-                player.value = undefined;
-            }
-
-            createPlayer();
-        }, delay);
-    } else {
-        console.error('Max retries reached, giving up');
-
-        if (player.value) {
-            player.value.destroy();
-            player.value = undefined;
-        }
-
-        error.value = streamError;
-        retryCount.value = 0;
-    }
-}
-
-/**
- * Request video lease from CloudTAK server and initialize streaming
- * Handles both existing active streams and creation of new temporary leases
- */
-async function requestLease(): Promise<void> {
-    if (!video.value) {
-        error.value = new Error('Video URL could not be loaded');
-        return;
-    } else if (!Hls.isSupported()) {
-        error.value = new Error('HLS.js is not supported in this browser.');
-        return;
-    } else {
-        error.value = undefined;
-    }
-
-    try {
-        const url = stdurl('/api/video/active');
-        url.searchParams.set('url', video.value.config.url)
-        active.value = await std(url);
-
-        if (active.value.metadata) {
-            videoProtocols.value = active.value.metadata.protocols;
-            loading.value = false;
-        } else if (active.value.leasable) {
-            const lease = await std('/api/video/lease', {
-                method: 'POST',
-                body:  {
-                    name: 'Temporary Lease',
-                    ephemeral: true, // Hidden from streaming list
-                    duration: 1 * 60 * 60, // 1 hour lease
-                    proxy: video.value.config.url
-                }
-            }) as VideoLeaseResponse
-
-            const { protocols } = await std(`/api/video/lease/${lease.path}/metadata`) as VideoLeaseMetadata;
-
-            videoLease.value = lease;
-            videoProtocols.value = protocols;
-
-            loading.value = false;
-        } else if (!active.value.leasable) {
-            error.value = new Error(active.value.message || 'Could not start stream');
-        }
-
-        if (!error.value && videoProtocols.value && videoProtocols.value.hls) {
-            retryCount.value = 0;
-            nextTick(() => {
-                createPlayer();
-            });
-        }
-    } catch (err) {
-        loading.value = false;
-        error.value = err instanceof Error ? err : new Error(String(err));
+        pushError.value = err instanceof Error ? err : new Error(String(err));
+    } finally {
+        pushing.value = false;
     }
 }
 </script>
@@ -565,22 +174,6 @@ async function requestLease(): Promise<void> {
 <style>
 .video-container {
     container-type: inline-size;
-}
-
-.modal-body--error {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.error-state {
-    padding: 1rem;
-    max-width: 520px;
-}
-
-.error-alert,
-.error-actions {
-    max-width: 480px;
 }
 
 @container (max-width: 500px) {
@@ -592,51 +185,6 @@ async function requestLease(): Promise<void> {
 @container (max-width: 450px) {
     .watchers-info {
         display: none !important;
-    }
-}
-
-.live-video::-webkit-media-controls-timeline {
-    display: none;
-}
-
-.live-video::-webkit-media-controls-current-time-display {
-    display: none;
-}
-
-.live-video::-webkit-media-controls-time-remaining-display {
-    display: none;
-}
-
-.buffering-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 10;
-    pointer-events: none;
-    backdrop-filter: blur(2px);
-}
-
-.buffering-icon {
-    color: white;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-    0%, 100% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.6;
     }
 }
 </style>

--- a/api/web/src/components/CloudTAK/util/Keywords.vue
+++ b/api/web/src/components/CloudTAK/util/Keywords.vue
@@ -131,6 +131,7 @@ const props = withDefaults(defineProps<{
 }>(), {
     keywords: () => [],
     placeholder: 'No Keywords',
+    relevant: undefined,
 });
 
 const { placeholder } = props;

--- a/api/web/src/components/VideoWall.vue
+++ b/api/web/src/components/VideoWall.vue
@@ -1,17 +1,7 @@
 <template>
-    <VideoWall
-        v-if='user'
-        :user='user'
-    />
+    <VideoWall />
 </template>
 
 <script setup lang='ts'>
 import VideoWall from './VideoWall/Main.vue';
-
-defineProps({
-    user: {
-        type: Object,
-        required: true
-    }
-});
 </script>

--- a/api/web/src/components/VideoWall/Main.vue
+++ b/api/web/src/components/VideoWall/Main.vue
@@ -252,7 +252,7 @@ async function removeVideo(id: string): Promise<void> {
 
         layout.value = layout.value.filter((item) => String(item.i) !== id);
         leases.value.delete(id);
-        names.value.delete(id);
+        names.delete(id);
         saved.value.delete(id);
     } catch (err) {
         error.value = err instanceof Error ? err : new Error(String(err));

--- a/api/web/src/components/VideoWall/Main.vue
+++ b/api/web/src/components/VideoWall/Main.vue
@@ -115,7 +115,7 @@
  * the wall from the Map View and placement is persisted per-user.
  */
 
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, reactive, onMounted, onUnmounted } from 'vue';
 import { GridLayout, GridItem } from 'grid-layout-plus';
 import type { Layout } from 'grid-layout-plus';
 import { std, stdurl } from '../../std.ts';
@@ -141,7 +141,7 @@ const layout = ref<Layout>([]);
 
 // ProfileVideo ID => Video Lease ID / resolved lease name
 const leases = ref<Map<string, number>>(new Map());
-const names = ref<Map<string, string>>(new Map());
+const names = reactive(new Map<string, string>());
 
 // Last known server-side positions - used to only PATCH videos that moved
 const saved = ref<Map<string, { x: number, y: number, w: number, h: number }>>(new Map());
@@ -252,7 +252,7 @@ async function removeVideo(id: string): Promise<void> {
 
         layout.value = layout.value.filter((item) => String(item.i) !== id);
         leases.value.delete(id);
-        names.value.delete(id);
+        names.delete(id);
         saved.value.delete(id);
     } catch (err) {
         error.value = err instanceof Error ? err : new Error(String(err));

--- a/api/web/src/components/VideoWall/Main.vue
+++ b/api/web/src/components/VideoWall/Main.vue
@@ -1,79 +1,281 @@
 <template>
-    <div class='h-full w-full cloudtak-bg text-white'>
-        <div
-            v-if='loading'
-        >
-            <TablerLoading />
+    <div class='h-full w-full cloudtak-bg text-white d-flex flex-column video-wall'>
+        <div class='d-flex align-items-center px-3 py-2 border-bottom video-wall-header'>
+            <img
+                class='cloudtak-logo me-2'
+                src='/CloudTAKLogo.svg'
+                alt='CloudTAK Logo'
+                draggable='false'
+            >
+            <div class='fs-3 fw-bold user-select-none'>
+                Video Wall
+            </div>
+
+            <div class='btn-list ms-auto'>
+                <TablerIconButton
+                    title='Refresh Videos'
+                    @click='refresh'
+                >
+                    <IconRefresh
+                        :size='24'
+                        stroke='1'
+                    />
+                </TablerIconButton>
+            </div>
         </div>
-        <div
-            v-else-if='error'
-        >
-            <TablerAlert
-                :err='error'
-            />
+
+        <div class='flex-grow-1 overflow-auto'>
+            <div
+                v-if='loading'
+                class='d-flex align-items-center justify-content-center h-100'
+            >
+                <TablerLoading desc='Loading Video Wall' />
+            </div>
+            <div
+                v-else-if='error'
+                class='d-flex align-items-center justify-content-center h-100'
+            >
+                <TablerAlert
+                    title='Video Wall Error'
+                    :err='error'
+                />
+            </div>
+            <div
+                v-else-if='layout.length === 0'
+                class='d-flex align-items-center justify-content-center h-100'
+            >
+                <TablerNone
+                    label='No Videos on the Wall'
+                    :create='false'
+                />
+            </div>
+            <GridLayout
+                v-else
+                v-model:layout='layout'
+                :col-num='12'
+                :row-height='60'
+                :margin='[8, 8]'
+                :is-draggable='true'
+                :is-resizable='true'
+                :vertical-compact='true'
+                :use-css-transforms='true'
+                @layout-updated='saveLayout'
+            >
+                <GridItem
+                    v-for='item in layout'
+                    :key='item.i'
+                    :i='item.i'
+                    :x='item.x'
+                    :y='item.y'
+                    :w='item.w'
+                    :h='item.h'
+                    :min-w='2'
+                    :min-h='3'
+                    drag-allow-from='.video-wall-drag'
+                    drag-ignore-from='.video-wall-nodrag'
+                >
+                    <div class='d-flex flex-column h-100 w-100 cloudtak-panel overflow-hidden'>
+                        <div class='d-flex align-items-center px-2 py-1 border-bottom video-wall-drag cursor-move'>
+                            <IconGripVertical
+                                :size='20'
+                                stroke='1'
+                            />
+                            <div
+                                class='text-sm text-truncate mx-2 user-select-none'
+                                v-text='names.get(String(item.i)) || "Video Stream"'
+                            />
+                            <div class='btn-list ms-auto video-wall-nodrag'>
+                                <TablerIconButton
+                                    title='Remove from Wall'
+                                    @click='removeVideo(String(item.i))'
+                                >
+                                    <IconX
+                                        :size='20'
+                                        stroke='1'
+                                    />
+                                </TablerIconButton>
+                            </div>
+                        </div>
+                        <VideoPlayer
+                            class='flex-grow-1 overflow-hidden video-wall-nodrag'
+                            :lease='leases.get(String(item.i))'
+                            @metadata='names.set(String(item.i), $event.name)'
+                        />
+                    </div>
+                </GridItem>
+            </GridLayout>
         </div>
-        <div
-            v-else-if='list.total === 0'
-        >
-            <TablerNone
-                label='No Video Sources Configured'
-                :create='false'
-            />
-        </div>
-        <template v-else>
-            <span v-text='list' />
-        </template>
     </div>
 </template>
 
 <script setup lang='ts'>
-import { ref, onMounted } from 'vue';
-import { server } from '../../std.ts';
+/**
+ * VideoWall - persistent grid of the user's saved video streams with
+ * drag & drop re-ordering, resizing and removal. Videos are pushed onto
+ * the wall from the Map View and placement is persisted per-user.
+ */
+
+import { ref, onMounted, onUnmounted } from 'vue';
+import { GridLayout, GridItem } from 'grid-layout-plus';
+import type { Layout } from 'grid-layout-plus';
+import { std, stdurl } from '../../std.ts';
+import { registerVideoWall } from '../../lib/video-wall.ts';
 import type { ProfileVideoList } from '../../types.ts';
+import VideoPlayer from '../util/VideoPlayer.vue';
+import {
+    IconX,
+    IconRefresh,
+    IconGripVertical,
+} from '@tabler/icons-vue';
 import {
     TablerNone,
-    TablerLoading,
     TablerAlert,
+    TablerLoading,
+    TablerIconButton,
 } from '@tak-ps/vue-tabler';
 
 const loading = ref(true);
 const error = ref<Error | undefined>();
 
-const list = ref<ProfileVideoList>({
-    total: 0,
-    items: []
-});
+const layout = ref<Layout>([]);
 
-const paging = ref<{
-    page: number;
-    limit: number;
-    order: 'asc' | 'desc';
-}>({
-    page: 0,
-    limit: 20,
-    order: 'desc'
-});
+// ProfileVideo ID => Video Lease ID / resolved lease name
+const leases = ref<Map<string, number>>(new Map());
+const names = ref<Map<string, string>>(new Map());
+
+// Last known server-side positions - used to only PATCH videos that moved
+const saved = ref<Map<string, { x: number, y: number, w: number, h: number }>>(new Map());
+
+const saveTimeout = ref<number | undefined>();
+
+let deregister: (() => void) | undefined;
 
 onMounted(async () => {
+    deregister = registerVideoWall(() => {
+        refresh();
+    });
+
     await listVideos();
 });
 
-async function listVideos() {
+onUnmounted(() => {
+    if (deregister) deregister();
+
+    if (saveTimeout.value) {
+        window.clearTimeout(saveTimeout.value);
+    }
+});
+
+async function refresh(): Promise<void> {
+    loading.value = true;
+    await listVideos();
+}
+
+async function listVideos(): Promise<void> {
     try {
-        const res = await server.GET('/api/profile/video', {
-            params: {
-                query: paging.value
-            }
-        })
+        error.value = undefined;
+
+        const url = stdurl('/api/profile/video');
+        url.searchParams.set('limit', '1000');
+        const list = await std(url) as ProfileVideoList;
+
+        const items: Layout = [];
+        const leaseMap = new Map<string, number>();
+        const savedMap = new Map<string, { x: number, y: number, w: number, h: number }>();
+
+        for (const video of list.items) {
+            items.push({
+                i: video.id,
+                x: video.position.x,
+                y: video.position.y,
+                w: video.position.w,
+                h: video.position.h,
+            });
+
+            leaseMap.set(video.id, video.lease);
+            savedMap.set(video.id, { ...video.position });
+        }
+
+        layout.value = items;
+        leases.value = leaseMap;
+        saved.value = savedMap;
 
         loading.value = false;
-        if (res.error) throw new Error(res.error.message);
-
-        list.value = res.data;
     } catch (err) {
+        loading.value = false;
         error.value = err instanceof Error ? err : new Error(String(err));
     }
 }
 
+/**
+ * Persist changed grid placements - debounced as drag operations can push
+ * a burst of layout updates as other items reflow around the moved item
+ */
+function saveLayout(updated: Layout): void {
+    if (saveTimeout.value) {
+        window.clearTimeout(saveTimeout.value);
+    }
 
+    saveTimeout.value = window.setTimeout(async () => {
+        for (const item of updated) {
+            const id = String(item.i);
+            const prev = saved.value.get(id);
+
+            if (!prev) continue;
+
+            const position = { x: item.x, y: item.y, w: item.w, h: item.h };
+
+            if (
+                prev.x === position.x && prev.y === position.y
+                && prev.w === position.w && prev.h === position.h
+            ) continue;
+
+            try {
+                await std(`/api/profile/video/${id}`, {
+                    method: 'PATCH',
+                    body: { position }
+                });
+
+                saved.value.set(id, position);
+            } catch (err) {
+                console.error('Failed to save Video Wall layout:', err);
+            }
+        }
+    }, 500);
+}
+
+async function removeVideo(id: string): Promise<void> {
+    try {
+        await std(`/api/profile/video/${id}`, {
+            method: 'DELETE'
+        });
+
+        layout.value = layout.value.filter((item) => String(item.i) !== id);
+        leases.value.delete(id);
+        names.value.delete(id);
+        saved.value.delete(id);
+    } catch (err) {
+        error.value = err instanceof Error ? err : new Error(String(err));
+    }
+}
 </script>
+
+<style>
+.video-wall .cloudtak-logo {
+    height: 32px;
+    width: 32px;
+}
+
+.video-wall .cursor-move {
+    cursor: move;
+}
+
+.video-wall .vgl-item--placeholder {
+    background: rgba(0, 132, 255, 0.3);
+    border-radius: 4px;
+}
+
+.video-wall .vgl-item__resizer {
+    z-index: 20;
+}
+</style>

--- a/api/web/src/components/util/VideoPlayer.vue
+++ b/api/web/src/components/util/VideoPlayer.vue
@@ -71,10 +71,10 @@
  * Lease `lease` ID (renewed automatically when expired).
  */
 
-import { ref, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue';
 import { std, stdurl } from '../../std.ts';
 import type { VideoLeaseResponse, VideoLeaseMetadata } from '../../types.ts';
-import Hls from 'hls.js'
+import Hls from 'hls.js';
 import {
     IconPlayerPauseFilled
 } from '@tabler/icons-vue';
@@ -255,12 +255,12 @@ async function deleteLease(): Promise<void> {
 
         loading.value = false;
     } catch (err) {
-        loading.value = false;
         setError(err instanceof Error ? err : new Error(String(err)));
     }
 }
 
 function setError(err: Error): void {
+    loading.value = false;
     error.value = err;
     emit('error', err);
 }
@@ -271,6 +271,13 @@ function setError(err: Error): void {
 async function createPlayer(): Promise<void> {
     try {
         const url = new URL(videoProtocols.value!.hls!.url);
+
+        // Send embedded basic-auth credentials via the Authorization header only,
+        // keeping them out of the URL exposed to devtools, caches & hls.js telemetry
+        const username = decodeURIComponent(url.username);
+        const password = decodeURIComponent(url.password);
+        url.username = '';
+        url.password = '';
 
         attachVideoEventHandlers();
 
@@ -284,8 +291,8 @@ async function createPlayer(): Promise<void> {
             liveSyncDurationCount: 3, // More tolerant of discontinuities
             liveMaxLatencyDurationCount: 10,
             xhrSetup: (xhr: XMLHttpRequest) => {
-                if (url.username && url.password) {
-                    xhr.setRequestHeader('Authorization', 'Basic ' + btoa(`${url.username}:${url.password}`));
+                if (username && password) {
+                    xhr.setRequestHeader('Authorization', 'Basic ' + btoa(`${username}:${password}`));
                 }
             }
         });
@@ -342,7 +349,7 @@ async function createPlayer(): Promise<void> {
                         console.log("Fatal media error:", data);
 
                         if (data.details === 'bufferAddCodecError' && data.error instanceof Error && data.error.name === 'NotSupportedError') {
-                            setError(new Error(`Your browser does not support the required video codec for this stream (${data.mimeType}`));
+                            setError(new Error(`Your browser does not support the required video codec for this stream${data.mimeType ? ` (${data.mimeType})` : ''}`));
                         } else if (player.value) {
                             try {
                                 player.value.recoverMediaError();
@@ -361,7 +368,7 @@ async function createPlayer(): Promise<void> {
                     handleStreamError(data.error);
                     break;
             }
-        })
+        });
     } catch (err) {
         setError(err instanceof Error ? err : new Error(String(err)));
     }
@@ -444,7 +451,7 @@ function handleStreamError(streamError: Error): void {
  */
 async function requestUrlStream(url: string): Promise<void> {
     const active_url = stdurl('/api/video/active');
-    active_url.searchParams.set('url', url)
+    active_url.searchParams.set('url', url);
     const active = await std(active_url) as {
         leasable: boolean;
         message?: string;
@@ -464,7 +471,7 @@ async function requestUrlStream(url: string): Promise<void> {
                 duration: 1 * 60 * 60, // 1 hour lease
                 proxy: url
             }
-        }) as VideoLeaseResponse
+        }) as VideoLeaseResponse;
 
         const { protocols } = await std(`/api/video/lease/${lease.path}/metadata`) as VideoLeaseMetadata;
 
@@ -516,12 +523,14 @@ async function requestLeaseStream(leaseId: number): Promise<void> {
  * Request the video stream from the CloudTAK server and initialize playback
  */
 async function requestStream(): Promise<void> {
+    loading.value = true;
+
     if (!Hls.isSupported()) {
         setError(new Error('HLS.js is not supported in this browser.'));
         return;
-    } else {
-        error.value = undefined;
     }
+
+    error.value = undefined;
 
     try {
         if (props.lease !== undefined) {
@@ -540,7 +549,6 @@ async function requestStream(): Promise<void> {
             });
         }
     } catch (err) {
-        loading.value = false;
         setError(err instanceof Error ? err : new Error(String(err)));
     }
 }

--- a/api/web/src/components/util/VideoPlayer.vue
+++ b/api/web/src/components/util/VideoPlayer.vue
@@ -111,7 +111,7 @@ const error = ref<Error | undefined>();
 const retryCount = ref(0);
 const maxRetries = ref(3);
 
-const player = ref<Hls | undefined>()
+const player = ref<Hls | undefined>();
 
 const videoLease = ref<VideoLeaseResponse | undefined>();
 const videoProtocols = ref<VideoLeaseMetadata["protocols"] | undefined>();

--- a/api/web/src/components/util/VideoPlayer.vue
+++ b/api/web/src/components/util/VideoPlayer.vue
@@ -1,0 +1,606 @@
+<template>
+    <div class='h-100 w-100 video-player'>
+        <div
+            v-if='loading'
+            class='col-12 d-flex align-items-center justify-content-center h-100'
+        >
+            <TablerLoading desc='Loading Stream' />
+        </div>
+        <template v-else-if='error'>
+            <div class='video-player-error d-flex flex-column align-items-center justify-content-center text-center gap-3 h-100 w-100'>
+                <div class='row g-2 w-100'>
+                    <TablerAlert
+                        class='video-player-error-alert w-100'
+                        title='Video Error'
+                        :compact='true'
+                        :err='error'
+                    />
+                </div>
+
+                <div class='row g-2 w-100 video-player-error-actions'>
+                    <div class='col-12'>
+                        <TablerButton
+                            class='w-100'
+                            @click='requestStream'
+                        >
+                            Retry
+                        </TablerButton>
+                    </div>
+                </div>
+            </div>
+        </template>
+        <template v-else-if='!videoProtocols || !videoProtocols.hls'>
+            <TablerNone
+                label='No HLS Streaming Protocol'
+                :create='false'
+            />
+        </template>
+        <template v-else>
+            <div class='position-relative w-100 h-100'>
+                <video
+                    ref='videoTag'
+                    class='w-100 h-100 live-video'
+                    controls
+                    autoplay
+                    muted
+                />
+
+                <div
+                    v-if='isBuffering'
+                    class='buffering-overlay'
+                >
+                    <div class='buffering-icon'>
+                        <IconPlayerPauseFilled :size='64' />
+                        <div class='mt-2 fw-bold'>
+                            Buffering...
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
+</template>
+
+<script setup lang='ts'>
+/**
+ * VideoPlayer - Unified HLS live-stream player used by the Floating Video Pane
+ * and the Video Wall, with retry and MediaMTX muxer-restart recovery.
+ *
+ * Streams are supplied either as a raw stream `url` (resolved via /api/video/active,
+ * creating a temporary ephemeral lease when required) or as an existing Video
+ * Lease `lease` ID (renewed automatically when expired).
+ */
+
+import { ref, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue'
+import { std, stdurl } from '../../std.ts';
+import type { VideoLeaseResponse, VideoLeaseMetadata } from '../../types.ts';
+import Hls from 'hls.js'
+import {
+    IconPlayerPauseFilled
+} from '@tabler/icons-vue';
+import {
+    TablerNone,
+    TablerAlert,
+    TablerLoading,
+    TablerButton,
+} from '@tak-ps/vue-tabler';
+
+export type VideoPlayerMetadata = {
+    name: string;
+    active: boolean;
+    watchers: number;
+    source_type?: string;
+    source_model?: string;
+};
+
+const props = defineProps<{
+    url?: string;
+    lease?: number;
+}>();
+
+const emit = defineEmits<{
+    metadata: [metadata: VideoPlayerMetadata];
+    error: [error: Error];
+}>();
+
+const videoTag = useTemplateRef<HTMLVideoElement>('videoTag');
+
+const loading = ref(true);
+const error = ref<Error | undefined>();
+
+const retryCount = ref(0);
+const maxRetries = ref(3);
+
+const player = ref<Hls | undefined>()
+
+const videoLease = ref<VideoLeaseResponse | undefined>();
+const videoProtocols = ref<VideoLeaseMetadata["protocols"] | undefined>();
+
+const isBuffering = ref(false);
+const bufferCheckInterval = ref<number | undefined>();
+const bufferRecoveryTimeout = ref<number | undefined>();
+
+const BUFFER_LOW_THRESHOLD = 2;
+const BUFFER_RECOVERY_THRESHOLD = 5;
+const BUFFER_CHECK_INTERVAL_MS = 500;
+const BUFFER_RECOVERY_TIMEOUT_MS = 10000;
+const LEASE_RENEW_DURATION = 60 * 60 * 24;
+
+/**
+ * Monitor video buffer levels and pause/resume playback as needed
+ * Prevents reaching the end of buffer which causes refresh loops
+ */
+function monitorBuffer(): void {
+    const video = videoTag.value;
+    if (!video) return;
+
+    try {
+        const buffered = video.buffered;
+        if (buffered.length === 0) {
+            if (isBuffering.value && !video.ended) return;
+            return;
+        }
+
+        const currentTime = video.currentTime;
+        const bufferedEnd = buffered.end(buffered.length - 1);
+        const bufferAhead = bufferedEnd - currentTime;
+
+        if (bufferAhead < BUFFER_LOW_THRESHOLD && !isBuffering.value && !video.ended) {
+            console.log(`Buffer running low (${bufferAhead.toFixed(2)}s), waiting for more data...`);
+            setBuffering(true);
+        }
+
+        if (bufferAhead > BUFFER_RECOVERY_THRESHOLD && isBuffering.value) {
+            console.log(`Buffer recovered (${bufferAhead.toFixed(2)}s), resuming playback...`);
+            setBuffering(false);
+
+            if (video.paused && !video.ended) {
+                video.play().catch(e => console.error("Failed to resume video playback after buffering:", e));
+            }
+        }
+    } catch (err) {
+        console.error('Error monitoring buffer:', err);
+    }
+}
+
+function clearBufferRecoveryTimeout(): void {
+    if (bufferRecoveryTimeout.value) {
+        clearTimeout(bufferRecoveryTimeout.value);
+        bufferRecoveryTimeout.value = undefined;
+    }
+}
+
+function setBuffering(buffering: boolean): void {
+    isBuffering.value = buffering;
+
+    if (!buffering) {
+        clearBufferRecoveryTimeout();
+        return;
+    }
+
+    clearBufferRecoveryTimeout();
+    bufferRecoveryTimeout.value = window.setTimeout(() => {
+        if (!isBuffering.value) return;
+
+        console.warn('Buffering did not recover in time, attempting stream restart');
+        handleStreamRestart();
+    }, BUFFER_RECOVERY_TIMEOUT_MS);
+}
+
+function clearBufferMonitoring(): void {
+    if (bufferCheckInterval.value) {
+        clearInterval(bufferCheckInterval.value);
+        bufferCheckInterval.value = undefined;
+    }
+
+    clearBufferRecoveryTimeout();
+    isBuffering.value = false;
+}
+
+function startBufferMonitoring(): void {
+    clearBufferMonitoring();
+    bufferCheckInterval.value = window.setInterval(monitorBuffer, BUFFER_CHECK_INTERVAL_MS);
+}
+
+function attachVideoEventHandlers(): void {
+    const video = videoTag.value;
+    if (!video) return;
+
+    video.onwaiting = () => {
+        if (!video.ended) setBuffering(true);
+    };
+
+    video.onstalled = () => {
+        if (!video.ended) setBuffering(true);
+    };
+
+    video.onplaying = () => {
+        setBuffering(false);
+    };
+
+    video.oncanplay = () => {
+        if (isBuffering.value) setBuffering(false);
+    };
+
+    video.onerror = () => {
+        setBuffering(false);
+    };
+}
+
+onUnmounted(async () => {
+    clearBufferMonitoring();
+
+    if (player.value) {
+        player.value.destroy();
+    }
+
+    await deleteLease();
+});
+
+onMounted(async () => {
+    await requestStream();
+});
+
+/**
+ * Clean up ephemeral video leases created by this player when it is destroyed
+ * Leases passed in via the `lease` prop are never deleted
+ */
+async function deleteLease(): Promise<void> {
+    if (!videoLease.value) return;
+
+    try {
+        await std(`/api/video/lease/${videoLease.value.id}`, {
+            method: 'DELETE',
+        });
+
+        loading.value = false;
+    } catch (err) {
+        loading.value = false;
+        setError(err instanceof Error ? err : new Error(String(err)));
+    }
+}
+
+function setError(err: Error): void {
+    error.value = err;
+    emit('error', err);
+}
+
+/**
+ * Create and configure HLS.js player with resilient settings for live streaming
+ */
+async function createPlayer(): Promise<void> {
+    try {
+        const url = new URL(videoProtocols.value!.hls!.url);
+
+        attachVideoEventHandlers();
+
+        player.value = new Hls({
+            enableWorker: true,
+            lowLatencyMode: false, // More forgiving for stream restarts
+            debug: false,
+            backBufferLength: 90, // Keep more buffer for smoother playback
+            maxBufferLength: 30, // Larger buffer for resilience
+            maxMaxBufferLength: 600,
+            liveSyncDurationCount: 3, // More tolerant of discontinuities
+            liveMaxLatencyDurationCount: 10,
+            xhrSetup: (xhr: XMLHttpRequest) => {
+                if (url.username && url.password) {
+                    xhr.setRequestHeader('Authorization', 'Basic ' + btoa(`${url.username}:${url.password}`));
+                }
+            }
+        });
+
+        player.value.attachMedia(videoTag.value!);
+
+        player.value.on(Hls.Events.MEDIA_ATTACHED, async () => {
+            if (player.value) player.value.loadSource(url.toString());
+        });
+
+        player.value.on(Hls.Events.MANIFEST_PARSED, async () => {
+            try {
+                if (videoTag.value) await videoTag.value.play();
+
+                startBufferMonitoring();
+            } catch (err) {
+                console.error("Error playing video:", err);
+            }
+        });
+
+        // Enhanced error handling for MediaMTX muxer restarts and network issues
+        player.value.on(Hls.Events.ERROR, (event, data) => {
+            console.log("HLS Error:", data);
+
+            switch (data.type) {
+                case Hls.ErrorTypes.NETWORK_ERROR:
+                    if (!data.fatal) {
+                        setBuffering(true);
+
+                        if (player.value) {
+                            player.value.startLoad();
+                        }
+
+                        break;
+                    } else {
+                        console.log("Fatal network error:", data);
+                        handleStreamError(data.error);
+                        break;
+                    }
+                case Hls.ErrorTypes.MEDIA_ERROR:
+                    if (!data.fatal) {
+                        setBuffering(true);
+
+                        if (player.value) {
+                            try {
+                                player.value.recoverMediaError();
+                            } catch (err) {
+                                console.error('Failed to recover non-fatal media error:', err);
+                            }
+                        }
+
+                        break;
+                    } else {
+                        console.log("Fatal media error:", data);
+
+                        if (data.details === 'bufferAddCodecError' && data.error instanceof Error && data.error.name === 'NotSupportedError') {
+                            setError(new Error(`Your browser does not support the required video codec for this stream (${data.mimeType}`));
+                        } else if (player.value) {
+                            try {
+                                player.value.recoverMediaError();
+                            } catch {
+                                handleStreamError(data.error);
+                            }
+                        } else {
+                            handleStreamError(data.error);
+                        }
+
+                        break;
+                    }
+                default:
+                    if (!data.fatal) return;
+
+                    handleStreamError(data.error);
+                    break;
+            }
+        })
+    } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+    }
+}
+
+/**
+ * Handle MediaMTX muxer restarts gracefully
+ * This occurs when MediaMTX creates new segment naming due to source hiccups
+ */
+ function handleStreamRestart(): void {
+    const hls = player.value;
+    if (!hls || !videoProtocols.value?.hls) return;
+
+    console.log('Handling HLS stream restart (muxer restart detected)');
+
+    clearBufferMonitoring();
+
+    try {
+        hls.recoverMediaError();
+        hls.stopLoad();
+        hls.loadSource(hls.url!);
+
+        const videoElement = hls.media;
+        if (videoElement) {
+            hls.once(Hls.Events.LEVEL_LOADED, () => {
+                // Seek to the end (live edge) to bypass the stalled gap
+                if (Number.isFinite(videoElement.duration) && videoElement.duration > 0) {
+                    videoElement.currentTime = videoElement.duration;
+                }
+
+                hls.startLoad();
+                videoElement.play().catch(e => console.error("Play failed", e));
+                startBufferMonitoring();
+            });
+
+            setBuffering(true);
+        }
+    } catch (err) {
+        console.error('Error handling stream restart:', err);
+        handleStreamError(err instanceof Error ? err : new Error(String(err)));
+    }
+}
+
+/**
+ * Handle stream errors with exponential backoff retry logic
+ */
+function handleStreamError(streamError: Error): void {
+    clearBufferMonitoring();
+
+    if (retryCount.value < maxRetries.value) {
+        const delay = 1000 * Math.pow(2, retryCount.value); // 1s, 2s, 4s
+        console.log(`Retrying stream in ${delay}ms (attempt ${retryCount.value + 1}/${maxRetries.value})`);
+
+        retryCount.value++;
+
+        setTimeout(() => {
+            if (player.value) {
+                player.value.destroy();
+                player.value = undefined;
+            }
+
+            createPlayer();
+        }, delay);
+    } else {
+        console.error('Max retries reached, giving up');
+
+        if (player.value) {
+            player.value.destroy();
+            player.value = undefined;
+        }
+
+        setError(streamError);
+        retryCount.value = 0;
+    }
+}
+
+/**
+ * Resolve a raw stream URL via CloudTAK - either an existing active stream
+ * or by creating a new temporary ephemeral lease
+ */
+async function requestUrlStream(url: string): Promise<void> {
+    const active_url = stdurl('/api/video/active');
+    active_url.searchParams.set('url', url)
+    const active = await std(active_url) as {
+        leasable: boolean;
+        message?: string;
+        metadata?: VideoPlayerMetadata & { protocols: VideoLeaseMetadata["protocols"] };
+    };
+
+    if (active.metadata) {
+        videoProtocols.value = active.metadata.protocols;
+        emit('metadata', active.metadata);
+        loading.value = false;
+    } else if (active.leasable) {
+        const lease = await std('/api/video/lease', {
+            method: 'POST',
+            body:  {
+                name: 'Temporary Lease',
+                ephemeral: true, // Hidden from streaming list
+                duration: 1 * 60 * 60, // 1 hour lease
+                proxy: url
+            }
+        }) as VideoLeaseResponse
+
+        const { protocols } = await std(`/api/video/lease/${lease.path}/metadata`) as VideoLeaseMetadata;
+
+        videoLease.value = lease;
+        videoProtocols.value = protocols;
+
+        loading.value = false;
+    } else {
+        setError(new Error(active.message || 'Could not start stream'));
+    }
+}
+
+/**
+ * Resolve an existing Video Lease by ID - renewing the lease if it has expired
+ */
+async function requestLeaseStream(leaseId: number): Promise<void> {
+    let lease = await std(`/api/video/lease/${leaseId}`) as VideoLeaseResponse;
+
+    if (lease.expiration && new Date(lease.expiration).getTime() < Date.now()) {
+        try {
+            lease = await std(`/api/video/lease/${leaseId}`, {
+                method: 'PATCH',
+                body: {
+                    duration: LEASE_RENEW_DURATION
+                }
+            }) as VideoLeaseResponse;
+        } catch (err) {
+            // Leases the user cannot manage (ie shared leases) cannot be renewed
+            console.error('Could not renew video lease:', err);
+        }
+    }
+
+    const metadata = await std(`/api/video/lease/${lease.path}/metadata`) as VideoLeaseMetadata;
+
+    videoProtocols.value = metadata.protocols;
+
+    emit('metadata', {
+        name: lease.name,
+        active: metadata.path ? metadata.path.ready : false,
+        watchers: metadata.path ? metadata.path.readers.length : 0,
+        source_type: lease.source_type,
+        source_model: lease.source_model || ''
+    });
+
+    loading.value = false;
+}
+
+/**
+ * Request the video stream from the CloudTAK server and initialize playback
+ */
+async function requestStream(): Promise<void> {
+    if (!Hls.isSupported()) {
+        setError(new Error('HLS.js is not supported in this browser.'));
+        return;
+    } else {
+        error.value = undefined;
+    }
+
+    try {
+        if (props.lease !== undefined) {
+            await requestLeaseStream(props.lease);
+        } else if (props.url) {
+            await requestUrlStream(props.url);
+        } else {
+            setError(new Error('Video URL could not be loaded'));
+            return;
+        }
+
+        if (!error.value && videoProtocols.value && videoProtocols.value.hls) {
+            retryCount.value = 0;
+            nextTick(() => {
+                createPlayer();
+            });
+        }
+    } catch (err) {
+        loading.value = false;
+        setError(err instanceof Error ? err : new Error(String(err)));
+    }
+}
+</script>
+
+<style>
+.video-player-error {
+    padding: 1rem;
+    max-width: 520px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.video-player-error-alert,
+.video-player-error-actions {
+    max-width: 480px;
+}
+
+.live-video::-webkit-media-controls-timeline {
+    display: none;
+}
+
+.live-video::-webkit-media-controls-current-time-display {
+    display: none;
+}
+
+.live-video::-webkit-media-controls-time-remaining-display {
+    display: none;
+}
+
+.buffering-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+    pointer-events: none;
+    backdrop-filter: blur(2px);
+}
+
+.buffering-icon {
+    color: white;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.6;
+    }
+}
+</style>

--- a/api/web/src/lib/video-wall.ts
+++ b/api/web/src/lib/video-wall.ts
@@ -6,22 +6,18 @@
  * can either notify it to refresh or open a new tab.
  */
 
-const CHANNEL_NAME = 'cloudtak:video-wall';
+import { WorkerMessageType } from '../base/events.ts';
+import type { WorkerMessage } from '../base/events.ts';
 
 export const VIDEO_WALL_PATH = '/video';
 export const VIDEO_WALL_WINDOW = 'cloudtak-video-wall';
-
-type WallMessage = {
-    type: 'ping' | 'pong' | 'refresh';
-    nonce?: string;
-};
 
 /**
  * Determine if a Video Wall tab is currently open by pinging over the BroadcastChannel
  */
 export function isVideoWallOpen(timeout = 500): Promise<boolean> {
     return new Promise((resolve) => {
-        const channel = new BroadcastChannel(CHANNEL_NAME);
+        const channel = new BroadcastChannel('cloudtak');
         const nonce = crypto.randomUUID();
 
         const timer = window.setTimeout(() => {
@@ -29,15 +25,15 @@ export function isVideoWallOpen(timeout = 500): Promise<boolean> {
             resolve(false);
         }, timeout);
 
-        channel.onmessage = (msg: MessageEvent<WallMessage>) => {
-            if (msg.data && msg.data.type === 'pong' && msg.data.nonce === nonce) {
+        channel.onmessage = (msg: MessageEvent<WorkerMessage>) => {
+            if (msg.data && msg.data.type === WorkerMessageType.VideoWall_Pong && msg.data.body.nonce === nonce) {
                 window.clearTimeout(timer);
                 channel.close();
                 resolve(true);
             }
         };
 
-        channel.postMessage({ type: 'ping', nonce });
+        channel.postMessage({ type: WorkerMessageType.VideoWall_Ping, body: { nonce } });
     });
 }
 
@@ -47,8 +43,8 @@ export function isVideoWallOpen(timeout = 500): Promise<boolean> {
  */
 export async function notifyVideoWall(): Promise<void> {
     if (await isVideoWallOpen()) {
-        const channel = new BroadcastChannel(CHANNEL_NAME);
-        channel.postMessage({ type: 'refresh' });
+        const channel = new BroadcastChannel('cloudtak');
+        channel.postMessage({ type: WorkerMessageType.VideoWall_Refresh });
         channel.close();
     } else {
         window.open(VIDEO_WALL_PATH, VIDEO_WALL_WINDOW);
@@ -60,14 +56,14 @@ export async function notifyVideoWall(): Promise<void> {
  * the callback when another tab pushes a new video. Returns a cleanup function.
  */
 export function registerVideoWall(onRefresh: () => void): () => void {
-    const channel = new BroadcastChannel(CHANNEL_NAME);
+    const channel = new BroadcastChannel('cloudtak');
 
-    channel.onmessage = (msg: MessageEvent<WallMessage>) => {
+    channel.onmessage = (msg: MessageEvent<WorkerMessage>) => {
         if (!msg.data) return;
 
-        if (msg.data.type === 'ping') {
-            channel.postMessage({ type: 'pong', nonce: msg.data.nonce });
-        } else if (msg.data.type === 'refresh') {
+        if (msg.data.type === WorkerMessageType.VideoWall_Ping) {
+            channel.postMessage({ type: WorkerMessageType.VideoWall_Pong, body: { nonce: msg.data.body.nonce } });
+        } else if (msg.data.type === WorkerMessageType.VideoWall_Refresh) {
             onRefresh();
         }
     };

--- a/api/web/src/lib/video-wall.ts
+++ b/api/web/src/lib/video-wall.ts
@@ -1,0 +1,76 @@
+/*
+ * Cross-Tab communication with the Video Wall
+ *
+ * The Video Wall runs as its own browser tab (video.html => /video). The Map view
+ * pushes videos onto the wall and needs to know if a wall tab is already open so it
+ * can either notify it to refresh or open a new tab.
+ */
+
+const CHANNEL_NAME = 'cloudtak:video-wall';
+
+export const VIDEO_WALL_PATH = '/video';
+export const VIDEO_WALL_WINDOW = 'cloudtak-video-wall';
+
+type WallMessage = {
+    type: 'ping' | 'pong' | 'refresh';
+    nonce?: string;
+};
+
+/**
+ * Determine if a Video Wall tab is currently open by pinging over the BroadcastChannel
+ */
+export function isVideoWallOpen(timeout = 500): Promise<boolean> {
+    return new Promise((resolve) => {
+        const channel = new BroadcastChannel(CHANNEL_NAME);
+        const nonce = crypto.randomUUID();
+
+        const timer = window.setTimeout(() => {
+            channel.close();
+            resolve(false);
+        }, timeout);
+
+        channel.onmessage = (msg: MessageEvent<WallMessage>) => {
+            if (msg.data && msg.data.type === 'pong' && msg.data.nonce === nonce) {
+                window.clearTimeout(timer);
+                channel.close();
+                resolve(true);
+            }
+        };
+
+        channel.postMessage({ type: 'ping', nonce });
+    });
+}
+
+/**
+ * Notify an open Video Wall that its contents have changed, or open a new
+ * Video Wall tab if one isn't open
+ */
+export async function notifyVideoWall(): Promise<void> {
+    if (await isVideoWallOpen()) {
+        const channel = new BroadcastChannel(CHANNEL_NAME);
+        channel.postMessage({ type: 'refresh' });
+        channel.close();
+    } else {
+        window.open(VIDEO_WALL_PATH, VIDEO_WALL_WINDOW);
+    }
+}
+
+/**
+ * Register the current tab as the Video Wall - responds to pings and invokes
+ * the callback when another tab pushes a new video. Returns a cleanup function.
+ */
+export function registerVideoWall(onRefresh: () => void): () => void {
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+
+    channel.onmessage = (msg: MessageEvent<WallMessage>) => {
+        if (!msg.data) return;
+
+        if (msg.data.type === 'ping') {
+            channel.postMessage({ type: 'pong', nonce: msg.data.nonce });
+        } else if (msg.data.type === 'refresh') {
+            onRefresh();
+        }
+    };
+
+    return () => channel.close();
+}

--- a/api/web/vite.config.ts
+++ b/api/web/vite.config.ts
@@ -78,6 +78,8 @@ export default defineConfig(({ mode }) => {
                             req.url = '/connection.html';
                         } else if (req.url?.startsWith('/setup') && !path.extname(req.url)) {
                             req.url = '/setup.html';
+                        } else if (req.url?.startsWith('/video') && !path.extname(req.url)) {
+                            req.url = '/video.html';
                         }
                         next();
                     });


### PR DESCRIPTION
### Context

- :tada: Implement the Video Wall - a full-page grid of a user's saved video streams with drag & drop re-ordering, dynamic resizing & removal
- :tada: Add a "Push to Video Wall" button to the Floating Video Pane which saves the stream to the wall & opens (or notifies) the Video Wall tab
- :tada: Persist Video Wall placement in the `profile_videos` table via a new `position` column & `PATCH /api/profile/video/:id` endpoint
- :tada: `POST /api/profile/video` now accepts a raw stream `url` - resolving it to an existing Video Lease or creating a user-owned proxy lease
- :rocket: Extract a unified `VideoPlayer` component (hls.js) shared by the Floating Video Pane & the Video Wall
- :white_check_mark: Add tests covering Profile Video creation from leases & URLs, placement updates & deletion