### PR TITLE
Permissions Management

### DIFF
--- a/api/common/control/layer.ts
+++ b/api/common/control/layer.ts
@@ -1,4 +1,5 @@
 import Err from '@openaddresses/batch-error';
+import type { StaticCapabilitiesDocument } from '@tak-ps/etl';
 import { PERMISSIONS } from '@tak-ps/etl';
 
 export default class LayerControl {
@@ -25,6 +26,31 @@ export default class LayerControl {
             if (!this.isValidPermission(permission)) {
                 const known = Object.keys(PERMISSIONS).map(p => `${p}:<${PERMISSIONS[p].join('|')}|*>`).join(', ');
                 throw new Err(400, null, `Unknown Permission: ${permission} - Permissions must be one of: ${known}`);
+            }
+        }
+    }
+
+    /**
+     * Ensure a set of Layer permissions is consistent with the Permissions a Task's
+     * Capabilities document declares - every granted permission must be declared and
+     * every required permission must be granted
+     */
+    static validateManifestPermissions(
+        permissions: Array<string>,
+        capabilities: StaticCapabilitiesDocument,
+        task: string,
+    ): void {
+        const declared = new Map(capabilities.permissions.map(p => [p.resource, p]));
+
+        for (const permission of permissions) {
+            if (!declared.has(permission)) {
+                throw new Err(400, null, `Permission ${permission} is not declared by ${task} - Declared permissions: ${Array.from(declared.keys()).join(', ') || 'none'}`);
+            }
+        }
+
+        for (const [resource, permission] of declared) {
+            if (permission.required && !permissions.includes(resource)) {
+                throw new Err(400, null, `Permission ${resource} is required by ${task}`);
             }
         }
     }

--- a/api/derived-types.d.ts
+++ b/api/derived-types.d.ts
@@ -49393,6 +49393,8 @@ export interface paths {
                     sort: "id" | "prefix" | "favorite" | "created" | "updated" | "name" | "logo" | "repo" | "readme" | "enableRLS";
                     /** @description Filter results by a human readable name field */
                     filter: string;
+                    /** @description Only return the Task with this exact prefix */
+                    prefix?: string;
                 };
                 header?: never;
                 path?: never;

--- a/api/stateless/routes/connection-layer.ts
+++ b/api/stateless/routes/connection-layer.ts
@@ -4,6 +4,7 @@ import Schema from '@openaddresses/batch-schema';
 import Err from '@openaddresses/batch-error';
 import Auth, { AuthResourceAccess, AuthUser } from '../../common/auth.js';
 import Lambda from '../lib/aws/lambda.js';
+import ECR from '../lib/aws/ecr.js';
 import CloudFormation from '../lib/aws/cloudformation.js';
 import LayerDeploy from '../lib/aws/layer-deploy.js';
 import Style, { StyleContainer } from '../../common/style.js';
@@ -788,6 +789,18 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
                 connection = auth.connection;
                 layer = await layerControl.from(connection, req.params.layerid);
+            }
+
+            if (req.body.permissions !== undefined) {
+                const task = req.body.task || layer.task;
+                const match = task.match(/^(.+)-v([0-9]+\.[0-9]+\.[0-9]+)$/);
+
+                if (match) {
+                    const capabilities = await ECR.capabilities(match[1], match[2]);
+                    if (capabilities) {
+                        CommonLayerControl.validateManifestPermissions(req.body.permissions, capabilities, task);
+                    }
+                }
             }
 
             let changed = false;

--- a/api/stateless/routes/task.ts
+++ b/api/stateless/routes/task.ts
@@ -31,6 +31,9 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 enum: Object.keys(Task),
             }),
             filter: Default.Filter,
+            prefix: Type.Optional(Type.String({
+                description: 'Only return the Task with this exact prefix',
+            })),
         }),
         res: Type.Object({
             total: Type.Integer(),
@@ -47,6 +50,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 sort: req.query.sort,
                 where: sql`
                     name ~* ${req.query.filter}
+                    AND (${req.query.prefix ?? null}::TEXT IS NULL OR prefix = ${req.query.prefix ?? null}::TEXT)
                 `,
             });
 

--- a/api/test/connection-layer.srv.test.ts
+++ b/api/test/connection-layer.srv.test.ts
@@ -384,6 +384,117 @@ test('PATCH: api/connection/1/layer/1 - invalid permissions', async () => {
     }
 });
 
+test('PATCH: api/connection/1/layer/1 - permissions validated against task manifest', async () => {
+    const manifest = (capabilities: object) => JSON.stringify({
+        schemaVersion: 2,
+        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+        annotations: {
+            'com.cloudtak.capabilities': JSON.stringify(capabilities),
+        },
+    });
+
+    const base = {
+        version: '1.0',
+        name: 'Test Task',
+        description: 'A Task used in testing',
+        compute: { memory: 256, timeout: 30 },
+        invocations: {},
+    };
+
+    try {
+        Sinon.stub(ECRClient.prototype, 'send').callsFake((command) => {
+            if (!(command instanceof BatchGetImageCommand)) throw new Error('Unexpected command');
+
+            const tag = command.input.imageIds![0].imageTag;
+
+            if (tag === 'etl-test-v1.0.0') {
+                return Promise.resolve({
+                    images: [{
+                        imageManifest: manifest({
+                            ...base,
+                            permissions: [{
+                                resource: 'feature:submit',
+                                required: true,
+                                description: 'Post features',
+                            }],
+                        }),
+                    }],
+                });
+            } else if (tag === 'etl-test-v1.1.0') {
+                return Promise.resolve({
+                    images: [{
+                        imageManifest: manifest({
+                            ...base,
+                            permissions: [{
+                                resource: 'feature:submit',
+                                required: true,
+                                description: 'Post features',
+                            }, {
+                                resource: 'video:*',
+                                required: false,
+                                description: 'Manage video',
+                            }],
+                        }),
+                    }],
+                });
+            }
+
+            throw new Error(`Unexpected tag: ${tag}`);
+        });
+
+        // Current version (1.0.0) does not declare video:*
+        const undeclared = await flight.fetch('/api/connection/1/layer/1', {
+            method: 'PATCH',
+            auth: { bearer: flight.token.admin },
+            body: { permissions: ['feature:submit', 'video:*'] },
+        }, false);
+
+        assert.equal(undeclared.status, 400);
+        assert.equal(undeclared.body.message, 'Permission video:* is not declared by etl-test-v1.0.0 - Declared permissions: feature:submit');
+
+        // Current version requires feature:submit
+        const missing = await flight.fetch('/api/connection/1/layer/1', {
+            method: 'PATCH',
+            auth: { bearer: flight.token.admin },
+            body: { permissions: [] },
+        }, false);
+
+        assert.equal(missing.status, 400);
+        assert.equal(missing.body.message, 'Permission feature:submit is required by etl-test-v1.0.0');
+
+        const ok = await flight.fetch('/api/connection/1/layer/1', {
+            method: 'PATCH',
+            auth: { bearer: flight.token.admin },
+            body: { permissions: ['feature:submit'] },
+        }, true);
+
+        assert.deepEqual(ok.body.permissions, ['feature:submit']);
+
+        // A task change in the body is validated against the new version's manifest
+        const newVersion = await flight.fetch('/api/connection/1/layer/1', {
+            method: 'PATCH',
+            auth: { bearer: flight.token.admin },
+            body: { task: 'etl-test-v1.1.0', permissions: ['video:*'] },
+        }, false);
+
+        assert.equal(newVersion.status, 400);
+        assert.equal(newVersion.body.message, 'Permission feature:submit is required by etl-test-v1.1.0');
+    } catch (err) {
+        assert.ifError(err);
+    }
+
+    Sinon.restore();
+
+    // Without a manifest available the existing permissions are cleared unchecked
+    const cleared = await flight.fetch('/api/connection/1/layer/1', {
+        method: 'PATCH',
+        auth: { bearer: flight.token.admin },
+        body: { permissions: [] },
+    }, true);
+
+    assert.deepEqual(cleared.body.permissions, []);
+});
+
 test('PATCH: api/connection/1/layer/1 - layer token cannot modify permissions', async () => {
     try {
         const token = 'etl.' + jwt.sign({ access: 'layer', id: 1, internal: true }, 'coe-wildland-fire');

--- a/api/test/task.srv.test.ts
+++ b/api/test/task.srv.test.ts
@@ -332,6 +332,28 @@ test('GET: api/task - single registered task', async () => {
     }
 });
 
+test('GET: api/task - prefix filter', async () => {
+    try {
+        const match = await flight.fetch('/api/task?prefix=etl-test', {
+            method: 'GET',
+            auth: { bearer: flight.token.admin },
+        }, true);
+
+        assert.equal(match.body.total, 1);
+        assert.equal(match.body.items[0].prefix, 'etl-test');
+
+        const miss = await flight.fetch('/api/task?prefix=etl-missing', {
+            method: 'GET',
+            auth: { bearer: flight.token.admin },
+        }, true);
+
+        assert.equal(miss.body.total, 0);
+        assert.deepEqual(miss.body.items, []);
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
 test('GET: api/task/1', async () => {
     try {
         const res = await flight.fetch('/api/task/1', {

--- a/api/web/src/components/Admin/AdminLayerUpdates.vue
+++ b/api/web/src/components/Admin/AdminLayerUpdates.vue
@@ -15,6 +15,15 @@
             </h1>
 
             <div class='ms-auto btn-list'>
+                <TablerButton
+                    v-if='updatable.length'
+                    class='btn-primary'
+                    :disabled='queue.length > 0 || Object.keys(updating).length > 0'
+                    @click='updateAll'
+                >
+                    <span v-if='queue.length'>Updating <span v-text='queue.length' /> remaining...</span>
+                    <span v-else>Update All (<span v-text='updatable.length' />)</span>
+                </TablerButton>
                 <TablerRefreshButton
                     :loading='loading'
                     @click='fetchList'
@@ -106,11 +115,22 @@
                 </table>
             </div>
         </div>
+
+        <LayerTaskUpdateModal
+            v-if='taskUpdate'
+            :layer='taskUpdate.layer'
+            :update='taskUpdate.update'
+            @close='closeUpdate'
+            @updated='closeUpdate'
+        />
     </div>
 </template>
 
 <script setup lang='ts'>
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, computed } from 'vue';
+import LayerTaskUpdateModal from '../util/LayerTaskUpdateModal.vue';
+import type { UpdateTarget } from '../util/LayerTaskUpdateModal.vue';
+import type { TaskUpdate } from '../util/LayerTaskSelect.vue';
 import { useRouter } from 'vue-router';
 import { openSecondaryView } from '../../utils/capacitor.ts';
 import { server } from '../../std.ts';
@@ -139,6 +159,11 @@ const list = ref<AdminLayerUpdateList>({
     items: []
 });
 
+const taskUpdate = ref<{ layer: UpdateTarget; update: TaskUpdate }>();
+const queue = ref<AdminLayerUpdate[]>([]);
+
+const updatable = computed(() => list.value.items.filter((layer) => layer.has_update && layer.latest_version));
+
 onMounted(async () => {
     await fetchList();
 });
@@ -165,38 +190,42 @@ async function fetchList(): Promise<void> {
     }
 }
 
-async function updateLayer(layer: AdminLayerUpdate): Promise<void> {
-    updating.value[layer.id] = true;
+function updateLayer(layer: AdminLayerUpdate): void {
     error.value = undefined;
 
-    try {
-        if (!layer.latest_version) {
-            throw new Error('No newer version available');
-        }
-
-        const res = await server.PATCH('/api/connection/{:connectionid}/layer/{:layerid}', {
-            params: {
-                query: {
-                    alarms: false
-                },
-                path: {
-                    ':connectionid': layerConnectionId(layer),
-                    ':layerid': layer.id
-                }
-            },
-            body: {
-                task: `${layer.task_prefix}-v${layer.latest_version}`
-            }
-        });
-
-        if (res.error) throw new Error(res.error.message);
-
-        await fetchList();
-    } catch (err) {
-        error.value = err instanceof Error ? err : new Error(String(err));
-    } finally {
-        delete updating.value[layer.id];
+    if (!layer.latest_version) {
+        error.value = new Error('No newer version available');
+        return;
     }
+
+    updating.value[layer.id] = true;
+
+    taskUpdate.value = {
+        layer: { id: layer.id, connection: layer.connection },
+        update: {
+            prefix: layer.task_prefix,
+            from: layer.current_version,
+            to: layer.latest_version
+        }
+    };
+}
+
+async function closeUpdate(): Promise<void> {
+    if (taskUpdate.value) delete updating.value[taskUpdate.value.layer.id];
+    taskUpdate.value = undefined;
+
+    const next = queue.value.shift();
+    if (next) {
+        updateLayer(next);
+    } else {
+        await fetchList();
+    }
+}
+
+function updateAll(): void {
+    queue.value = updatable.value.slice();
+    const first = queue.value.shift();
+    if (first) updateLayer(first);
 }
 
 async function redeployLayer(layer: AdminLayerUpdate): Promise<void> {

--- a/api/web/src/components/ETL/Layer/LayerDeployment.vue
+++ b/api/web/src/components/ETL/Layer/LayerDeployment.vue
@@ -91,67 +91,15 @@
             <template v-else>
                 <div class='row g-2'>
                     <div class='col-md-12'>
-                        <div class='d-flex'>
-                            <label class='form-label'>Layer Task</label>
-                            <div class='ms-auto'>
-                                <div class='btn-list'>
-                                    <div>
-                                        <TablerIconButton
-                                            v-if='!newTaskVersion && !loading.version'
-                                            title='Check for new version'
-                                            @click='latestVersion'
-                                        >
-                                            <IconRefresh
-                                                :size='16'
-                                                stroke='1'
-                                            />
-                                        </TablerIconButton>
-                                        <div
-                                            v-else-if='loading.version'
-                                            class='d-flex justify-content-center'
-                                        >
-                                            <div
-                                                class='spinner-border'
-                                                role='status'
-                                            />
-                                        </div>
-                                        <span v-else>
-                                            New Task Version
-                                            <span
-                                                v-if='disabled'
-                                                v-text='newTaskVersion'
-                                            />
-                                            <span
-                                                v-else
-                                                class='cursor-pointer text-blue'
-                                                @click='updateTask'
-                                                v-text='newTaskVersion'
-                                            />
-                                        </span>
-                                    </div>
-                                    <div v-if='!disabled'>
-                                        <IconSettings
-                                            :size='16'
-                                            stroke='1'
-                                            class='cursor-pointer'
-                                            @click='taskmodal = true'
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <input
+                        <LayerTaskSelect
                             v-model='config.task'
                             :disabled='disabled'
-                            :class='{
-                                "is-invalid": errors.task
-                            }'
-                            class='form-control'
-                            placeholder='Schedule Task'
-                        >
+                            :updates='true'
+                            @update='taskUpdate = $event'
+                        />
                         <div
                             v-if='errors.task'
-                            class='invalid-feedback'
+                            class='invalid-feedback d-block'
                             v-text='errors.task'
                         />
                     </div>
@@ -206,11 +154,12 @@
             </template>
         </div>
 
-        <TaskModal
-            v-if='taskmodal'
-            :task='config.task'
-            @close='taskmodal = false'
-            @task='taskmodal = false; config.task = $event'
+        <LayerTaskUpdateModal
+            v-if='taskUpdate'
+            :layer='layer'
+            :update='taskUpdate'
+            @close='taskUpdate = undefined'
+            @updated='taskUpdated'
         />
     </div>
 </template>
@@ -218,7 +167,9 @@
 <script setup lang='ts'>
 import { ref, onMounted, onUnmounted } from 'vue';
 import { useRoute } from 'vue-router';
-import TaskModal from './utils/TaskModal.vue';
+import LayerTaskSelect from '../../util/LayerTaskSelect.vue';
+import type { TaskUpdate } from '../../util/LayerTaskSelect.vue';
+import LayerTaskUpdateModal from '../../util/LayerTaskUpdateModal.vue';
 import { server } from '../../../std.ts';
 import type { ETLLayer, ETLLayerTask } from '../../../types.ts';
 import {
@@ -230,7 +181,6 @@ import {
 import {
     IconPencil,
     IconRefresh,
-    IconSettings,
     IconCloudUpload,
 } from '@tabler/icons-vue';
 
@@ -249,8 +199,7 @@ const route = useRoute();
 const disabled = ref(true);
 const looping = ref<ReturnType<typeof setInterval> | false>(false);
 const config = ref<ETLLayer>(JSON.parse(JSON.stringify(props.layer)));
-const newTaskVersion = ref<string>();
-const taskmodal = ref(false);
+const taskUpdate = ref<TaskUpdate>();
 const errors = ref<Record<string, { message: string } | false>>({
     cloudwatch: false
 });
@@ -388,33 +337,13 @@ async function saveLayer() {
     }
 }
 
-function updateTask() {
-    config.value.task = config.value.task.replace(/-v[0-9]+\.[0-9]+\.[0-9]+$/, `-v${newTaskVersion.value}`);
-    newTaskVersion.value = undefined;
-}
+function taskUpdated(layer: ETLLayer) {
+    taskUpdate.value = undefined;
+    config.value = JSON.parse(JSON.stringify(layer));
+    disabled.value = true;
 
-async function latestVersion() {
-    loading.value.version = true;
-    const match = config.value.task.match(/^(.*)-v([0-9]+\.[0-9]+\.[0-9]+)$/)
-    if (!match) return;
-    const task = match[1];
-    const version = match[2];
-
-    const res = await server.GET('/api/task/raw/{:task}', {
-        params: {
-            path: {
-                ':task': task
-            }
-        }
-    });
-    if (res.error) throw new Error(res.error.message);
-    const versions = res.data.versions.map((v) => v.version);
-
-    if (versions.indexOf(version) !== 0) {
-        newTaskVersion.value = versions[0];
-    }
-
-    loading.value.version = false;
+    emit('refresh');
+    emit('stack');
 }
 
 </script>

--- a/api/web/src/components/ETL/Layer/utils/TaskModal.vue
+++ b/api/web/src/components/ETL/Layer/utils/TaskModal.vue
@@ -22,16 +22,19 @@ interface TaskItem {
 
 type TaskSort = 'id' | 'prefix' | 'favorite' | 'created' | 'updated' | 'name' | 'logo' | 'repo' | 'readme' | 'enableRLS';
 
-withDefaults(defineProps<{
-    task?: string;
+const props = withDefaults(defineProps<{
+    modelValue?: string;
 }>(), {
-    task: '',
+    modelValue: '',
 });
 
 const emit = defineEmits<{
-    (e: 'task', value: string): void;
+    (e: 'update:modelValue', value: string): void;
     (e: 'close'): void;
 }>();
+
+// Browse the task list only when no task is set or the user asks to change it
+const browsing = ref(!props.modelValue);
 
 const loading = reactive({
     version: false,
@@ -73,8 +76,8 @@ async function fetchTask() {
 
         versions.value = (taskRes.data as ETLTaskVersions).versions.map((v) => v.version);
 
-        if (versions.value.length) {
-            version.value = versions.value[0];
+        if (!version.value || !versions.value.includes(version.value)) {
+            version.value = versions.value[0] || '';
         }
 
         if (current.value.readme) {
@@ -114,19 +117,61 @@ async function fetchTasks() {
     list.items = res.data.items as TaskItem[];
 
 
-    if (list.total && list.items.length) {
+    if (!current.value && list.total && list.items.length) {
         current.value = list.items[0];
     }
 
     loading.tasks = false;
 }
 
+async function fetchCurrent() {
+    const match = props.modelValue.match(/^(.+)-v([0-9]+\.[0-9]+\.[0-9]+)$/);
+    if (!match) return;
+
+    loading.task = true;
+
+    const res = await server.GET('/api/task', {
+        params: {
+            query: {
+                filter: match[1],
+                limit: 1,
+                page: 0,
+                sort: 'name',
+                order: 'asc',
+            }
+        }
+    });
+
+    if (res.error) throw new Error(res.error.message);
+
+    const task = (res.data.items as TaskItem[]).find((t) => t.prefix === match[1]);
+    if (!task) {
+        browsing.value = true;
+        loading.task = false;
+        return;
+    }
+
+    version.value = match[2];
+    current.value = task;
+}
+
+function select() {
+    if (!current.value) return;
+    emit('update:modelValue', `${current.value.prefix}-v${version.value}`);
+    emit('close');
+}
+
 watch(current, fetchTask);
 
 watch(paging, fetchTasks, { deep: true });
 
-onMounted(() => {
-    fetchTasks();
+onMounted(async () => {
+    if (props.modelValue) await fetchCurrent();
+    if (browsing.value) await fetchTasks();
+});
+
+watch(browsing, async () => {
+    if (browsing.value && !list.items.length) await fetchTasks();
 });
 
 </script>
@@ -142,7 +187,10 @@ onMounted(() => {
         <div class='modal-status bg-yellow' />
         <div class='modal-body py-4'>
             <div class='row g-0'>
-                <div class='col-12 col-md-3 border-end'>
+                <div
+                    v-if='browsing'
+                    class='col-12 col-md-3 border-end'
+                >
                     <div class='card-header'>
                         <div class='card-title subheader'>
                             Task Selection
@@ -199,7 +247,10 @@ onMounted(() => {
                         </div>
                     </div>
                 </div>
-                <div class='col-12 col-md-9 position-relative px-4'>
+                <div
+                    class='position-relative px-4'
+                    :class='browsing ? "col-12 col-md-9" : "col-12"'
+                >
                     <TablerLoading
                         v-if='loading.task'
                         desc='Loading Task'
@@ -214,6 +265,17 @@ onMounted(() => {
                                 class='card-title subheader'
                                 v-text='`${current.name} (${current.prefix})`'
                             />
+                            <div
+                                v-if='!browsing'
+                                class='ms-auto'
+                            >
+                                <button
+                                    class='btn btn-sm btn-secondary'
+                                    @click='browsing = true'
+                                >
+                                    Change Task
+                                </button>
+                            </div>
                         </div>
                         <div class='card-body'>
                             <TablerMarkdown
@@ -234,7 +296,7 @@ onMounted(() => {
                                         <button
                                             class='btn btn-primary w-100'
                                             style='margin-top: 8px;'
-                                            @click='emit("task", `${current.prefix}-v${version}`)'
+                                            @click='select'
                                         >
                                             Select
                                         </button>

--- a/api/web/src/components/util/LayerTaskSelect.vue
+++ b/api/web/src/components/util/LayerTaskSelect.vue
@@ -15,7 +15,7 @@
                     :inline='true'
                     desc='Loading Task'
                 />
-                <template v-else-if='selected.id'>
+                <template v-else-if='selected.prefix'>
                     <div class='col-12 d-flex align-items-center user-select-none'>
                         <img
                             v-if='selected.logo'
@@ -34,17 +34,60 @@
                             class='mx-2'
                             v-text='selected.name'
                         />
-                        <div class='ms-auto btn-list'>
+                        <div class='ms-auto btn-list align-items-center'>
+                            <template v-if='updates'>
+                                <div
+                                    v-if='loading.update'
+                                    class='spinner-border spinner-border-sm'
+                                    role='status'
+                                />
+                                <div
+                                    v-else-if='checkedUpdate && !latestVersion'
+                                    class='d-flex align-items-center'
+                                >
+                                    <span class='small text-muted'>Up to date</span>
+                                    <TablerIconButton
+                                        title='Check for Updates'
+                                        class='ms-1'
+                                        @click='checkUpdates'
+                                    >
+                                        <IconRefresh
+                                            :size='20'
+                                            stroke='1'
+                                        />
+                                    </TablerIconButton>
+                                </div>
+                                <button
+                                    v-else-if='latestVersion'
+                                    class='btn btn-sm btn-primary'
+                                    @click='emit("update", { prefix: String(selected.prefix), from: String(selected.version), to: latestVersion })'
+                                >
+                                    Update to v<span v-text='latestVersion' />
+                                </button>
+                                <button
+                                    v-else
+                                    class='btn btn-sm btn-secondary'
+                                    @click='checkUpdates'
+                                >
+                                    <IconRefresh
+                                        :size='16'
+                                        stroke='1'
+                                        class='me-1'
+                                    />
+                                    Check for Updates
+                                </button>
+                            </template>
+
                             <TablerEnum
                                 v-model='selected.version'
+                                :disabled='disabled'
                                 :options='selected.versions'
                             />
 
-
                             <TablerIconButton
-                                v-if='selected.id'
+                                v-if='!disabled'
                                 title='Remove Task'
-                                @click='selected.id = undefined'
+                                @click='selected = { id: undefined }'
                             >
                                 <IconTrash
                                     :size='32'
@@ -128,7 +171,7 @@
                 </template>
             </div>
             <div
-                v-if='!loading.main && !loading.task && list.total > paging.limit && !selected.id'
+                v-if='!loading.main && !loading.task && list.total > paging.limit && !selected.prefix'
                 class='card-footer d-flex'
             >
                 <div class='ms-auto'>
@@ -193,6 +236,7 @@ import type { APIList } from '../../types.ts';
 import {
     IconStar,
     IconTrash,
+    IconRefresh,
     IconBroadcast,
     IconInfoSquare,
 } from '@tabler/icons-vue';
@@ -221,17 +265,29 @@ interface Task {
     [key: string]: unknown;
 }
 
+export interface TaskUpdate {
+    prefix: string;
+    from: string;
+    to: string;
+}
+
 const props = withDefaults(defineProps<{
     modelValue?: string;
     disabled?: boolean;
+    updates?: boolean;
 }>(), {
     modelValue: undefined,
     disabled: false,
+    updates: false,
 });
 
 const emit = defineEmits<{
     (e: 'update:modelValue', value: string | undefined): void;
+    (e: 'update', value: TaskUpdate): void;
 }>();
+
+const checkedUpdate = ref(false);
+const latestVersion = ref<string>();
 
 const loading = ref<Record<string, boolean>>({
     main: true,
@@ -272,7 +328,8 @@ async function resolveTask(task: Task): Promise<Task> {
     const res = await server.GET('/api/task', {
         params: {
             query: {
-                filter: String(task.prefix || ''),
+                filter: '',
+                prefix: String(task.prefix),
                 limit: 1,
                 page: 0,
                 order: paging.value.order,
@@ -283,13 +340,17 @@ async function resolveTask(task: Task): Promise<Task> {
 
     if (res.error) throw new Error(res.error.message);
 
-    const match = res.data.items.find((item) => item.prefix === task.prefix);
-
-    return match || task;
+    // Unregistered tasks still render using their prefix as the name
+    return res.data.items[0] || { ...task, name: task.prefix };
 }
 
+watch(() => [selected.value.prefix, selected.value.version], () => {
+    checkedUpdate.value = false;
+    latestVersion.value = undefined;
+});
+
 watch(selected, () => {
-    if (selected.value.id) {
+    if (selected.value.prefix) {
         emit('update:modelValue', `${selected.value.prefix}-v${selected.value.version}`);
     } else {
         emit('update:modelValue', undefined);
@@ -364,6 +425,33 @@ async function select(task: Task, version?: string) {
     }
 
     loading.value.task = false;
+}
+
+async function checkUpdates() {
+    if (!selected.value.prefix) return;
+
+    loading.value.update = true;
+
+    try {
+        const res = await server.GET('/api/task/raw/{:task}', {
+            params: {
+                path: {
+                    ':task': String(selected.value.prefix)
+                }
+            }
+        });
+
+        if (res.error) throw new Error(res.error.message);
+
+        const versions = res.data.versions.map((v) => v.version);
+        selected.value.versions = versions;
+
+        const latest = versions[0];
+        latestVersion.value = (latest && latest !== selected.value.version) ? latest : undefined;
+        checkedUpdate.value = true;
+    } finally {
+        loading.value.update = false;
+    }
 }
 
 async function listTasks() {

--- a/api/web/src/components/util/LayerTaskUpdateModal.vue
+++ b/api/web/src/components/util/LayerTaskUpdateModal.vue
@@ -1,0 +1,320 @@
+<template>
+    <TablerModal size='lg'>
+        <div class='modal-header'>
+            <IconArrowUp
+                size='24'
+                stroke='1'
+            />
+            <span class='mx-2'>
+                Update Task: v<span v-text='update.from' /> → v<span v-text='update.to' />
+            </span>
+            <button
+                type='button'
+                class='btn-close'
+                aria-label='Close'
+                @click='emit("close")'
+            />
+        </div>
+        <div
+            class='modal-body overflow-auto'
+            style='max-height: 60vh'
+        >
+            <TablerLoading
+                v-if='loading'
+                desc='Loading Task Permissions'
+            />
+            <TablerAlert
+                v-else-if='error'
+                title='Task Update Error'
+                :err='error'
+            />
+            <template v-else>
+                <div
+                    v-if='!next'
+                    class='alert alert-warning'
+                >
+                    The new task version does not publish a Capabilities document - existing Layer permissions will be kept as-is.
+                </div>
+                <TablerNone
+                    v-else-if='!rows.length'
+                    :create='false'
+                    :compact='true'
+                    label='Permissions Requested'
+                />
+                <table
+                    v-else
+                    class='table table-vcenter card-table'
+                >
+                    <thead>
+                        <tr>
+                            <th>Permission</th>
+                            <th class='text-center'>
+                                Then (v<span v-text='update.from' />)
+                            </th>
+                            <th class='text-center'>
+                                Now (v<span v-text='update.to' />)
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr
+                            v-for='row in rows'
+                            :key='row.resource'
+                            :class='{ "bg-yellow-lt": row.changed }'
+                        >
+                            <td>
+                                <code v-text='row.resource' />
+                                <div
+                                    v-if='row.description'
+                                    class='small text-secondary'
+                                    v-text='row.description'
+                                />
+                            </td>
+                            <td class='text-center'>
+                                <span
+                                    v-if='row.then === "granted"'
+                                    class='badge bg-green-lt'
+                                >Granted</span>
+                                <span
+                                    v-else-if='row.then === "denied"'
+                                    class='badge bg-secondary-lt'
+                                >Not Granted</span>
+                                <span
+                                    v-else
+                                    class='text-muted'
+                                >—</span>
+                            </td>
+                            <td class='text-center'>
+                                <span
+                                    v-if='row.now === "removed"'
+                                    class='badge bg-red-lt'
+                                >Removed</span>
+                                <span
+                                    v-else-if='row.now === "required"'
+                                    class='badge bg-green-lt'
+                                >Required</span>
+                                <TablerToggle
+                                    v-else
+                                    v-model='granted[row.resource]'
+                                    label='Grant'
+                                />
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </template>
+        </div>
+        <div class='modal-footer'>
+            <button
+                class='btn'
+                @click='emit("close")'
+            >
+                Cancel
+            </button>
+            <div class='ms-auto'>
+                <button
+                    class='btn btn-primary'
+                    :disabled='loading || !!error || saving'
+                    @click='accept'
+                >
+                    <span
+                        v-if='saving'
+                        class='spinner-border spinner-border-sm me-2'
+                        role='status'
+                    />
+                    Accept &amp; Update
+                </button>
+            </div>
+        </div>
+    </TablerModal>
+</template>
+
+<script setup lang='ts'>
+import { ref, computed, onMounted } from 'vue';
+import { server } from '../../std.ts';
+import type { ETLLayer, ETLTaskCapabilities } from '../../types.ts';
+import type { TaskUpdate } from './LayerTaskSelect.vue';
+import { IconArrowUp } from '@tabler/icons-vue';
+import {
+    TablerModal,
+    TablerLoading,
+    TablerAlert,
+    TablerToggle,
+    TablerNone,
+} from '@tak-ps/vue-tabler';
+
+type Permission = ETLTaskCapabilities['permissions'][number];
+
+interface PermissionRow {
+    resource: string;
+    description: string;
+    then: 'granted' | 'denied' | 'absent';
+    now: 'required' | 'optional' | 'removed';
+    changed: boolean;
+}
+
+export interface UpdateTarget {
+    id: number;
+    connection: number | null;
+    permissions?: string[];
+}
+
+const props = defineProps<{
+    layer: UpdateTarget;
+    update: TaskUpdate;
+}>();
+
+const emit = defineEmits<{
+    (e: 'close'): void;
+    (e: 'updated', layer: ETLLayer): void;
+}>();
+
+const loading = ref(true);
+const saving = ref(false);
+const error = ref<Error>();
+const prev = ref<ETLTaskCapabilities | null>(null);
+const next = ref<ETLTaskCapabilities | null>(null);
+const granted = ref<Record<string, boolean>>({});
+const current = ref<string[]>([]);
+
+const rows = computed<PermissionRow[]>(() => {
+    if (!next.value) return [];
+
+    const currentSet = new Set(current.value);
+    const prevPerms = new Map<string, Permission>((prev.value?.permissions || []).map((p) => [p.resource, p]));
+    const nextPerms = new Map<string, Permission>(next.value.permissions.map((p) => [p.resource, p]));
+
+    const resources = new Set<string>([...prevPerms.keys(), ...currentSet, ...nextPerms.keys()]);
+
+    return Array.from(resources).sort().map((resource) => {
+        const before = prevPerms.get(resource);
+        const after = nextPerms.get(resource);
+
+        const then: PermissionRow['then'] = currentSet.has(resource) ? 'granted' : (before ? 'denied' : 'absent');
+        const now: PermissionRow['now'] = !after ? 'removed' : (after.required ? 'required' : 'optional');
+
+        return {
+            resource,
+            description: after?.description || before?.description || '',
+            then,
+            now,
+            changed: now === 'removed' || (now === 'required' && then !== 'granted') || (then === 'absent'),
+        };
+    });
+});
+
+onMounted(async () => {
+    try {
+        [current.value, prev.value, next.value] = await Promise.all([
+            props.layer.permissions ? props.layer.permissions : fetchPermissions(),
+            fetchCapabilities(props.update.from),
+            fetchCapabilities(props.update.to)
+        ]);
+
+        if (next.value) {
+            const currentSet = new Set(current.value);
+            for (const permission of next.value.permissions) {
+                granted.value[permission.resource] = permission.required || currentSet.has(permission.resource);
+            }
+        }
+    } catch (err) {
+        error.value = err instanceof Error ? err : new Error(String(err));
+        loading.value = false;
+        return;
+    }
+
+    loading.value = false;
+
+    // Nothing for the user to decide - submit without prompting
+    if (!requirementsChanged()) await accept();
+});
+
+/**
+ * Permission requirements changed if the new manifest introduces a resource the Layer
+ * doesn't already grant, or drops one it does
+ */
+function requirementsChanged(): boolean {
+    if (!next.value) return false;
+
+    const currentSet = new Set(current.value);
+    const nextSet = new Set(next.value.permissions.map((p) => p.resource));
+
+    for (const resource of nextSet) {
+        if (!currentSet.has(resource)) return true;
+    }
+
+    for (const resource of currentSet) {
+        if (!nextSet.has(resource)) return true;
+    }
+
+    return false;
+}
+
+async function fetchPermissions(): Promise<string[]> {
+    const res = await server.GET('/api/connection/{:connectionid}/layer/{:layerid}', {
+        params: {
+            query: { alarms: false, download: false },
+            path: {
+                ':connectionid': props.layer.connection ?? 0,
+                ':layerid': props.layer.id
+            }
+        }
+    });
+
+    if (res.error) throw new Error(res.error.message);
+
+    return res.data.permissions;
+}
+
+async function fetchCapabilities(version: string): Promise<ETLTaskCapabilities | null> {
+    const res = await server.GET('/api/task/raw/{:task}/version/{:version}', {
+        params: {
+            path: {
+                ':task': props.update.prefix,
+                ':version': version
+            }
+        }
+    });
+
+    if (res.error) throw new Error(res.error.message);
+
+    return res.data.capabilities;
+}
+
+function permissions(): string[] {
+    if (!next.value) return current.value;
+
+    return next.value.permissions
+        .map((p) => p.resource)
+        .filter((resource) => granted.value[resource]);
+}
+
+async function accept() {
+    saving.value = true;
+    error.value = undefined;
+
+    try {
+        const res = await server.PATCH('/api/connection/{:connectionid}/layer/{:layerid}', {
+            params: {
+                query: { alarms: true },
+                path: {
+                    ':connectionid': props.layer.connection ?? 0,
+                    ':layerid': props.layer.id
+                }
+            },
+            body: {
+                task: `${props.update.prefix}-v${props.update.to}`,
+                permissions: permissions()
+            }
+        });
+
+        if (res.error) throw new Error(res.error.message);
+
+        emit('updated', res.data as ETLLayer);
+    } catch (err) {
+        error.value = err instanceof Error ? err : new Error(String(err));
+    } finally {
+        saving.value = false;
+    }
+}
+</script>


### PR DESCRIPTION
### Context

- :tada: Introduce Task Specific UI for ETL Version & Permissions Management

cc/ @chriselsen As you are the only other provider of ETLs that I am aware of, you'll want to migrate your ETL build pipeline to use https://github.com/dfpc-coe/etl-base (`cloudtak-etl`) for building. This will package the ETL container image with a manifest document containing permissions and capabilities accessible before lambda runtime, greatly decreasing the config and number of steps needed in the UI to get a lambda operational.


<img width="1972" height="824" alt="image" src="https://github.com/user-attachments/assets/642078ba-ee5f-43d5-b088-b3b2df481638" />

<img width="1662" height="798" alt="image" src="https://github.com/user-attachments/assets/ec30b3f4-6b99-4628-ae31-da967d36f1b7" />
