### PR TITLE
Protect Icon Generation Path

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=/home/etl
 WORKDIR $HOME
 
 # Data source configuration
-ARG DATA_SOURCE_URL=https://github.com/dfpc-coe/CloudTAK-Data/archive/refs/tags/v1.1.0.zip
+ARG DATA_SOURCE_URL=https://github.com/dfpc-coe/CloudTAK-Data/archive/refs/tags/v1.2.0.zip
 ARG API_URL
 ARG USE_LOCAL_ZIP=false
 ARG WEB_PLUGINS

--- a/api/stateless/lib/sprites.ts
+++ b/api/stateless/lib/sprites.ts
@@ -103,22 +103,28 @@ export default class SpriteBuilder {
     static async from_icons(icons: Array<Static<typeof IconResponse>>, spriteConfig: SpriteConfig = {}) {
         const src = [];
         for (const icon of icons) {
-            const buff = Buffer.from(icon.data.split(',')[1], 'base64');
+            let contents: Buffer;
+            try {
+                const buff = Buffer.from(icon.data.split(',')[1], 'base64');
 
-            const contents = await Sharp(buff)
-                .resize({
-                    width: 32,
-                    height: 48,
-                    fit: 'contain',
-                    background: {
-                        r: 0,
-                        g: 0,
-                        b: 0,
-                        alpha: 0,
-                    },
-                })
-                .png()
-                .toBuffer();
+                contents = await Sharp(buff)
+                    .resize({
+                        width: 32,
+                        height: 48,
+                        fit: 'contain',
+                        background: {
+                            r: 0,
+                            g: 0,
+                            b: 0,
+                            alpha: 0,
+                        },
+                    })
+                    .png()
+                    .toBuffer();
+            } catch (err) {
+                console.error(`not ok - failed to process icon ${icon.path} for spritesheet, skipping`, err);
+                continue;
+            }
 
             let iconPath = spriteConfig.name ? String(icon[spriteConfig.name]) : icon.path.replace(/.*?\//, '');
 


### PR DESCRIPTION
### Context

- :bug: Ensure a single poisoned icon can't break server launch - Closes: https://github.com/dfpc-coe/CloudTAK/issues/1623
- :bug: Fix underlying non-conformant PNG files in CloudTAK-Data