### PR TITLE
Data Sync Bugs

### DIFF
--- a/api/web/src/base/overlay-class.ts
+++ b/api/web/src/base/overlay-class.ts
@@ -592,8 +592,7 @@ export default class Overlay {
                 await mapStore.makeActiveMission(undefined);
             }
 
-            const { value: token } = await Preferences.get({ key: 'token' });
-            const sub = await Subscription.from(this.mode_id, token || '', {
+            const sub = await Subscription.from(this.mode_id, {
                 subscribed: true
             });
 

--- a/api/web/src/base/subscription-changes.ts
+++ b/api/web/src/base/subscription-changes.ts
@@ -11,17 +11,14 @@ import type {
 export default class SubscriptionChanges {
     guid: string;
 
-    token: string;
     missiontoken?: string;
 
     constructor(
         guid: string,
         opts: {
-            token: string,
             missiontoken?: string,
         }
     ) {
-        this.token = opts.token;
         this.missiontoken = opts.missiontoken;
 
         this.guid = guid;

--- a/api/web/src/base/subscription-contents.ts
+++ b/api/web/src/base/subscription-contents.ts
@@ -9,17 +9,14 @@ import type { Mission } from '../types.ts';
 export default class SubscriptionContents {
     guid: string;
 
-    token: string;
     missiontoken?: string;
 
     constructor(
         guid: string,
         opts: {
-            token: string,
             missiontoken?: string,
         }
     ) {
-        this.token = opts.token;
         this.missiontoken = opts.missiontoken;
 
         this.guid = guid;

--- a/api/web/src/base/subscription-feature.ts
+++ b/api/web/src/base/subscription-feature.ts
@@ -15,19 +15,16 @@ import { WorkerMessageType } from './events.ts';
 export default class SubscriptionFeature {
     parent: Subscription;
 
-    token: string;
     missiontoken?: string;
 
     constructor(
         parent: Subscription,
         opts: {
-            token: string,
             missiontoken?: string,
         }
     ) {
         this.parent = parent;
 
-        this.token = opts.token;
         this.missiontoken = opts.missiontoken;
     }
 

--- a/api/web/src/base/subscription-layer.ts
+++ b/api/web/src/base/subscription-layer.ts
@@ -50,19 +50,16 @@ async function updateLocalLayers(
 export default class SubscriptionLayer {
     parent: Subscription;
 
-    token: string;
     missiontoken?: string;
 
     constructor(
         parent: Subscription,
         opts: {
-            token: string,
             missiontoken?: string,
         }
     ) {
         this.parent = parent;
 
-        this.token = opts.token;
         this.missiontoken = opts.missiontoken;
     }
 

--- a/api/web/src/base/subscription-log.ts
+++ b/api/web/src/base/subscription-log.ts
@@ -12,17 +12,14 @@ import type {
 export default class SubscriptionLog {
     guid: string;
 
-    token: string;
     missiontoken?: string;
 
     constructor(
         guid: string,
         opts: {
-            token: string,
             missiontoken?: string,
         }
     ) {
-        this.token = opts.token;
         this.missiontoken = opts.missiontoken;
 
         this.guid = guid;

--- a/api/web/src/base/subscription.ts
+++ b/api/web/src/base/subscription.ts
@@ -171,10 +171,11 @@ export default class Subscription {
 
         if (exists) {
             if (opts.subscribed !== undefined || opts.missiontoken !== undefined) {
-                await exists.update({
-                    subscribed: opts.subscribed ?? exists.subscribed,
-                    token: opts.missiontoken ?? exists.token
-                });
+                const update: { subscribed?: boolean, token?: string } = {};
+                if (opts.subscribed !== undefined) update.subscribed = opts.subscribed;
+                if (opts.missiontoken !== undefined) update.token = opts.missiontoken;
+
+                await exists.update(update);
             }
 
             if (opts.reload !== false) {
@@ -266,7 +267,7 @@ export default class Subscription {
         }
 
         if (body.token !== undefined) {
-            this.token = body.token;
+            this.setMissionToken(body.token);
         }
 
         if (body.description !== undefined) {
@@ -276,7 +277,7 @@ export default class Subscription {
         await db.subscription.update(this.guid, {
             dirty: this.dirty,
             subscribed: this.subscribed,
-            token: this.missiontoken
+            token: this.missiontoken || ''
         });
 
         if (body.description !== undefined || body.keywords !== undefined || body.groups !== undefined) {
@@ -339,6 +340,20 @@ export default class Subscription {
     }
 
     /**
+     * Update the Mission Token, propagating it to the sub-stores which
+     * each hold their own copy for generating MissionAuthorization headers
+     */
+    setMissionToken(token?: string): void {
+        this.missiontoken = token || undefined;
+
+        this.log.missiontoken = this.missiontoken;
+        this.change.missiontoken = this.missiontoken;
+        this.contents.missiontoken = this.missiontoken;
+        this.feature.missiontoken = this.missiontoken;
+        this.layer.missiontoken = this.missiontoken;
+    }
+
+    /**
      * Reload the Mission from the local Database
      */
     async reload(): Promise<void> {
@@ -348,7 +363,7 @@ export default class Subscription {
         if (exists) {
             Object.assign(this.meta, exists.meta);
             this.role = exists.role;
-            this.missiontoken = exists.token;
+            this.setMissionToken(exists.token);
             this.subscribed = exists.subscribed;
         }
     };

--- a/api/web/src/base/subscription.ts
+++ b/api/web/src/base/subscription.ts
@@ -48,7 +48,6 @@ export default class Subscription {
     layer: SubscriptionLayer;
     chat: SubscriptionChat;
 
-    token: string;
     missiontoken?: string;
 
     dirty: boolean;
@@ -63,7 +62,6 @@ export default class Subscription {
         role: MissionRole,
         opts: {
             subscribed: boolean,
-            token: string,
             missiontoken?: string,
         }
     ) {
@@ -76,28 +74,23 @@ export default class Subscription {
         };
 
         this.log = new SubscriptionLog(mission.guid, {
-            missiontoken: opts.missiontoken,
-            token: opts.token
+            missiontoken: opts.missiontoken
         });
 
         this.change = new SubscriptionChanges(mission.guid, {
-            missiontoken: opts.missiontoken,
-            token: opts.token
+            missiontoken: opts.missiontoken
         });
 
         this.contents = new SubscriptionContents(mission.guid, {
-            missiontoken: opts.missiontoken,
-            token: opts.token
+            missiontoken: opts.missiontoken
         });
 
         this.feature = new SubscriptionFeature(this, {
-            missiontoken: opts.missiontoken,
-            token: opts.token
+            missiontoken: opts.missiontoken
         });
 
         this.layer = new SubscriptionLayer(this, {
-            missiontoken: opts.missiontoken,
-            token: opts.token
+            missiontoken: opts.missiontoken
         });
 
         this.chat = new SubscriptionChat(mission.guid, mission.name);
@@ -119,8 +112,6 @@ export default class Subscription {
             }
         }
 
-        this.token = opts.token;
-
         if (opts?.missiontoken) this.missiontoken = opts.missiontoken;
 
         this.dirty = false;
@@ -131,7 +122,6 @@ export default class Subscription {
      */
     static async from(
         guid: string,
-        token: string,
         opts?: {
             subscribed?: boolean
         }
@@ -147,7 +137,6 @@ export default class Subscription {
             exists.meta,
             exists.role,
             {
-                token: token,
                 missiontoken: exists.token,
                 subscribed: opts?.subscribed !== undefined ? opts.subscribed : exists.subscribed,
             }
@@ -161,13 +150,12 @@ export default class Subscription {
     static async load(
         guid: string,
         opts: {
-            token: string
             reload?: boolean,
             missiontoken?: string,
             subscribed?: boolean
-        }
+        } = {}
     ): Promise<Subscription> {
-        const exists = await this.from(guid, opts.token);
+        const exists = await this.from(guid);
 
         if (exists) {
             if (opts.subscribed !== undefined || opts.missiontoken !== undefined) {

--- a/api/web/src/components/CloudTAK/CoTView.vue
+++ b/api/web/src/components/CloudTAK/CoTView.vue
@@ -695,7 +695,6 @@
 
 <script setup lang='ts'>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
-import { Preferences } from '@capacitor/preferences';
 import { useRoute, useRouter } from 'vue-router'
 import FeatureIcon from './util/FeatureIcon.vue';
 import BufferInput from './Inputs/BufferInput.vue';
@@ -844,8 +843,7 @@ const interval = ref<ReturnType<typeof setInterval> | undefined>();
 watch(cot, async () => {
     if (cot.value) {
         if (cot.value.origin.mode === OriginMode.MISSION && cot.value.origin.mode_id) {
-            const { value: token } = await Preferences.get({ key: 'token' });
-            subscription.value = await Subscription.from(cot.value.origin.mode_id, token || '');
+            subscription.value = await Subscription.from(cot.value.origin.mode_id);
         } else {
             subscription.value = undefined;
         }
@@ -957,8 +955,7 @@ async function load_cot() {
     }))
 
     if (baseCOT && baseCOT.origin.mode === OriginMode.MISSION && baseCOT.origin.mode_id) {
-        const { value: token } = await Preferences.get({ key: 'token' });
-        subscription.value = await Subscription.from(baseCOT.origin.mode_id, token || '');
+        subscription.value = await Subscription.from(baseCOT.origin.mode_id);
     }
 
     if (baseCOT) {

--- a/api/web/src/components/CloudTAK/Menu/MenuMission.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuMission.vue
@@ -128,7 +128,6 @@
 
 <script setup lang='ts'>
 import { ref, onMounted } from 'vue';
-import { Preferences } from '@capacitor/preferences';
 import { std } from '../../../std.ts';
 import type { Feature } from '../../../types.ts';
 import type { Component } from 'vue';
@@ -248,10 +247,8 @@ async function fetchMission(reload = false): Promise<void> {
     loading.value = true;
 
     try {
-        const { value: storedToken } = await Preferences.get({ key: 'token' });
         subscription.value = await Subscription.load(String(route.params.mission), {
             reload,
-            token: String(storedToken || ''),
             missiontoken: token.value,
         });
 

--- a/api/web/src/components/CloudTAK/Menu/Mission/MissionContents.vue
+++ b/api/web/src/components/CloudTAK/Menu/Mission/MissionContents.vue
@@ -287,13 +287,9 @@ async function deleteFile(hash: string) {
 }
 
 const uploadHeaders = computed(() => {
-    const headers: Record<string, string> = {}
-
-    if (props.subscription.token) {
-        headers.MissionAuthorization = props.subscription.token;
-    };
-
-    return headers;
+    // The mission token, NOT the CloudTAK JWT - the server forwards this
+    // header verbatim to TAK Server as the Mission Token when present
+    return props.subscription.headers();
 });
 
 async function doneUpload() {

--- a/api/web/src/components/CloudTAK/RadialMenu/RadialMenu.vue
+++ b/api/web/src/components/CloudTAK/RadialMenu/RadialMenu.vue
@@ -204,7 +204,6 @@
 
 <script setup lang="ts">
 import { ref, shallowRef, onMounted, onUnmounted, nextTick, useTemplateRef, watch } from 'vue';
-import { Preferences } from '@capacitor/preferences';
 import { OriginMode } from '../../../base/cot.ts';
 import Subscription from '../../../base/subscription.ts';
 // @ts-expect-error no declaration file for RadialMenu.js
@@ -357,8 +356,7 @@ async function genMenuItems(
                     menuItems.value.push({ id: 'lock', icon: '#radial-lock' })
                 }
             } else if (cot.value.origin.mode === OriginMode.MISSION && cot.value.origin.mode_id) {
-                const { value: token } = await Preferences.get({ key: 'token' });
-                const sub = await Subscription.from(cot.value.origin.mode_id, token || '');
+                const sub = await Subscription.from(cot.value.origin.mode_id);
 
                 if (sub && sub.role && sub.role.permissions.includes("MISSION_WRITE")) {
                     // User pucks/skittles cannot be edited

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -721,9 +721,7 @@ export const useMapStore = defineStore('cloudtak', {
                 return null
             }
 
-            const { value: token } = await Preferences.get({ key: 'token' });
-
-            let sub = (await Subscription.from(guid, token || '', { subscribed: true })) || null;
+            let sub = (await Subscription.from(guid, { subscribed: true })) || null;
 
             if (sub) {
                 // Get map data on the map ASAP, even if it is stale
@@ -740,7 +738,6 @@ export const useMapStore = defineStore('cloudtak', {
             } else {
                 try {
                     sub = await Subscription.load(guid, {
-                        token: token || '',
                         reload: opts?.reload || false,
                         subscribed: true,
                         missiontoken: overlay.token || undefined

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -308,7 +308,7 @@ export default class AtlasDatabase {
             for (const sub of await Subscription.localList({
                 subscribed: true
             })) {
-                const store = await Subscription.from(sub.guid, this.atlas.token, {
+                const store = await Subscription.from(sub.guid, {
                     subscribed: true
                 });
 
@@ -541,7 +541,7 @@ export default class AtlasDatabase {
                 });
             }
         } else if (cot.origin.mode === OriginMode.MISSION && cot.origin.mode_id) {
-            const subscription = await Subscription.from(cot.origin.mode_id, this.atlas.token, {
+            const subscription = await Subscription.from(cot.origin.mode_id, {
                 subscribed: true
             });
 
@@ -611,7 +611,7 @@ export default class AtlasDatabase {
                 if (change.type === 'ADD_CONTENT') {
                     if (change.contentUid) this.subscriptionPending.set(change.contentUid, task.properties.mission.guid);
                 } else if (change.type === 'REMOVE_CONTENT') {
-                    const sub = await Subscription.from(task.properties.mission.guid, this.atlas.token, {
+                    const sub = await Subscription.from(task.properties.mission.guid, {
                         subscribed: true
                     });
                     if (!sub) {
@@ -631,7 +631,7 @@ export default class AtlasDatabase {
             }
 
             if (doMissionRefresh && task.properties.mission.guid) {
-                const sub = await Subscription.from(task.properties.mission.guid, this.atlas.token, {
+                const sub = await Subscription.from(task.properties.mission.guid, {
                     subscribed: true
                 });
 
@@ -649,7 +649,7 @@ export default class AtlasDatabase {
                 });
             }
         } else if (task.properties.type === 't-x-m-c-l' && task.properties.mission && task.properties.mission.guid) {
-            const sub = await Subscription.from(task.properties.mission.guid, this.atlas.token, {
+            const sub = await Subscription.from(task.properties.mission.guid, {
                 subscribed: true
             });
 
@@ -660,7 +660,7 @@ export default class AtlasDatabase {
 
             await sub.log.refresh();
         } else if (task.properties.type === 't-x-m-c-m' && task.properties.mission && task.properties.mission.guid) {
-            const sub = await Subscription.from(task.properties.mission.guid, this.atlas.token, {
+            const sub = await Subscription.from(task.properties.mission.guid, {
                 subscribed: true
             });
 
@@ -743,7 +743,7 @@ export default class AtlasDatabase {
                 throw new Error(`Cannot add ${feat.id} to a mission as no mission GUID was found - Please report this error`);
             }
 
-            const sub = await Subscription.from(mission_guid, this.atlas.token, {
+            const sub = await Subscription.from(mission_guid, {
                 subscribed: true
             });
 

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -730,10 +730,14 @@ export default class AtlasDatabase {
             const pendingGuid = this.subscriptionPending.get(feat.id);
             this.subscriptionPending.delete(feat.id);
 
+            // The feature's own mission must win over the Active Mission -
+            // otherwise updates to features in other subscribed missions get
+            // refiled (and, if authored, re-published) into the Active Mission
             const mission_guid =
-                this.mission // An Active Mission
-                || pendingGuid
-                || feat.origin?.mode_id; // The feature has a Mission Origin
+                pendingGuid // A Mission Change event told us which mission this belongs to
+                || feat.origin?.mode_id // The feature carries an explicit Mission Origin
+                || (exists && exists.origin.mode === OriginMode.MISSION ? exists.origin.mode_id : undefined) // Already filed in a Mission store
+                || this.mission; // An authored feature destined for the Active Mission
 
             if (!mission_guid) {
                 throw new Error(`Cannot add ${feat.id} to a mission as no mission GUID was found - Please report this error`);


### PR DESCRIPTION
### Context

- :bug: Fix Mission Token handling in `Subscription.update` - tokens were written to the user JWT field instead of `missiontoken`, never persisted, and never propagated to the Log/Change/Contents/Feature/Layer sub-stores, causing persistent 401s on password-protected Data Syncs
- :bug: Fix Active Mission hijacking feature filing - updates to features belonging to other subscribed missions were refiled (and re-published to the TAK Server if authored) into the Active Mission; the feature's own mission now takes precedence
- :bug: Fix Mission file uploads sending the CloudTAK JWT as the `MissionAuthorization` header instead of the Mission Token, breaking uploads to protected missions
