### PR TITLE
Access Level

### DIFF
--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionInfo.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionInfo.vue
@@ -179,6 +179,13 @@
                                     />
                                     <span>Deactivate</span>
                                 </button>
+
+                                <TablerInlineAlert
+                                    v-if='!canEditMission'
+                                    severity='info'
+                                    title='Read-Only Access'
+                                    description='You only have READ access to this mission so it cannot be made active.'
+                                />
                             </template>
                         </template>
 
@@ -268,6 +275,7 @@ import {
 } from '@tabler/icons-vue';
 import {
     TablerBorder,
+    TablerInlineAlert,
     TablerLoading,
     TablerModal,
     TablerNone,

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionInfo.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionInfo.vue
@@ -184,7 +184,7 @@
                                     v-if='!canEditMission'
                                     severity='info'
                                     title='Read-Only Access'
-                                    description='You only have READ access to this mission so it cannot be made active.'
+description='You have read-only access to this mission, so you cannot activate or deactivate it.'
                                 />
                             </template>
                         </template>


### PR DESCRIPTION
### Context

I lost 30 minutes scratching my head why the active button was grayed out...

- :rocket: Show an info section if the Make Active button is grayed out when the user is READ only

<img width="1108" height="1012" alt="image" src="https://github.com/user-attachments/assets/78d0c116-c976-499a-aed9-1bfb560666b8" />
