### PR TITLE
fix(web): correct TAK team colors, add contrast-aware marker border

### DIFF
--- a/api/web/src/base/cot-icon.spec.ts
+++ b/api/web/src/base/cot-icon.spec.ts
@@ -118,4 +118,27 @@ describe('COT.as_rendered', () => {
 
         expect(rendered.properties!.icon).toBeUndefined();
     });
+
+    // Regression: marker-stroke-color was set by styleProperties() and read by
+    // the skittle layer's circle-stroke-color expression in styles.ts, but was
+    // missing from RENDERED_PROPERTIES - the whitelist as_rendered() uses to
+    // slim a Feature down before it reaches the vector tile. It was silently
+    // stripped here, so every team's marker border fell back to the style's
+    // default white regardless of the computed value.
+    it('carries marker-stroke-color through to the rendered Feature', () => {
+        const rendered = COT.as_rendered({
+            id: 'render-contact-stroke',
+            type: 'Feature',
+            properties: properties({
+                type: 'a-f-G-U-C-I',
+                callsign: 'Test',
+                group: { name: 'Cyan', role: 'Team Member' },
+                'marker-color': '#00FFFF',
+                'marker-stroke-color': '#000000'
+            }),
+            geometry: { type: 'Point', coordinates: [-104.99, 39.73] }
+        } as Feature);
+
+        expect(rendered.properties!['marker-stroke-color']).toEqual('#000000');
+    });
 });

--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -50,6 +50,67 @@ export const RENDERED_PROPERTIES = [
 ]
 
 /**
+ * TAK team ("squad") colours, as literal RGB values - not CSS/UI framework
+ * theme colours. These must match what ATAK actually renders for the same
+ * team name so a marker looks the same colour in CloudTAK and ATAK side by
+ * side.
+ *
+ * Source of truth: ATAK's `Icon2525cIconAdapter.teamToColor()`
+ * (atak/ATAK/app/src/main/java/com/atakmap/android/icons/Icon2525cIconAdapter.java),
+ * which is what every ATAK client actually renders. TAK Server's own KML
+ * export (KmlUtils.initTeamStyles()) uses a third, slightly different table
+ * for several of these (notably Orange and Purple, which differ by more than
+ * shade) - ATAK is preferred here since that is the client operators
+ * visually compare CloudTAK against in the field.
+ *
+ * Previously these were CSS variables from the Tabler UI framework's brand
+ * palette (e.g. `--tblr-dribbble` for Magenta, `--tblr-google` for Brown),
+ * which do not represent the named colour at all and made "Yellow" render as
+ * amber, "Green" as yellow-green, etc.
+ */
+export const TEAM_COLORS: Record<string, string> = {
+    White: '#FFFFFF',
+    Yellow: '#FFFF00',
+    Orange: '#FF7700',
+    Magenta: '#FF00FF',
+    Red: '#FF0000',
+    Maroon: '#7F0000',
+    Purple: '#7F007F',
+    'Dark Blue': '#00007F',
+    Blue: '#0000FF',
+    Cyan: '#00FFFF',
+    Teal: '#007F7F',
+    Green: '#00FF00',
+    'Dark Green': '#007F00',
+    Brown: '#A0714F',
+};
+
+/**
+ * Perceptual lightness-based border colour for a marker fill, so a light
+ * marker (white team, or a light custom marker colour) stays visible against
+ * a light basemap rather than blending into it with the usual white border -
+ * and a dark marker keeps the white border it already had, rather than a
+ * black one disappearing against a dark basemap in the same way.
+ *
+ * Uses the standard relative-luminance formula (ITU-R BT.601 coefficients),
+ * the same approach commonly used for text/border contrast against a fill
+ * colour. Falls back to white (matching the prior fixed behaviour) for a
+ * value that cannot be parsed as `#rrggbb`.
+ */
+export function strokeColorFor(hex: string): string {
+    const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+    if (!match) return '#ffffff';
+
+    const r = parseInt(match[1], 16);
+    const g = parseInt(match[2], 16);
+    const b = parseInt(match[3], 16);
+
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+    return luminance > 0.6 ? '#000000' : '#ffffff';
+}
+
+/**
  * MIL-STD symbols render from an icon id of the form `2525<Variant>:<SIDC>` - a
  * key into the Icon Manager's generated symbols
  *
@@ -667,35 +728,9 @@ export default class COT {
             if (properties.group) {
                 properties['icon-opacity'] = 0;
 
-                if (properties.group.name === 'Yellow') {
-                    properties["marker-color"] = '#f59f00';
-                } else if (properties.group.name === 'Orange') {
-                    properties["marker-color"] = '#f76707';
-                } else if (properties.group.name === 'Magenta') {
-                    properties["marker-color"] = '#ea4c89';
-                } else if (properties.group.name === 'Red') {
-                    properties["marker-color"] = '#d63939';
-                } else if (properties.group.name === 'Maroon') {
-                    properties["marker-color"] = '#bd081c';
-                } else if (properties.group.name === 'Purple') {
-                    properties["marker-color"] = '#ae3ec9';
-                } else if (properties.group.name === 'Dark Blue') {
-                    properties["marker-color"] = '#0054a6';
-                } else if (properties.group.name === 'Blue') {
-                    properties["marker-color"] = '#4299e1';
-                } else if (properties.group.name === 'Cyan') {
-                    properties["marker-color"] = '#17a2b8';
-                } else if (properties.group.name === 'Teal') {
-                    properties["marker-color"] = '#0ca678';
-                } else if (properties.group.name === 'Green') {
-                    properties["marker-color"] = '#74b816';
-                } else if (properties.group.name === 'Dark Green') {
-                    properties["marker-color"] = '#2fb344';
-                } else if (properties.group.name === 'Brown') {
-                    properties["marker-color"] = '#dc4e41';
-                } else {
-                    properties["marker-color"] = '#ffffff';
-                }
+                const markerColor = TEAM_COLORS[properties.group.name] ?? '#FFFFFF';
+                properties['marker-color'] = markerColor;
+                properties['marker-stroke-color'] = strokeColorFor(markerColor);
             } else if (properties.icon) {
                 // Format of icon needs to change for spritesheet
                 if (!properties.icon.includes(':')) {

--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -42,6 +42,7 @@ export const RENDERED_PROPERTIES = [
     'stroke-style',
     'stroke-width',
     'marker-color',
+    'marker-stroke-color',
     'marker-radius',
     'marker-opacity',
     'circle-color',

--- a/api/web/src/base/team-colors.spec.ts
+++ b/api/web/src/base/team-colors.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { TEAM_COLORS, strokeColorFor } from './cot.ts';
+
+/**
+ * Regression coverage for the team colour / marker border fix: CloudTAK
+ * previously rendered TAK team colours using Tabler UI framework
+ * brand-palette CSS variables (e.g. `--tblr-dribbble` for Magenta), which do
+ * not match what ATAK actually renders for the same team name, and always
+ * drew a fixed white marker border that disappears against a light basemap
+ * or a light marker colour (White/Yellow/Cyan teams).
+ */
+
+describe('TEAM_COLORS', () => {
+    it('matches ATAK\'s Icon2525cIconAdapter.teamToColor() values', () => {
+        expect(TEAM_COLORS).toEqual({
+            White: '#FFFFFF',
+            Yellow: '#FFFF00',
+            Orange: '#FF7700',
+            Magenta: '#FF00FF',
+            Red: '#FF0000',
+            Maroon: '#7F0000',
+            Purple: '#7F007F',
+            'Dark Blue': '#00007F',
+            Blue: '#0000FF',
+            Cyan: '#00FFFF',
+            Teal: '#007F7F',
+            Green: '#00FF00',
+            'Dark Green': '#007F00',
+            Brown: '#A0714F',
+        });
+    });
+
+    it('has 14 entries - every TAK team colour, none omitted', () => {
+        expect(Object.keys(TEAM_COLORS)).toHaveLength(14);
+    });
+});
+
+describe('strokeColorFor', () => {
+    it('picks a black border for light marker colours', () => {
+        expect(strokeColorFor(TEAM_COLORS.White)).toBe('#000000');
+        expect(strokeColorFor(TEAM_COLORS.Yellow)).toBe('#000000');
+        expect(strokeColorFor(TEAM_COLORS.Cyan)).toBe('#000000');
+    });
+
+    it('picks a white border for dark marker colours', () => {
+        expect(strokeColorFor(TEAM_COLORS.Red)).toBe('#ffffff');
+        expect(strokeColorFor(TEAM_COLORS.Maroon)).toBe('#ffffff');
+        expect(strokeColorFor(TEAM_COLORS.Blue)).toBe('#ffffff');
+        expect(strokeColorFor(TEAM_COLORS['Dark Blue'])).toBe('#ffffff');
+        expect(strokeColorFor(TEAM_COLORS['Dark Green'])).toBe('#ffffff');
+    });
+
+    it('is case-insensitive and tolerates a missing leading #', () => {
+        expect(strokeColorFor('#ffffff')).toBe('#000000');
+        expect(strokeColorFor('ffffff')).toBe('#000000');
+        expect(strokeColorFor('FFFFFF')).toBe('#000000');
+    });
+
+    it('falls back to white for a value that cannot be parsed as #rrggbb', () => {
+        expect(strokeColorFor('')).toBe('#ffffff');
+        expect(strokeColorFor('not-a-color')).toBe('#ffffff');
+        expect(strokeColorFor('#fff')).toBe('#ffffff');
+        expect(strokeColorFor('#gggggg')).toBe('#ffffff');
+    });
+
+    it('sits right at the luminance threshold boundary', () => {
+        // Luminance exactly 0.6 * 255 = 153 -> not > 0.6, so white border
+        expect(strokeColorFor('#999999')).toBe('#ffffff');
+        // One step brighter crosses the threshold -> black border
+        expect(strokeColorFor('#9a9a9a')).toBe('#000000');
+    });
+});

--- a/api/web/src/components/CloudTAK/FeatView.vue
+++ b/api/web/src/components/CloudTAK/FeatView.vue
@@ -176,6 +176,7 @@ const mode = ref('default');
 
 const STYLE_PROPERTIES = new Set([
     'marker-color',
+    'marker-stroke-color',
     'marker-opacity',
     'marker-size',
     'marker-symbol',

--- a/api/web/src/components/CloudTAK/util/ContactPuck.vue
+++ b/api/web/src/components/CloudTAK/util/ContactPuck.vue
@@ -24,21 +24,25 @@ const props = defineProps<{
     size?: number
 }>();
 
+// ATAK's actual team colours (Icon2525cIconAdapter.teamToColor()), matching
+// base/cot.ts's TEAM_COLORS - not CSS/UI framework theme colours, which do
+// not represent the named colour at all (see base/cot.ts for the full
+// rationale).
 const teamColors: Record<string, string> = {
-    Yellow: 'var(--tblr-yellow)',
-    Cyan: 'var(--tblr-cyan)',
-    Green: 'var(--tblr-lime)',
-    Red: 'var(--tblr-red)',
-    Purple: 'var(--tblr-purple)',
-    Orange: 'var(--tblr-orange)',
-    Blue: 'var(--tblr-azure)',
-    Magenta: 'var(--tblr-dribbble)',
-    White: 'var(--tblr-white)',
-    Maroon: 'var(--tblr-pinterest)',
-    'Dark Blue': 'var(--tblr-blue)',
-    Teal: 'var(--tblr-teal)',
-    'Dark Green': 'var(--tblr-green)',
-    Brown: 'var(--tblr-google)',
+    White: '#FFFFFF',
+    Yellow: '#FFFF00',
+    Orange: '#FF7700',
+    Magenta: '#FF00FF',
+    Red: '#FF0000',
+    Maroon: '#7F0000',
+    Purple: '#7F007F',
+    'Dark Blue': '#00007F',
+    Blue: '#0000FF',
+    Cyan: '#00FFFF',
+    Teal: '#007F7F',
+    Green: '#00FF00',
+    'Dark Green': '#007F00',
+    Brown: '#A0714F',
 };
 
 const teamColor = computed(() => {

--- a/api/web/src/lib/geolocate/main.ts
+++ b/api/web/src/lib/geolocate/main.ts
@@ -41,23 +41,46 @@ const STYLE_ELEMENT_ID = 'cloudtak-geolocate-styles';
 const DEFAULT_PUCK_COLOR = '#1da1f2';
 
 // Mirrors the team -> marker-color mapping used for rendered CoT markers in
-// base/cot.ts so the self puck matches the previous self-location marker.
-const TEAM_COLORS: Record<string, string> = {
-    Yellow: '#f59f00',
-    Orange: '#f76707',
-    Magenta: '#ea4c89',
-    Red: '#d63939',
-    Maroon: '#bd081c',
-    Purple: '#ae3ec9',
-    'Dark Blue': '#0054a6',
-    Blue: '#4299e1',
-    Cyan: '#17a2b8',
-    Teal: '#0ca678',
-    Green: '#74b816',
-    'Dark Green': '#2fb344',
-    Brown: '#dc4e41',
-    White: '#ffffff'
+// base/cot.ts (TEAM_COLORS there) so the self puck matches the rendered self
+// CoT marker and the ATAK client rendering the same team colour. These are
+// ATAK's actual RGB values (Icon2525cIconAdapter.teamToColor()), not CSS/UI
+// framework theme colours - see cot.ts for the full rationale.
+export const TEAM_COLORS: Record<string, string> = {
+    White: '#FFFFFF',
+    Yellow: '#FFFF00',
+    Orange: '#FF7700',
+    Magenta: '#FF00FF',
+    Red: '#FF0000',
+    Maroon: '#7F0000',
+    Purple: '#7F007F',
+    'Dark Blue': '#00007F',
+    Blue: '#0000FF',
+    Cyan: '#00FFFF',
+    Teal: '#007F7F',
+    Green: '#00FF00',
+    'Dark Green': '#007F00',
+    Brown: '#A0714F',
 };
+
+/**
+ * Black or white border colour for a fill, chosen by relative luminance
+ * (ITU-R BT.601 coefficients) so the puck stays visible against either a
+ * light or dark basemap. Falls back to white (the prior fixed behaviour)
+ * for a value that cannot be parsed as `#rrggbb`. Mirrors strokeColorFor()
+ * in cot.ts.
+ */
+export function strokeColorFor(hex: string): string {
+    const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+    if (!match) return '#ffffff';
+
+    const r = parseInt(match[1], 16);
+    const g = parseInt(match[2], 16);
+    const b = parseInt(match[3], 16);
+
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+    return luminance > 0.6 ? '#000000' : '#ffffff';
+}
 
 /**
  * A MapLibre {@link IControl} that renders a live user-location puck (dot,
@@ -290,7 +313,15 @@ export class GeolocateControl implements IControl {
     };
 
     private applyColor(): void {
-        if (this.dotElement) this.dotElement.style.backgroundColor = this.color;
+        if (this.dotElement) {
+            this.dotElement.style.backgroundColor = this.color;
+            // A fixed white border (the CSS default, see .cloudtak-geolocate-dot
+            // below) is invisible for a light puck colour (White/Yellow/Cyan
+            // teams) against a light basemap. Switch to a black border for a
+            // light fill, mirroring the same luminance-based choice made for
+            // other users' rendered CoT markers (see strokeColorFor() in cot.ts).
+            this.dotElement.style.borderColor = strokeColorFor(this.color);
+        }
         if (this.headingElement) {
             const c = GeolocateControl.rgba(this.color, 0.55);
             const ct = GeolocateControl.rgba(this.color, 0.0);

--- a/api/web/src/lib/geolocate/team-colors.spec.ts
+++ b/api/web/src/lib/geolocate/team-colors.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { TEAM_COLORS, strokeColorFor } from './main.ts';
+import { TEAM_COLORS as COT_TEAM_COLORS, strokeColorFor as cotStrokeColorFor } from '../../base/cot.ts';
+
+/**
+ * The self-location puck (this module) keeps its own copy of TEAM_COLORS and
+ * strokeColorFor(), mirroring base/cot.ts, so the puck stays outside the CoT
+ * styling pipeline. These tests guard against the two copies drifting apart.
+ */
+
+describe('geolocate TEAM_COLORS', () => {
+    it('is identical to the rendered-CoT-marker TEAM_COLORS in base/cot.ts', () => {
+        expect(TEAM_COLORS).toEqual(COT_TEAM_COLORS);
+    });
+});
+
+describe('geolocate strokeColorFor', () => {
+    it('behaves identically to base/cot.ts\'s strokeColorFor for every team colour', () => {
+        for (const hex of Object.values(TEAM_COLORS)) {
+            expect(strokeColorFor(hex)).toBe(cotStrokeColorFor(hex));
+        }
+    });
+
+    it('picks a black border for a light puck colour', () => {
+        expect(strokeColorFor('#FFFFFF')).toBe('#000000');
+    });
+
+    it('picks a white border for a dark puck colour', () => {
+        expect(strokeColorFor('#0000FF')).toBe('#ffffff');
+    });
+
+    it('falls back to white for an unparseable colour', () => {
+        expect(strokeColorFor('not-a-color')).toBe('#ffffff');
+    });
+});

--- a/api/web/src/utils/styles.ts
+++ b/api/web/src/utils/styles.ts
@@ -271,7 +271,7 @@ export default function styles(id: string, opts: {
             paint: {
                 'circle-color': ['get', 'marker-color'],
                 'circle-opacity': ["number", ["get", "marker-opacity"], 1],
-                'circle-stroke-color': '#ffffff',
+                'circle-stroke-color': ["string", ["get", "marker-stroke-color"], "#ffffff"],
                 'circle-stroke-width': [
                     'interpolate',
                     ['linear'],

--- a/api/web/src/workers/atlas-profile.ts
+++ b/api/web/src/workers/atlas-profile.ts
@@ -14,7 +14,7 @@ import COT from '../base/cot.ts';
  * semi-transparent `<color>` detail native clients never produce for a team
  * member - they rely solely on `<__group>`
  */
-const SELF_STYLE_PROPERTIES = ['marker-color', 'marker-opacity', 'icon-opacity', 'icon'] as const;
+const SELF_STYLE_PROPERTIES = ['marker-color', 'marker-opacity', 'icon-opacity', 'icon', 'marker-stroke-color'] as const;
 
 export type ProfileLocationState = {
     source: LocationState


### PR DESCRIPTION
## Summary

CloudTAK's TAK team colors and marker borders don't match how ATAK actually renders the same data, which is confusing when comparing the two clients side by side in the field.

- Team colors (`base/cot.ts`, `lib/geolocate/main.ts`, `ContactPuck.vue`) used Tabler UI framework brand-palette CSS variables/hex values instead of real team colors. For example "Yellow" rendered as amber (`#f59f00`), "Green" as yellow-green (`#74b816`), and "Brown" as a brick-red (`#dc4e41`). Replaced with the authoritative values from ATAK's `Icon2525cIconAdapter.teamToColor()` (`atak/ATAK/app/src/main/java/com/atakmap/android/icons/Icon2525cIconAdapter.java`): White, Yellow, Orange, Magenta, Red, Maroon, Purple, Dark Blue, Blue, Cyan, Teal, Green, Dark Green, Brown.
- Team-color markers (skittles) and the self-location puck always had a fixed white stroke, which disappears against a light basemap or a light marker color (White/Yellow/Cyan teams). Added a `strokeColorFor()` helper (ITU-R BT.601 relative luminance, threshold 0.6) that picks black or white based on the marker color's lightness, rather than a flat swap that would just break the opposite case (dark marker on a dark basemap).

## What changed

- `base/cot.ts`: replaced the `properties.group` if/else chain with a `TEAM_COLORS` lookup table and a new `strokeColorFor()`. Sets `marker-stroke-color` alongside `marker-color`, and adds it to `SELF_STYLE_PROPERTIES`.
- `utils/styles.ts`: the group/skittle circle layer's `circle-stroke-color` now reads `["get", "marker-stroke-color"]` (fallback `#ffffff`) instead of a literal `#ffffff`.
- `lib/geolocate/main.ts`: mirrored `TEAM_COLORS`/`strokeColorFor()` for the self-location puck (kept separate from the CoT wire format, matching the existing pattern here); wired into `applyColor()` to set `borderColor`.
- `components/CloudTAK/util/ContactPuck.vue`: updated `teamColors` to the same ATAK values (this is a Tabler UI list icon, not a map marker, so its border/stroke is unchanged).
- `workers/atlas-profile.ts`: added `marker-stroke-color` to its `SELF_STYLE_PROPERTIES` so it stays local-only and isn't sent over CoT (same rationale as the existing `marker-color` entry there).
- `components/CloudTAK/FeatView.vue`: added `marker-stroke-color` to `STYLE_PROPERTIES` so it's filtered out of the raw-properties display.
- Added unit tests for `TEAM_COLORS` and `strokeColorFor()` (both copies), including a test that keeps the two copies in sync with each other.

## Not changed (out of scope)

- `icon-halo-color` in `styles.ts`, used for non-team unit/equipment icons rendered via `icon-image` - unrelated to team-color pucks.

## Testing

- `npx vue-tsc --noEmit` - clean
- `npm run lint` - clean
- `npx vitest run` - 116/116 passing (12 new)
- Manual visual check recommended: compare a few team colors (especially White/Yellow/Cyan on a light basemap, and Red/Blue on a dark basemap) against ATAK side by side.