### PR TITLE
Bump capacitor-network plugin from 0.1.2 to 0.1.3.

### DIFF
--- a/api/web/package-lock.json
+++ b/api/web/package-lock.json
@@ -21,7 +21,7 @@
                 "@capacitor/keyboard": "^8.0.3",
                 "@capacitor/preferences": "^8.0.1",
                 "@capacitor/status-bar": "^8.0.2",
-                "@capawesome/capacitor-network": "0.1.2",
+                "@capawesome/capacitor-network": "0.1.3",
                 "@capgo/background-geolocation": "^8.0.39",
                 "@capgo/capacitor-compass": "^8.1.17",
                 "@capgo/capacitor-updater": "^8.50.1",
@@ -548,9 +548,9 @@
             "license": "ISC"
         },
         "node_modules/@capawesome/capacitor-network": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@capawesome/capacitor-network/-/capacitor-network-0.1.2.tgz",
-            "integrity": "sha512-0eqMv7JNuOTS7+JqN1mMjgCGG3ORMbhhaM9jaKcm0yFWZgg+hDfrW1C6U517azrnKwk35msXNaSUg2DxfR6tIw==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@capawesome/capacitor-network/-/capacitor-network-0.1.3.tgz",
+            "integrity": "sha512-TlnT5iFIiMvkZaFg48HlEgMEijym/mzGbijaX/k/7VJIyrzhzzOQhYqZrOkwMINuhhFbHVJ9X5bnwnikc4uodg==",
             "funding": [
                 {
                     "type": "github",

--- a/api/web/package.json
+++ b/api/web/package.json
@@ -43,7 +43,7 @@
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/preferences": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
-        "@capawesome/capacitor-network": "0.1.2",
+        "@capawesome/capacitor-network": "0.1.3",
         "@capgo/background-geolocation": "^8.0.39",
         "@capgo/capacitor-compass": "^8.1.17",
         "@capgo/capacitor-updater": "^8.50.1",

--- a/api/web/src/stores/device/network.ts
+++ b/api/web/src/stores/device/network.ts
@@ -3,7 +3,7 @@ import type { PluginListenerHandle } from '@capacitor/core';
 import type { GetStatusResult } from '@capawesome/capacitor-network';
 
 /**
- * Network status exposed by `@capawesome/capacitor-network` 0.1.2.
+ * Network status exposed by `@capawesome/capacitor-network` 0.1.3.
  *
  * A connection, including validated public internet access, does not guarantee
  * that the configured TAK server is reachable.
@@ -46,10 +46,9 @@ export class NetworkStatus {
 
     /**
      * Conservative minimize-data signal, not proof of a satellite connection.
-     * Android: satellite on 15+, or bandwidth-constrained on 16+.
+     * Android: satellite on 15+, or bandwidth-constrained when API 36 or
+     * U Extensions 16 is available.
      * iOS: `NWPath.isUltraConstrained` on 26+. Unsupported on Web.
-     * Android 14/15 SDK Extensions support is tracked in
-     * capawesome-team/capacitor-plugins#964.
      */
     get isUltraConstrained(): boolean | null {
         return this.ultraConstrained;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@capacitor/keyboard": "^8.0.3",
                 "@capacitor/preferences": "^8.0.1",
                 "@capacitor/status-bar": "^8.0.2",
-                "@capawesome/capacitor-network": "0.1.2",
+                "@capawesome/capacitor-network": "0.1.3",
                 "@capgo/background-geolocation": "^8.0.39",
                 "@capgo/capacitor-compass": "^8.1.17",
                 "@capgo/capacitor-updater": "^8.50.1",
@@ -744,9 +744,9 @@
             "license": "ISC"
         },
         "node_modules/@capawesome/capacitor-network": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@capawesome/capacitor-network/-/capacitor-network-0.1.2.tgz",
-            "integrity": "sha512-0eqMv7JNuOTS7+JqN1mMjgCGG3ORMbhhaM9jaKcm0yFWZgg+hDfrW1C6U517azrnKwk35msXNaSUg2DxfR6tIw==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@capawesome/capacitor-network/-/capacitor-network-0.1.3.tgz",
+            "integrity": "sha512-TlnT5iFIiMvkZaFg48HlEgMEijym/mzGbijaX/k/7VJIyrzhzzOQhYqZrOkwMINuhhFbHVJ9X5bnwnikc4uodg==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/preferences": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
-        "@capawesome/capacitor-network": "0.1.2",
+        "@capawesome/capacitor-network": "0.1.3",
         "@capgo/background-geolocation": "^8.0.39",
         "@capgo/capacitor-compass": "^8.1.17",
         "@capgo/capacitor-updater": "^8.50.1",


### PR DESCRIPTION
This release adds bandwidth-constrained network detection through U Extensions 16 on Android.

Adding this extends support for constrained coverage detection to the older Android 14 and 15. Before this change it only worked on Android 16 and newer.

Android 14 and 15 runs on ~20% of US phones, according to [StatCounter](https://gs.statcounter.com/android-version-market-share/all/united-states-of-america).