### PR TITLE
Consistent Menu Styling

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.api",
-    "version": "13.58.0",
+    "version": "13.59.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.api",
-            "version": "13.58.0",
+            "version": "13.59.1",
             "license": "ISC",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -3147,13 +3147,13 @@
             }
         },
         "node_modules/@turf/bbox": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
-            "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.4.0.tgz",
+            "integrity": "sha512-yOX9lALc2GmjYUIE99+nRj7eZA7eDtx7Ixu/hrgIo+YqHvL1reaPVTC9rQWMHMm0pH0/WHjzk8uOpAHjptrudQ==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/meta": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/meta": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3162,12 +3162,12 @@
             }
         },
         "node_modules/@turf/bbox-polygon": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.5.tgz",
-            "integrity": "sha512-Cs9Laej8zfSY51kORM9UcbY4Uf/7X3OIZr/LydbrmmARFSpYH/FZsEQjAGi1S1Q0aYbibVqjEUReHN3ZVsV5eA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.4.0.tgz",
+            "integrity": "sha512-hF0ylAOhzwk9i7m/PCmTtg+TP5AnFb9B+bMXgEPIYd/C3BOVet1YaA8nF6ViN5bNF0GSkWFYivvclSgWbtZyqg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3176,13 +3176,13 @@
             }
         },
         "node_modules/@turf/boolean-point-in-polygon": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
-            "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.4.0.tgz",
+            "integrity": "sha512-GQrHc6WSDHhf32GB/b9AGyOeC05AQ3nGN7ooWTrlCYefKn7X9/2wG9BNexF47AuyDq5jPdOvITVR26BLFWV+mA==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "point-in-polygon-hao": "^1.1.0",
                 "tslib": "^2.8.1"
@@ -3192,13 +3192,13 @@
             }
         },
         "node_modules/@turf/center": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.5.tgz",
-            "integrity": "sha512-eub5/Kfdmn89ZqwCONHI7astmTDEtN5M6+JfOkgoSyhKKFhUJYNxUyH1F/vCtIP7j1K369Vs4L9TYiuGapvIKQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.4.0.tgz",
+            "integrity": "sha512-JVuTaIdnQtmTV8eQfVxqza1okKiaFzgVeIA6Xoy/u6aBMxg2+oBpS6GcHZkEqR8OapPWValB1AYYqimUSiyOXw==",
             "license": "MIT",
             "dependencies": {
-                "@turf/bbox": "7.3.5",
-                "@turf/helpers": "7.3.5",
+                "@turf/bbox": "7.4.0",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3207,13 +3207,13 @@
             }
         },
         "node_modules/@turf/centroid": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.5.tgz",
-            "integrity": "sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.4.0.tgz",
+            "integrity": "sha512-WglCFe+TnMqeYa/LcbUp37NgIF0zHTNYmlxwUm40fyyzyLsYeDq4dgFWLTYpvRNqb5oIMV6xsBjSf+vCPtVJ6w==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/meta": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/meta": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3222,13 +3222,13 @@
             }
         },
         "node_modules/@turf/circle": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.5.tgz",
-            "integrity": "sha512-Tse7GJrx0rxaQ5BdY6pHZ9HFPrZwRMry2yaqq94UsUyonhy1m7U2icB3Zp4M8o4XjHIGTCq9i2BYcGJram51Sw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.4.0.tgz",
+            "integrity": "sha512-H7dXQP7WRpIE/UwZFFGYoSewsali5rjk9yzHPNZ03Bc9F11PWA3H+lwznEWmi/wLMMx91uMU+NkyGtJUeQr9cg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/destination": "7.3.5",
-                "@turf/helpers": "7.3.5",
+                "@turf/destination": "7.4.0",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3237,12 +3237,12 @@
             }
         },
         "node_modules/@turf/clone": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
-            "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.4.0.tgz",
+            "integrity": "sha512-IfYnuil7XYJauy3crzIYEr26QkmBiTgFdGfYwUUe3S6dawX+lyb3vhuaYyssEPcCJq83g0G7hwxZy7141Mmzjg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3251,13 +3251,13 @@
             }
         },
         "node_modules/@turf/destination": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.5.tgz",
-            "integrity": "sha512-x6ylChhOlIbucRSw7wF6z2gSEqqQl+dE0nSH5AL/ojZkqqGYahiw+2P4A8ZMuDM6rzH+FIqRYDes0o4nSArZCw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.4.0.tgz",
+            "integrity": "sha512-+jFpOUtzCiN8l9ZOvr66rxi/UxizphXaBDldaw9NfxlX/HcMn3ZDzC8IiCHiNXAilVh4WpCH0qqmH9ykOgdBKA==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3266,13 +3266,13 @@
             }
         },
         "node_modules/@turf/distance": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
-            "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.4.0.tgz",
+            "integrity": "sha512-ODkopQDG1m/U6Mx7OMmShncaCvneomwX3lZY1CDA7x40bhDdTTRYP/n/6LicZVyIO4/oK+aXkov4NOtWYthA2g==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3281,16 +3281,16 @@
             }
         },
         "node_modules/@turf/ellipse": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.5.tgz",
-            "integrity": "sha512-C478LrdvUkjwIVGN6PoYsFp27PuT+W2IH4ZOVt9sd4359hRPFhJ2m+f8jSPfS6rdamdvc/O+h7vNmOIBRP/TeA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.4.0.tgz",
+            "integrity": "sha512-m5s/fwYUbNN1MW/nW33sZ/jD58lMU1kGP6muU4inGAP7OxKbS15yz+Qg2aXsfyKcb0z19AFjhnCLQGWHU0sl1w==",
             "license": "MIT",
             "dependencies": {
-                "@turf/destination": "7.3.5",
-                "@turf/distance": "7.3.5",
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
-                "@turf/transform-rotate": "7.3.5",
+                "@turf/destination": "7.4.0",
+                "@turf/distance": "7.4.0",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
+                "@turf/transform-rotate": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3299,13 +3299,13 @@
             }
         },
         "node_modules/@turf/explode": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.5.tgz",
-            "integrity": "sha512-Qdd7ehX5AF0DdpJl+JJyxws7jEmsZBRV35wTm+Lyhapuc3yLHU7tN5EqJ+2lVV7RkUgBXEFQV+34pmPLPGQn+w==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.4.0.tgz",
+            "integrity": "sha512-kTWoryCTAiBwFvyJYNQWLJCaFx4bSRpyCjJWmuLoBEQRh9Fi4JLDEug+6JZxygMxCMWGXBH8/R3ICl+soLPFAg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/meta": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/meta": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3314,9 +3314,9 @@
             }
         },
         "node_modules/@turf/helpers": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
-            "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+            "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
             "license": "MIT",
             "dependencies": {
                 "@types/geojson": "^7946.0.10",
@@ -3327,12 +3327,12 @@
             }
         },
         "node_modules/@turf/invariant": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
-            "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.4.0.tgz",
+            "integrity": "sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3341,14 +3341,14 @@
             }
         },
         "node_modules/@turf/line-arc": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.5.tgz",
-            "integrity": "sha512-XrPicIoN7XCtiJ7e7ELje7GjMZrBw/nuJnz0mQoCwwHwmX8Oz9oRfb6uaiS8NeR4WBzUVdkmVR/ro0kW4lypog==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.4.0.tgz",
+            "integrity": "sha512-fkqfm3S1nRIBoKoK3LfpjDVGswyOw1cRb0W1qV6Na02ccrCJfJ7P9C4SkKZz2iakZioFCot4emraWno3B9YsYg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/circle": "7.3.5",
-                "@turf/destination": "7.3.5",
-                "@turf/helpers": "7.3.5",
+                "@turf/circle": "7.4.0",
+                "@turf/destination": "7.4.0",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3357,12 +3357,12 @@
             }
         },
         "node_modules/@turf/meta": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
-            "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.4.0.tgz",
+            "integrity": "sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
+                "@turf/helpers": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3371,15 +3371,15 @@
             }
         },
         "node_modules/@turf/nearest-point": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.5.tgz",
-            "integrity": "sha512-qcsbj9fo5CYhGeIDaJORoqiZyjNGu2+Te31MVaFoTTxqqkXypxp9e6HJGvUi2zPd1Zk3oAWXhvm1a+UXw2G56w==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.4.0.tgz",
+            "integrity": "sha512-rH+M5H/rWiOXStiHkV3Cs5OS+Tg/531Tonr7tm2pUjVy1RRLmDqSzKn+iFs3S6ybvjSK2pJa1BbTXjYlc8Pv3Q==",
             "license": "MIT",
             "dependencies": {
-                "@turf/clone": "7.3.5",
-                "@turf/distance": "7.3.5",
-                "@turf/helpers": "7.3.5",
-                "@turf/meta": "7.3.5",
+                "@turf/clone": "7.4.0",
+                "@turf/distance": "7.4.0",
+                "@turf/helpers": "7.4.0",
+                "@turf/meta": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3388,16 +3388,16 @@
             }
         },
         "node_modules/@turf/point-on-feature": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.5.tgz",
-            "integrity": "sha512-Y7W+JZJCmm9Qq93NHpk4dVhzAtAk2Uyau2Uk1ttCJ2Jsnuu4dwSjOurpmgDmMUe7yPmzihAUYhMFDumpAja8ZA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.4.0.tgz",
+            "integrity": "sha512-H7YamrW510QJLnhWIT9oecm1siwhwvb4SZrZSqu6hUOS+pFxumJjUYogE+B6kL+Ymtui2+h6cOtOHJnrNrKaEA==",
             "license": "MIT",
             "dependencies": {
-                "@turf/boolean-point-in-polygon": "7.3.5",
-                "@turf/center": "7.3.5",
-                "@turf/explode": "7.3.5",
-                "@turf/helpers": "7.3.5",
-                "@turf/nearest-point": "7.3.5",
+                "@turf/boolean-point-in-polygon": "7.4.0",
+                "@turf/center": "7.4.0",
+                "@turf/explode": "7.4.0",
+                "@turf/helpers": "7.4.0",
+                "@turf/nearest-point": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3406,13 +3406,13 @@
             }
         },
         "node_modules/@turf/rhumb-bearing": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.5.tgz",
-            "integrity": "sha512-pYjBAuQTND0+6Y+v+zlQ7Y68SGjP4iG8qJ5QKjFRbB/yeorTY3m9yiXIN4lSyno3TPzEgBeNULuo26H6ygDyng==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.4.0.tgz",
+            "integrity": "sha512-y5omgg5SqHwz46fZlra2/70z5eOKXSp/ZzRNIDYKJVYF5oNT2YbG9Z6lj4Az51bjqJQESXUoR6wRmFnpliIp0w==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3421,13 +3421,13 @@
             }
         },
         "node_modules/@turf/rhumb-destination": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.5.tgz",
-            "integrity": "sha512-znICdPBtZq5EKh/Qu0TkiMyNhqiYfM2VUlFOWa7iegCWe1E+X7q/f6rlZ5TcmYVyLZ95XZ6eciDNmgVmpHVWaw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.4.0.tgz",
+            "integrity": "sha512-3x4dNLheJJIK/6daH9U7dDkFRSq3wqvDIdqgSxsqgFHoNEI6xDACKGrx47JFWVbg/zh9osG5JSv96e70Y4P5XA==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3436,13 +3436,13 @@
             }
         },
         "node_modules/@turf/rhumb-distance": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.5.tgz",
-            "integrity": "sha512-dBFxmKrjRaAdwc4SCmGyAS2BDPCH35IBNl++Ypd1RB8JR2D3khl3zrTvxrlJ5qoN1WDvyPbvDYCrt2UnTX+8Nw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.4.0.tgz",
+            "integrity": "sha512-29pFCftS/yxEzrYWB777I23Mob+yw9WAECJNw+uabbJi6fwFphJfqWApMXY2ZnudVSJFCGJbByVAHVDTvOGG+w==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3451,16 +3451,16 @@
             }
         },
         "node_modules/@turf/sector": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.5.tgz",
-            "integrity": "sha512-9mtBorGPZfbZI2MoI0nkN5ogmbCz/NLpHdEM0UwwWiOW430iPhwZ649DXH32lDGerfzREX10vpamX8v1P9YVrw==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.4.0.tgz",
+            "integrity": "sha512-BGTbeT/LHW+6H43by4EQfAQaql94rOg5sxIN1T9/PeQR13KV6CnCVzxEmMzPVEZvy7VDfssv9eMerY0WGkjfYg==",
             "license": "MIT",
             "dependencies": {
-                "@turf/circle": "7.3.5",
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
-                "@turf/line-arc": "7.3.5",
-                "@turf/meta": "7.3.5",
+                "@turf/circle": "7.4.0",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
+                "@turf/line-arc": "7.4.0",
+                "@turf/meta": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3469,19 +3469,19 @@
             }
         },
         "node_modules/@turf/transform-rotate": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.5.tgz",
-            "integrity": "sha512-WXkteI0DihwCukZesVXVVYpsoyftYoiBtq1b+u1Dz4HyATK25zfEeWChlgRtApbiePF6uqG7bSQS+K8vjC4c0A==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.4.0.tgz",
+            "integrity": "sha512-JsXtvydU23rJdOlS5u9Fpdi6mPtbRCo8/6y3QSjkg37EubFTd357M+lX8+lQ+LHjs8hXxvp9LKBZwTujlqsDcw==",
             "license": "MIT",
             "dependencies": {
-                "@turf/centroid": "7.3.5",
-                "@turf/clone": "7.3.5",
-                "@turf/helpers": "7.3.5",
-                "@turf/invariant": "7.3.5",
-                "@turf/meta": "7.3.5",
-                "@turf/rhumb-bearing": "7.3.5",
-                "@turf/rhumb-destination": "7.3.5",
-                "@turf/rhumb-distance": "7.3.5",
+                "@turf/centroid": "7.4.0",
+                "@turf/clone": "7.4.0",
+                "@turf/helpers": "7.4.0",
+                "@turf/invariant": "7.4.0",
+                "@turf/meta": "7.4.0",
+                "@turf/rhumb-bearing": "7.4.0",
+                "@turf/rhumb-destination": "7.4.0",
+                "@turf/rhumb-distance": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -3490,13 +3490,13 @@
             }
         },
         "node_modules/@turf/truncate": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
-            "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.4.0.tgz",
+            "integrity": "sha512-eTXO62l1mD++mKlhUqLNHGcgCQvhxXJGB/EUL1KSzpVIeMYtgcmItAneWdHW+gEpmHfjeDjBuvtbZWA23r7Eig==",
             "license": "MIT",
             "dependencies": {
-                "@turf/helpers": "7.3.5",
-                "@turf/meta": "7.3.5",
+                "@turf/helpers": "7.4.0",
+                "@turf/meta": "7.4.0",
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
             },
@@ -4944,9 +4944,9 @@
             }
         },
         "node_modules/csv-stringify": {
-            "version": "6.8.1",
-            "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
-            "integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
+            "version": "6.8.2",
+            "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.2.tgz",
+            "integrity": "sha512-V0md5rBGlZb5WOfUmBWM8tr1+vvbe00EC2+ZhIYPKypA1GLvGuh0NzWEK0L+yRplocH7r37YGoT9uK0r1TtqBQ==",
             "license": "MIT"
         },
         "node_modules/cwise-compiler": {
@@ -6456,9 +6456,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+            "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -6536,9 +6536,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.8.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-            "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+            "version": "17.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+            "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7974,9 +7974,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.17",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
             "funding": [
                 {
                     "type": "github",
@@ -10256,9 +10256,9 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.23.1",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-            "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+            "version": "4.23.5",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+            "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.28.0"
@@ -11046,9 +11046,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-            "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.19.0"

--- a/api/web/src/App.vue
+++ b/api/web/src/App.vue
@@ -460,25 +460,29 @@ html[data-bs-theme='light'] .cloudtak-accent .text-white-50:not(.badge):not(.btn
 
 /*
  * Shared surface for panels floating above the map (navigation banner,
- * map controls, draggable floating panes). Sets --tblr-border-color so
+ * map controls, draggable floating panes, bottom panes). Sets --tblr-border-color so
  * Bootstrap border utilities inside the panel pick up the same subtle
- * separator color.
+ * separator color, and --tblr-card-box-shadow so panels built on a Tabler
+ * card get the panel shadow instead of the flat card one.
  */
 .cloudtak-panel {
+    --tblr-card-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
     border-radius: 8px;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+    box-shadow: var(--tblr-card-box-shadow);
 }
 
+/* Backgrounds mirror TablerDropdown's --tabler-dropdown-bg so floating panels
+ * read as the same surface as the notification dropdown. */
 html[data-bs-theme='dark'] .cloudtak-panel {
     --tblr-border-color: rgba(255, 255, 255, 0.14);
-    background-color: rgba(40, 53, 71, 0.95);
+    background-color: rgba(20, 20, 25, 0.96);
     color: rgba(255, 255, 255, 0.92);
     border: 1px solid rgba(255, 255, 255, 0.14);
 }
 
 html[data-bs-theme='light'] .cloudtak-panel {
     --tblr-border-color: rgba(0, 0, 0, 0.12);
-    background-color: rgba(255, 255, 255, 0.95);
+    background-color: rgba(255, 255, 255, 0.96);
     color: var(--tblr-body-color);
     border: 1px solid rgba(0, 0, 0, 0.12);
 }

--- a/api/web/src/components/CloudTAK/ActiveMission.vue
+++ b/api/web/src/components/CloudTAK/ActiveMission.vue
@@ -1,12 +1,10 @@
 <template>
     <div
-        class='d-flex text-white align-items-center px-2'
+        class='cloudtak-panel d-flex align-items-center px-2'
         style='
             z-index: 1;
             height: 60px;
-            max-width: 100%;
-            background-color: rgba(0, 0, 0, 0.5);
-            border-radius: 0px 0px 6px 0px;
+            max-width: calc(100vw - 16px);
         '
     >
         <template v-if='!mapStore.mission'>
@@ -45,7 +43,7 @@
             </div>
 
             <div
-                class='d-none d-md-block border-start border-white opacity-50 mx-1'
+                class='d-none d-md-block border-start mx-1'
                 style='height: 32px;'
             />
 

--- a/api/web/src/components/CloudTAK/Map.vue
+++ b/api/web/src/components/CloudTAK/Map.vue
@@ -55,7 +55,7 @@
 
             <GenericBottomPane v-if='mode === "SetLocation"'>
                 <div
-                    class='card user-select-none text-white cloudtak-bg rounded-top'
+                    class='card cloudtak-panel user-select-none'
                 >
                     <div class='card-header'>
                         <div class='col-8'>
@@ -109,8 +109,11 @@
 
             <div
                 v-if='mode === "Default"'
-                class='position-absolute beginning-0 text-white'
-                style='top: var(--status-bar-height, 0px);'
+                class='position-absolute'
+                style='
+                    top: calc(8px + var(--status-bar-height, 0px));
+                    left: 8px;
+                '
             >
                 <ActiveMission />
             </div>
@@ -126,7 +129,7 @@
                 class='position-absolute'
                 :class='{ "cloudtak-left-controls--nav": mapStore.navigation.active }'
                 style='
-                    top: calc(70px + var(--status-bar-height, 0px));
+                    top: calc(76px + var(--status-bar-height, 0px));
                     left: 8px;
                 '
             >
@@ -1081,12 +1084,12 @@ async function handleRadial(event: string): Promise<void> {
  */
 @media (max-width: 767.98px) {
     .cloudtak-navigating {
-        margin-top: 66px;
+        margin-top: 74px;
         border-radius: 8px;
     }
 
     .cloudtak-left-controls--nav {
-        top: 126px !important;
+        top: 134px !important;
     }
 }
 

--- a/api/web/src/components/CloudTAK/util/DrawOverlay.vue
+++ b/api/web/src/components/CloudTAK/util/DrawOverlay.vue
@@ -2,7 +2,7 @@
     <GenericBottomPane>
         <div
             v-if='mapStore.draw.mode === DrawToolMode.POINT'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <template v-if='!appStore.isMobileDetected'>
@@ -69,7 +69,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.CIRCLE'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconCircle
@@ -103,7 +103,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.RECTANGLE'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconVector
@@ -136,7 +136,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.LINESTRING || mapStore.draw.mode === DrawToolMode.SNAPPING'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconLine
@@ -210,7 +210,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.POLYGON'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconPolygon
@@ -243,7 +243,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.SECTOR'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconCone
@@ -276,7 +276,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.FREEHAND'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconLasso
@@ -341,7 +341,7 @@
         </div>
         <div
             v-else-if='mapStore.draw.mode === DrawToolMode.SELECT'
-            class='card user-select-none'
+            class='card cloudtak-panel user-select-none'
         >
             <div class='card-header'>
                 <IconPencil


### PR DESCRIPTION
Unifies the floating-panel surface styling across the map UI. Split out of the CoreDevice branch (#1632), which no longer contains any `api/web` changes.

- `App.vue` — `.cloudtak-panel` now sets `--tblr-card-box-shadow` so Tabler cards built on the panel pick up the panel shadow instead of the flat card one. Dark background aligned to `TablerDropdown`'s `--tabler-dropdown-bg` so floating panels read as the same surface as the notification dropdown.
- `ActiveMission.vue` — adopts `.cloudtak-panel` in place of its bespoke translucent black background and one-off border radius.
- `Map.vue` — `SetLocation` bottom pane adopts `.cloudtak-panel`; ActiveMission is inset 8px from the top/left edges, with the left controls and mobile offsets shifted to match.
- `DrawOverlay.vue` — all eight draw-mode cards adopt `.cloudtak-panel`.