### PR TITLE
Configurable Extra connect-src CSP Origins

### DIFF
--- a/api/nginx.conf.js
+++ b/api/nginx.conf.js
@@ -26,6 +26,22 @@ if (url.hostname === 'localhost') {
         'connect-src': [`'self'`]
     }
 
+    // Optional space-separated extra connect-src origins so a deployment can
+    // authorize plugins that consume an external data feed (e.g. a public
+    // websocket API) without editing this file or forking the image.
+    // Example: CSP_CONNECT_SRC='wss://ws1.blitzortung.org wss://*.example.com'
+    // Only conservative source-expression characters are accepted so a
+    // malformed value cannot break out of the quoted header.
+    if (process.env.CSP_CONNECT_SRC) {
+        for (const src of process.env.CSP_CONNECT_SRC.split(/\s+/).filter(Boolean)) {
+            if (/^[A-Za-z0-9*.:/-]+$/.test(src)) {
+                csp['connect-src'].push(src);
+            } else {
+                console.error(`CSP_CONNECT_SRC: ignoring invalid source "${src}"`);
+            }
+        }
+    }
+
     cspstr = `add_header 'Content-Security-Policy' "`
     for (const [key, value] of Object.entries(csp)) {
         console.error(key, value);


### PR DESCRIPTION
## Problem

The plugin system makes it easy to build frontend plugins that consume an external data feed — but the nginx CSP is fixed at `connect-src 'self'` (plus the API host), so any browser `fetch`/`WebSocket` to a third-party origin is blocked by the page's CSP in production. The only workaround today is forking/patching `api/nginx.conf.js` in the image.

Concrete case: a community lightning plugin (Blitzortung websocket feed, `wss://ws*.blitzortung.org`) works on a dev build but its socket is CSP-refused on any deployed instance.

## Change

`nginx.conf.js` accepts an optional space-separated `CSP_CONNECT_SRC` env var whose entries are appended to `connect-src`. Entries are validated against a conservative character allowlist (`[A-Za-z0-9*.:/-]`) so a malformed value cannot break out of the quoted header — invalid entries are logged to stderr and skipped.

**No behavior change when the variable is unset** — the generated config is identical to before.

## Testing

```
$ API_URL=https://map.example.com CSP_CONNECT_SRC='wss://ws1.blitzortung.org wss://*.blitzortung.org bad;value' node nginx.conf.js | grep -o "connect-src[^;]*" | head -1
connect-src 'self' wss://ws1.blitzortung.org wss://*.blitzortung.org map.example.com:* *.example.com:*
# stderr: CSP_CONNECT_SRC: ignoring invalid source "bad;value"

$ API_URL=https://map.example.com node nginx.conf.js | grep -o "connect-src[^;]*" | head -1
connect-src 'self' map.example.com:* *.example.com:*
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)