### PR TITLE
Invalid Features

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tak-ps/CloudTAK.api",
-    "version": "13.66.0",
+    "version": "13.66.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tak-ps/CloudTAK.api",
-            "version": "13.66.0",
+            "version": "13.66.1",
             "license": "ISC",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -35,7 +35,7 @@
                 "@tak-ps/etl": "^10.11.0",
                 "@tak-ps/node-cot": "^14.50.0",
                 "@tak-ps/node-safeurl": "^1.5.0",
-                "@tak-ps/node-tak": "^12.23.0",
+                "@tak-ps/node-tak": "^12.24.0",
                 "@turf/bbox": "^7.1.0",
                 "@turf/bbox-polygon": "^7.2.0",
                 "@turf/meta": "^7.0.0",
@@ -163,13 +163,13 @@
             }
         },
         "node_modules/@aws-sdk/checksums": {
-            "version": "3.1000.26",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.26.tgz",
-            "integrity": "sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA==",
+            "version": "3.1000.27",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.27.tgz",
+            "integrity": "sha512-insWOqKKNUrbN/dohEG7BJ0U5GkyqhjbMb/NHNaLUtq+7my2M8C4EnZZZoxMmXRqCC+P9dEr+KyJA2JGGzoKLg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -179,14 +179,14 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudformation": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1107.0.tgz",
-            "integrity": "sha512-zg2r7EtzGAqfJh6jthNdx84RGkzN3ZDtVOGkoTxJMODgWwovTXe3i9W8HUjx1NUWCYPYc+DFxscRn/0R2W/Q/w==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1108.0.tgz",
+            "integrity": "sha512-BspahG8n1CvsZTHq13PP07Z6Nm07MgotIeuCv4b4j+lr8POgW+dJKFKc8rTaYbP/F5iuBCK7XfvtscNbjQJ+0g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -198,14 +198,14 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1107.0.tgz",
-            "integrity": "sha512-8nE6u/7N5RXFrKQ2GUHjy/dRKqxrf571j9ikzs77kVj5FwdIR/1yY756EaTDXVvRB/9T2pmWCTcXoR2zqOujGQ==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1108.0.tgz",
+            "integrity": "sha512-zjKhoY1slqslyfmyMFNsAOi9802HgHUYZ3zEUF+nM1ffMu32zGrjLVRpJlYzANaK2W+Wu+WSuVMZJpnRwbOx6Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/middleware-compression": "^4.5.16",
@@ -218,14 +218,14 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1107.0.tgz",
-            "integrity": "sha512-jsQ+1zdivSeLvp4qILfYxSMw624bnmyAaNThkYfZrw5oM2Z1aCbU927mwRBFIoo5WZAua6KY1zP3Qawrt0TexA==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1108.0.tgz",
+            "integrity": "sha512-GVd4/2L2QXc8PLWMzlO/nfa3OpW929ae484r+Lv95efuuSS7eEAjbftyQTH7abCHn4BDIXaXCcX20B8T0WnbGQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -237,14 +237,14 @@
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1107.0.tgz",
-            "integrity": "sha512-NcxixHATZXKGFrQCGcl7X704mON3T9a8f1s4y+3e9K4yJWLFZJfNsGXUvpi6dCH6OB2m2+WtWmZBUOjJSyICQw==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1108.0.tgz",
+            "integrity": "sha512-I9r4rNJaBD3Hi919MyJfYKhoj3e5U0NG0x5q4mOyuPzEiZVfxJNdposz0jDY1arPAizgwhHZSGhAXWiABcEXFg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -256,14 +256,14 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1107.0.tgz",
-            "integrity": "sha512-k3xBmiBJYtpY1RKJms3BnTVg6nvFGEhbzINLkSfxAGkfS+Ehz3bOl6BcPWjKQP9Jsyi3IHMNY3Opjp1sf6J3EA==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1108.0.tgz",
+            "integrity": "sha512-l8zjB18DP0zvW7/KbAlMS6DLFTxBY4tVY2N1OH4dLw891AGuRo4VdJeYGFpVgbUp+0OZlhJkjzryVU5eVK+RlQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -275,17 +275,17 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1107.0.tgz",
-            "integrity": "sha512-95N3VATuqbyhEUO0YHQSsgKdkG872rZXm+O2ZkffsF8RJLRDQAsplVD8/OdWW3vX78vNDogK/zbfD1VG1OcSIA==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1108.0.tgz",
+            "integrity": "sha512-prdothEAFE1G8H0s0+zFGuNZdSj+Acg/siB1dFxPS181op9+hJ1GLr+b2anJch4B9a/xbWy7k8eG/enH3cNSjQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/checksums": "^3.1000.26",
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/middleware-sdk-s3": "^3.972.72",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/checksums": "^3.1000.27",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.73",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -297,14 +297,14 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1107.0.tgz",
-            "integrity": "sha512-eyVZ/9GXYFQxaKlOAdd9so/2hpZNhG+kMfv/pE5tZaE7G1u4XZBpebPX/OhQJXEppbbGv9cc3lrpfcO9slBYFg==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1108.0.tgz",
+            "integrity": "sha512-pZtoHWD+WorgM9xK1ikNcKLbtEMIS6wFtELuCX5AOo9v3ZajV8wOEmXz/7JnBHbsLmyBnyv3NCf7whyV++joiw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -316,15 +316,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1107.0.tgz",
-            "integrity": "sha512-R/aEydhqNWB7dyN6h9aGFXR7NeGOpbrypM2JwQ8LVNVDdBldZXTcgp+VDnh4Ko6Llkjl2r6p4R4ANyG2vredYQ==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1108.0.tgz",
+            "integrity": "sha512-Zv+txQxuHUteCyI1kv3WIteoZ3j+Uucrp8cVeqeJhCFdBtGjKLL4NfBOwzwwSVamxssRhQrpdNnMTw6iMkeuXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/middleware-sdk-sqs": "^3.972.39",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/middleware-sdk-sqs": "^3.972.40",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -336,15 +336,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1107.0.tgz",
-            "integrity": "sha512-9Rf4GpBDvNM0Fomv+uuGsX9YnZlxBOpbPamD8A4xAOZQP9v9GeDccXU/XEt84k/cWwR9Orol5ON1aId5vSRiiQ==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1108.0.tgz",
+            "integrity": "sha512-K+Lo3mDU/gWvkUPIhji5WkrZD8BzbMTPyyc5HLK+lpKyszSmVJb+eWENkP+sxDp0tBrx4hun+evakBQ6fxQESg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-node": "^3.972.78",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-node": "^3.972.79",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -356,13 +356,13 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.977.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
-            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "version": "3.977.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+            "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.2",
-                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws-sdk/types": "^3.974.3",
+                "@aws-sdk/xml-builder": "^3.972.38",
                 "@aws/lambda-invoke-store": "^0.3.0",
                 "@smithy/core": "^3.31.1",
                 "@smithy/signature-v4": "^5.6.12",
@@ -375,13 +375,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.67",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
-            "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+            "version": "3.972.68",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+            "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -391,13 +391,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.69",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
-            "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+            "version": "3.972.70",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+            "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -409,20 +409,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.973.12",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
-            "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+            "version": "3.973.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+            "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/credential-provider-env": "^3.972.67",
-                "@aws-sdk/credential-provider-http": "^3.972.69",
-                "@aws-sdk/credential-provider-login": "^3.972.74",
-                "@aws-sdk/credential-provider-process": "^3.972.67",
-                "@aws-sdk/credential-provider-sso": "^3.973.11",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-                "@aws-sdk/nested-clients": "^3.997.41",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/credential-provider-env": "^3.972.68",
+                "@aws-sdk/credential-provider-http": "^3.972.70",
+                "@aws-sdk/credential-provider-login": "^3.972.75",
+                "@aws-sdk/credential-provider-process": "^3.972.68",
+                "@aws-sdk/credential-provider-sso": "^3.973.12",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+                "@aws-sdk/nested-clients": "^3.997.42",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/credential-provider-imds": "^4.4.16",
                 "@smithy/types": "^4.16.1",
@@ -433,14 +433,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.74",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
-            "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+            "version": "3.972.75",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+            "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/nested-clients": "^3.997.41",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/nested-clients": "^3.997.42",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -450,18 +450,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.78",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
-            "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+            "version": "3.972.79",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+            "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.67",
-                "@aws-sdk/credential-provider-http": "^3.972.69",
-                "@aws-sdk/credential-provider-ini": "^3.973.12",
-                "@aws-sdk/credential-provider-process": "^3.972.67",
-                "@aws-sdk/credential-provider-sso": "^3.973.11",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/credential-provider-env": "^3.972.68",
+                "@aws-sdk/credential-provider-http": "^3.972.70",
+                "@aws-sdk/credential-provider-ini": "^3.973.13",
+                "@aws-sdk/credential-provider-process": "^3.972.68",
+                "@aws-sdk/credential-provider-sso": "^3.973.12",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/credential-provider-imds": "^4.4.16",
                 "@smithy/types": "^4.16.1",
@@ -472,13 +472,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.67",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
-            "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+            "version": "3.972.68",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+            "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -488,15 +488,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.973.11",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
-            "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+            "version": "3.973.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+            "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/nested-clients": "^3.997.41",
-                "@aws-sdk/token-providers": "3.1103.0",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/nested-clients": "^3.997.42",
+                "@aws-sdk/token-providers": "3.1108.0",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -506,14 +506,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.73",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
-            "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+            "version": "3.972.74",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+            "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/nested-clients": "^3.997.41",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/nested-clients": "^3.997.42",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -523,9 +523,9 @@
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.1107.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1107.0.tgz",
-            "integrity": "sha512-aQohoTGU0xYavudEZ+zEJejVfqH9Eu5Bk1yLi8soHyJO88qnSW+vF9qARjS8oLyo1ivXeesWvlGHfAuhCOw4Mg==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1108.0.tgz",
+            "integrity": "sha512-2hq5FL7oXIHW/m9VASuEL9f7Z67jzXy1g5lEfxGs5sWnAB9GtueY/Bn26lcsSWun/p5T5phXRrLZN9uBvcuP5w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/core": "^3.31.1",
@@ -539,18 +539,18 @@
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.1107.0"
+                "@aws-sdk/client-s3": "^3.1108.0"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.72",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.72.tgz",
-            "integrity": "sha512-lSAoVPvQxX1d8TOM6waKDBQrvvZcm4w6pCldFAsRUffEaXq6lYY0pPyew3KlLu6Xqb74DXI42hGvSsbGBLljlw==",
+            "version": "3.972.73",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.73.tgz",
+            "integrity": "sha512-oy7sRA5HvHcAvkcKX6F8RI240jcOf3c8y/Gqjs9qemIibdKQqGBIi0uwa+47ZRYqGLpdEO28TQU4G73yUzo06Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -560,12 +560,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.972.39",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.39.tgz",
-            "integrity": "sha512-dlKLmJg1dLQVfFXUPS+f+SqXrRGHDVumY4gjM8sCLGao+zkDXEu8TObTyiaheKjT20ruok9Xs8oLocNItKQ0fw==",
+            "version": "3.972.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.40.tgz",
+            "integrity": "sha512-inMaGeVemJEIp9Bc5Wlw0aVgVgUr/OwGqg5CLwO8TbMi6m1xFd+BG0fO/nJKVS/rkb9FSRxU/l0njDBz8OQvHQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -575,14 +575,14 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.41",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
-            "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+            "version": "3.997.42",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+            "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/fetch-http-handler": "^5.6.13",
                 "@smithy/node-http-handler": "^4.9.13",
@@ -594,12 +594,12 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.996.43",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-            "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+            "version": "3.996.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+            "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/signature-v4": "^5.6.12",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -609,14 +609,14 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1103.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
-            "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+            "version": "3.1108.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+            "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.6",
-                "@aws-sdk/nested-clients": "^3.997.41",
-                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/core": "^3.977.7",
+                "@aws-sdk/nested-clients": "^3.997.42",
+                "@aws-sdk/types": "^3.974.3",
                 "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
@@ -626,9 +626,9 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.974.2",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "version": "3.974.3",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+            "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.16.1",
@@ -639,9 +639,9 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.37",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "version": "3.972.38",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+            "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.16.1",
@@ -2896,12 +2896,12 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.31.1",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
-            "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+            "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.16.1",
+                "@smithy/types": "^4.17.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2909,13 +2909,13 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.4.16",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-            "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+            "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@smithy/core": "^3.32.0",
+                "@smithy/types": "^4.17.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2923,13 +2923,13 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.6.13",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
-            "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+            "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@smithy/core": "^3.32.0",
+                "@smithy/types": "^4.17.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2937,13 +2937,13 @@
             }
         },
         "node_modules/@smithy/middleware-compression": {
-            "version": "4.5.16",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.16.tgz",
-            "integrity": "sha512-VwD+5B6lkieGIGxFx4pSXFZpevLJj3fl8JayvGHojnS5AblrvVJfz1DvCVJEg3XrMCBvs6HZa1znW9Is4xeFcg==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.6.0.tgz",
+            "integrity": "sha512-IB8cmku2CGnBgoTxDmPu8idnSjXt8DTDMMz/GylqUNZZ4mT4RsOSI9BllVb7Ylf4MdvoGSxldaj0GMxoVWe7Rg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@smithy/core": "^3.32.0",
+                "@smithy/types": "^4.17.0",
                 "fflate": "0.8.1",
                 "tslib": "^2.6.2"
             },
@@ -2952,13 +2952,13 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.9.13",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-            "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+            "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@smithy/core": "^3.32.0",
+                "@smithy/types": "^4.17.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2966,13 +2966,13 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.6.12",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
-            "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+            "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.31.1",
-                "@smithy/types": "^4.16.1",
+                "@smithy/core": "^3.32.0",
+                "@smithy/types": "^4.17.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2980,9 +2980,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+            "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3040,9 +3040,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "14.51.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.51.0.tgz",
-            "integrity": "sha512-KVplxFEVgQmOd1vZsDc9S5LTEujH/kfi6rt9Axijtnhz6Mvokv6g8iyDqCOLTpFjYxaAYUH/yZs6718VMNlVzQ==",
+            "version": "14.52.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.52.0.tgz",
+            "integrity": "sha512-FziAtpDBWdXLYch0EBotGCUimqXDo2+kSPOTIcICZJdtwFGFs3EnvDP9IWy22AtNx46EIqmiE6cmVz5WT14wrQ==",
             "license": "MIT",
             "dependencies": {
                 "@archiver/archiver": "^0.1.0",
@@ -3103,9 +3103,9 @@
             }
         },
         "node_modules/@tak-ps/node-tak": {
-            "version": "12.23.1",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-tak/-/node-tak-12.23.1.tgz",
-            "integrity": "sha512-XcOGx12SfrILHKF79tEK75BW3o6ClpOunI5cAjoY675vNs0BO20DOFZuIasg0DrV0ZKL/RtsQGFw7wMW3OIZ7Q==",
+            "version": "12.24.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-tak/-/node-tak-12.24.0.tgz",
+            "integrity": "sha512-Zt8AmtPbrdeHQSXHK+pAmW0gJVbc94iYtchMggGCOwWyBKvVVxZXRbgWjBuQDgmrhIjRosMbvzkGMTKcnC+8Lg==",
             "license": "MIT",
             "dependencies": {
                 "@openaddresses/batch-error": "^2.12.0",
@@ -3123,7 +3123,7 @@
                 "node": ">= 22"
             },
             "peerDependencies": {
-                "@tak-ps/node-cot": "^v14.30.1"
+                "@tak-ps/node-cot": "^14.52.0"
             }
         },
         "node_modules/@tak-ps/serverless-http": {
@@ -6540,9 +6540,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.9.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-            "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+            "version": "17.10.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.10.0.tgz",
+            "integrity": "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/api/package.json
+++ b/api/package.json
@@ -56,7 +56,7 @@
         "@tak-ps/etl": "^10.11.0",
         "@tak-ps/node-cot": "^14.50.0",
         "@tak-ps/node-safeurl": "^1.5.0",
-        "@tak-ps/node-tak": "^12.23.0",
+        "@tak-ps/node-tak": "^12.24.0",
         "@turf/bbox": "^7.1.0",
         "@turf/bbox-polygon": "^7.2.0",
         "@turf/meta": "^7.0.0",

--- a/api/stateless/routes/connection-layer-cot.ts
+++ b/api/stateless/routes/connection-layer-cot.ts
@@ -123,7 +123,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                     // Once NodeJS supports Set.difference we can simplify this
                     const inputFeats = new Set(req.body.uids);
 
-                    const features = await api.MissionLayer.latestFeats(
+                    const { features } = await api.MissionLayer.latestFeats(
                         data.name,
                         `layer-${layer.id}`,
                         { token: data.mission_token || undefined },

--- a/api/stateless/routes/marti-mission.ts
+++ b/api/stateless/routes/marti-mission.ts
@@ -85,6 +85,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         res: Type.Object({
             type: Type.String(),
             features: Type.Array(Feature.Feature),
+            invalid: Type.Array(Type.Object({
+                id: Type.Optional(Type.String()),
+                callsign: Type.Optional(Type.String()),
+                error: Type.String(),
+            })),
         }),
     }, async (req, res) => {
         try {
@@ -96,9 +101,27 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 ? { token: String(req.headers['missionauthorization']) }
                 : await profileControl.subscription(user.email, req.params.guid);
 
-            const features = await api.Mission.latestFeats(req.params.guid, opts);
+            const feats = await api.Mission.latestFeats(req.params.guid, opts);
 
-            res.json({ type: 'FeatureCollection', features });
+            res.json({
+                type: 'FeatureCollection',
+                features: feats.features,
+                invalid: feats.invalid.map((invalid) => {
+                    const event = invalid.feature as {
+                        _attributes?: { uid?: unknown };
+                        detail?: { contact?: { _attributes?: { callsign?: unknown } } };
+                    } | null | undefined;
+
+                    const uid = event?._attributes?.uid;
+                    const callsign = event?.detail?.contact?._attributes?.callsign;
+
+                    return {
+                        id: typeof uid === 'string' ? uid : undefined,
+                        callsign: typeof callsign === 'string' ? callsign : undefined,
+                        error: invalid.error,
+                    };
+                }),
+            });
         } catch (err) {
             Err.respond(err, res);
         }
@@ -417,7 +440,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
                 const fc = {
                     type: 'FeatureCollection',
-                    features: await api.Mission.latestFeats(req.params.name, opts),
+                    features: (await api.Mission.latestFeats(req.params.name, opts)).features,
                 };
 
                 if (req.query.format === 'geojson') {


### PR DESCRIPTION
### Context

Add per-feature parsing in node-cot and utilize it in node-tak when parsing the contents of a Mission Sync Features API Call. This prevents a 4xx API response with no features when a single feature is invalid.

While this change is not yet exposed in the UI, the API will return an ID and Callsign when possible for the feature which is invalid and not added to CloudTAK's map