### PR TITLE
Mission GUID Routes

### DIFF
--- a/api/derived-types.d.ts
+++ b/api/derived-types.d.ts
@@ -29510,236 +29510,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/manifest.webmanifest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Return the Web Manifest for PWA Use */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            name: string;
-                            short_name: string;
-                            description: string;
-                            start_url: string;
-                            display: string;
-                            background_color: string;
-                            theme_color: string;
-                            lang: string;
-                            scope: string;
-                            icons: {
-                                src: string;
-                                sizes: string;
-                                type: string;
-                            }[];
-                            orientation: string;
-                            categories: string[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/manifest.webmanifest/logos/{:size}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Return a resized PNG logo for PWA use */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Logo size in pixels */
-                    ":size": number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/marti/api/files/{:hash}": {
         parameters: {
             query?: never;
@@ -29953,7 +29723,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/layer": {
+    "/api/marti/missions/{:guid}/layer": {
         parameters: {
             query?: never;
             header?: never;
@@ -29967,7 +29737,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -30092,7 +29862,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -30226,7 +29996,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/layer/{:layerid}": {
+    "/api/marti/missions/{:guid}/layer/{:layerid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -30240,7 +30010,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":layerid": string;
                 };
@@ -30367,7 +30137,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/layer/{:uid}/cot": {
+    "/api/marti/missions/{:guid}/layer/{:uid}/cot": {
         parameters: {
             query?: never;
             header?: never;
@@ -30382,7 +30152,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":uid": string;
                 };
@@ -30489,7 +30259,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/layer/{:uid}/cot/{:cotuid}": {
+    "/api/marti/missions/{:guid}/layer/{:uid}/cot/{:cotuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -30506,7 +30276,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":uid": string;
                     /** @description No Description */
@@ -30607,7 +30377,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/layer/{:uid}": {
+    "/api/marti/missions/{:guid}/layer/{:uid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -30624,7 +30394,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":uid": string;
                 };
@@ -30727,7 +30497,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":uid": string;
                 };
@@ -30830,7 +30600,7 @@ export interface paths {
         };
         trace?: never;
     };
-    "/api/marti/missions/{:name}/log": {
+    "/api/marti/missions/{:guid}/log": {
         parameters: {
             query?: never;
             header?: never;
@@ -30851,7 +30621,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -30961,7 +30731,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -31071,7 +30841,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/log/{:logid}": {
+    "/api/marti/missions/{:guid}/log/{:logid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -31091,7 +30861,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":logid": string;
                 };
@@ -31211,7 +30981,7 @@ export interface paths {
         };
         trace?: never;
     };
-    "/api/marti/missions/{:name}/log/{:log}": {
+    "/api/marti/missions/{:guid}/log/{:log}": {
         parameters: {
             query?: never;
             header?: never;
@@ -31228,7 +30998,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":log": string;
                 };
@@ -31327,7 +31097,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}": {
+    "/api/marti/missions/{:guid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -31354,7 +31124,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -31546,7 +31316,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -31648,7 +31418,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -32599,7 +32369,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/qr": {
+    "/api/marti/missions/{:guid}/qr": {
         parameters: {
             query?: never;
             header?: never;
@@ -32613,7 +32383,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -32706,7 +32476,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/changes": {
+    "/api/marti/missions/{:guid}/changes": {
         parameters: {
             query?: never;
             header?: never;
@@ -32729,7 +32499,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33298,7 +33068,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/archive": {
+    "/api/marti/missions/{:guid}/archive": {
         parameters: {
             query?: never;
             header?: never;
@@ -33317,7 +33087,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33410,7 +33180,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/role": {
+    "/api/marti/missions/{:guid}/role": {
         parameters: {
             query?: never;
             header?: never;
@@ -33424,7 +33194,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33522,7 +33292,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33629,7 +33399,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/subscriptions": {
+    "/api/marti/missions/{:guid}/subscriptions": {
         parameters: {
             query?: never;
             header?: never;
@@ -33643,7 +33413,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33744,7 +33514,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/subscriptions/roles": {
+    "/api/marti/missions/{:guid}/subscriptions/roles": {
         parameters: {
             query?: never;
             header?: never;
@@ -33758,7 +33528,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33869,7 +33639,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/contacts": {
+    "/api/marti/missions/{:guid}/contacts": {
         parameters: {
             query?: never;
             header?: never;
@@ -33883,7 +33653,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -33986,7 +33756,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/upload": {
+    "/api/marti/missions/{:guid}/upload": {
         parameters: {
             query?: never;
             header?: never;
@@ -34001,7 +33771,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -34114,7 +33884,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                 };
                 cookie?: never;
             };
@@ -34213,7 +33983,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/marti/missions/{:name}/upload/{:hash}": {
+    "/api/marti/missions/{:guid}/upload/{:hash}": {
         parameters: {
             query?: never;
             header?: never;
@@ -34230,7 +34000,7 @@ export interface paths {
                 header?: never;
                 path: {
                     /** @description No Description */
-                    ":name": string;
+                    ":guid": string;
                     /** @description No Description */
                     ":hash": string;
                 };
@@ -43337,12 +43107,12 @@ export interface paths {
                     "application/json": {
                         longitude: number;
                         latitude: number;
-                        altitude?: number;
-                        accuracy?: number;
-                        altitudeAccuracy?: number;
-                        speed?: number;
-                        bearing?: number;
-                        time?: number;
+                        altitude?: number | null;
+                        accuracy?: number | null;
+                        altitudeAccuracy?: number | null;
+                        speed?: number | null;
+                        bearing?: number | null;
+                        time?: number | null;
                     };
                 };
             };
@@ -43433,7 +43203,119 @@ export interface paths {
                 };
             };
         };
-        post?: never;
+        /**
+         * Submit a live location update for the authenticated user.
+         *                 Identical to the PUT route - native background location services
+         *                 can only POST, and emit null for unavailable optional fields.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        longitude: number;
+                        latitude: number;
+                        altitude?: number | null;
+                        accuracy?: number | null;
+                        altitudeAccuracy?: number | null;
+                        speed?: number | null;
+                        bearing?: number | null;
+                        time?: number | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -46529,124 +46411,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/retention": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Run a retention action */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        action: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            name: string;
-                            status: "success" | "error";
-                            deleted: number;
-                            duration: number;
-                            message?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/server/injector": {
         parameters: {
             query?: never;
@@ -47301,1557 +47065,6 @@ export interface paths {
                 };
             };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/iconset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Iconsets */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    scope?: "server" | "user";
-                    /** @description Limit the number of responses returned. Use 0 to return all results without pagination; otherwise the limit is capped at 1000. */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort: "uid" | "created" | "updated" | "version" | "name" | "username" | "username_internal" | "default_group" | "default_friendly" | "default_hostile" | "default_neutral" | "default_unknown" | "skip_resize" | "spritesheet_data" | "spritesheet_json" | "enableRLS";
-                    /** @description Filter results by a human readable name field */
-                    filter: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                uid: string;
-                                created: string;
-                                updated: string;
-                                version: number;
-                                name: string;
-                                username: null | string;
-                                username_internal: boolean;
-                                default_group: null | string;
-                                default_friendly: null | string;
-                                default_hostile: null | string;
-                                default_neutral: null | string;
-                                default_unknown: null | string;
-                                skip_resize: boolean;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create Iconset */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        uid: string;
-                        version: number;
-                        /** @description Human readable name */
-                        name: string;
-                        /**
-                         * @description If true, the iconset will not be shown in the UI for selection
-                         * @default false
-                         */
-                        internal: boolean;
-                        scope?: "server" | "user";
-                        default_group?: string;
-                        default_friendly?: string;
-                        default_hostile?: string;
-                        default_neutral?: string;
-                        default_unknown?: string;
-                        skip_resize?: boolean;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uid: string;
-                            created: string;
-                            updated: string;
-                            version: number;
-                            name: string;
-                            username: null | string;
-                            username_internal: boolean;
-                            default_group: null | string;
-                            default_friendly: null | string;
-                            default_hostile: null | string;
-                            default_neutral: null | string;
-                            default_unknown: null | string;
-                            skip_resize: boolean;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/iconset/{:iconset}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Iconset */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description No Description */
-                    format?: "json" | "zip";
-                    /** @description No Description */
-                    download?: boolean;
-                    /** @description Resize Images to 32x32px */
-                    resize?: boolean;
-                    /** @description No Description */
-                    token?: string;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uid: string;
-                            created: string;
-                            updated: string;
-                            version: number;
-                            name: string;
-                            username: null | string;
-                            username_internal: boolean;
-                            default_group: null | string;
-                            default_friendly: null | string;
-                            default_hostile: null | string;
-                            default_neutral: null | string;
-                            default_unknown: null | string;
-                            skip_resize: boolean;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Delete Iconset */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update Iconset */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        public?: boolean;
-                        default_group?: string;
-                        default_friendly?: string;
-                        default_hostile?: string;
-                        default_neutral?: string;
-                        default_unknown?: string;
-                        skip_resize?: boolean;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            uid: string;
-                            created: string;
-                            updated: string;
-                            version: number;
-                            name: string;
-                            username: null | string;
-                            username_internal: boolean;
-                            default_group: null | string;
-                            default_friendly: null | string;
-                            default_hostile: null | string;
-                            default_neutral: null | string;
-                            default_unknown: null | string;
-                            skip_resize: boolean;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/iconset/{:iconset}/regen": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Regenerate Iconset Spritesheet */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/iconset/{:iconset}/icon": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create Icon */
-        post: {
-            parameters: {
-                query: {
-                    /** @description Regenerate Iconset spritesheet after upload */
-                    regen: boolean;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @description Human readable name */
-                        name: string;
-                        data: string;
-                        type2525b?: null | string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            created: string;
-                            updated: string;
-                            name: string;
-                            format: string;
-                            iconset: string;
-                            type2525b: string | null;
-                            data: string;
-                            path: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/icon": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Icons */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    scope?: "server" | "user";
-                    /** @description Limit the number of responses returned. Use 0 to return all results without pagination; otherwise the limit is capped at 1000. */
-                    limit: number;
-                    /** @description Iterate through "pages" of items based on the "limit" query param */
-                    page: number;
-                    /** @description Order in which results are returned based on the "sort" query param */
-                    order: "asc" | "desc";
-                    /** @description No Description */
-                    sort?: "id" | "created" | "updated" | "name" | "format" | "iconset" | "type2525b" | "data" | "path" | "enableRLS";
-                    /** @description No Description */
-                    iconset?: string;
-                    /** @description Filter results by a human readable name field */
-                    filter: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                id: number;
-                                created: string;
-                                updated: string;
-                                name: string;
-                                format: string;
-                                iconset: string;
-                                type2525b: string | null;
-                                data: string;
-                                path: string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/iconset/{:iconset}/icon/{:icon}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Icon Metadata */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                    /** @description No Description */
-                    ":icon": number | string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            created: string;
-                            updated: string;
-                            name: string;
-                            format: string;
-                            iconset: string;
-                            type2525b: string | null;
-                            data: string;
-                            path: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /** Remove Icon from Iconset */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                    /** @description No Description */
-                    ":icon": number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Update Icon in Iconset */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                    /** @description No Description */
-                    ":icon": number;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        name?: string;
-                        data?: string;
-                        type2525b?: null | string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: number;
-                            created: string;
-                            updated: string;
-                            name: string;
-                            format: string;
-                            iconset: string;
-                            type2525b: string | null;
-                            data: string;
-                            path: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/api/iconset/{:iconset}/sprite{:size}.json": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Spriteset JSON for CoT types */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description No Description */
-                    scope?: "server" | "user";
-                    /** @description No Description */
-                    token?: string;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                    /** @description No Description */
-                    ":size": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": unknown;
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/iconset/{:iconset}/sprite{:size}.png": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Return a sprite sheet for CoT Types */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description No Description */
-                    token?: string;
-                };
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":iconset": string;
-                    /** @description No Description */
-                    ":size": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -50482,494 +48695,6 @@ export interface paths {
                     content: {
                         "application/json": {
                             body: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/type/cot": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Type */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    filter: string;
-                    /** @description No Description */
-                    domain?: "a" | "b" | "r" | "t" | "c" | "y";
-                    /** @description No Description */
-                    identity: "p" | "u" | "a" | "f" | "n" | "s" | "h" | "j" | "k" | "o";
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            items: {
-                                cot: string;
-                                desc: string;
-                                full?: string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/type/2525e": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List 2525E Symbol Sets & Symbols - returned SIDCs can be used on the Feature `type` property
-         *
-         *                 Symbols are hierarchical: Symbol Set => Entity => Entity Type => Entity Subtype
-         *                 When no filter is provided and a symbolset is given, only top-level Entities are returned -
-         *                 pass an Entity Code as `parent` to descend into its Entity Types / Subtypes.
-         *                 When a filter is provided a flat search across all Symbols is performed.
-         */
-        get: {
-            parameters: {
-                query: {
-                    /** @description No Description */
-                    filter: string;
-                    /** @description No Description */
-                    identity: "p" | "u" | "a" | "f" | "n" | "s" | "h" | "j" | "k" | "o";
-                    /** @description No Description */
-                    symbolset?: string;
-                    /** @description 6 digit Entity Code to list the children of - requires symbolset */
-                    parent?: string;
-                    /** @description Limit the number of responses returned */
-                    limit: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            total: number;
-                            symbolsets: {
-                                id: string;
-                                name: string;
-                            }[];
-                            items: {
-                                sidc: string;
-                                name: string;
-                                /** @description The most specific level of the Symbol name - ie the Entity Subtype name */
-                                title: string;
-                                remarks: string;
-                                symbolset: string;
-                                children: number;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/type/2525e/{:sidc}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get metadata for a given 2525D/2525E Numeric SIDC */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":sidc": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            sidc: string;
-                            name: string;
-                            remarks: string;
-                            symbolset: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-                /** @description Error Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            status: number;
-                            message: string;
-                            /** @description Extended error details (ie: TAK Server exception trace) */
-                            details?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/type/cot/{:type}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Type */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description No Description */
-                    ":type": string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successful Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            cot: string;
-                            desc: string;
-                            full?: string;
                         };
                     };
                 };
@@ -52950,6 +50675,2393 @@ export interface paths {
                             };
                         };
                     };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/retention": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run a retention action */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        action: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            name: string;
+                            status: "success" | "error";
+                            deleted: number;
+                            duration: number;
+                            message?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/type/cot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Type */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    filter: string;
+                    /** @description No Description */
+                    domain?: "a" | "b" | "r" | "t" | "c" | "y";
+                    /** @description No Description */
+                    identity: "p" | "u" | "a" | "f" | "n" | "s" | "h" | "j" | "k" | "o";
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                cot: string;
+                                desc: string;
+                                full?: string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/type/2525e": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List 2525E Symbol Sets & Symbols - returned SIDCs can be used on the Feature `type` property
+         *
+         *                 Symbols are hierarchical: Symbol Set => Entity => Entity Type => Entity Subtype
+         *                 When no filter is provided and a symbolset is given, only top-level Entities are returned -
+         *                 pass an Entity Code as `parent` to descend into its Entity Types / Subtypes.
+         *                 When a filter is provided a flat search across all Symbols is performed.
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    filter: string;
+                    /** @description No Description */
+                    identity: "p" | "u" | "a" | "f" | "n" | "s" | "h" | "j" | "k" | "o";
+                    /** @description No Description */
+                    symbolset?: string;
+                    /** @description 6 digit Entity Code to list the children of - requires symbolset */
+                    parent?: string;
+                    /** @description Limit the number of responses returned */
+                    limit: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            symbolsets: {
+                                id: string;
+                                name: string;
+                            }[];
+                            items: {
+                                sidc: string;
+                                name: string;
+                                /** @description The most specific level of the Symbol name - ie the Entity Subtype name */
+                                title: string;
+                                remarks: string;
+                                symbolset: string;
+                                children: number;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/type/2525e/{:sidc}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get metadata for a given 2525D/2525E Numeric SIDC */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":sidc": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sidc: string;
+                            name: string;
+                            remarks: string;
+                            symbolset: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/type/cot/{:type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Type */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":type": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            cot: string;
+                            desc: string;
+                            full?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/manifest.webmanifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return the Web Manifest for PWA Use */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            name: string;
+                            short_name: string;
+                            description: string;
+                            start_url: string;
+                            display: string;
+                            background_color: string;
+                            theme_color: string;
+                            lang: string;
+                            scope: string;
+                            icons: {
+                                src: string;
+                                sizes: string;
+                                type: string;
+                            }[];
+                            orientation: string;
+                            categories: string[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/manifest.webmanifest/logos/{:size}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return a resized PNG logo for PWA use */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Logo size in pixels */
+                    ":size": number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/iconset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Iconsets */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    scope?: "server" | "user";
+                    /** @description Limit the number of responses returned. Use 0 to return all results without pagination; otherwise the limit is capped at 1000. */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort: "uid" | "created" | "updated" | "version" | "name" | "username" | "username_internal" | "default_group" | "default_friendly" | "default_hostile" | "default_neutral" | "default_unknown" | "skip_resize" | "spritesheet_data" | "spritesheet_json" | "enableRLS";
+                    /** @description Filter results by a human readable name field */
+                    filter: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                uid: string;
+                                created: string;
+                                updated: string;
+                                version: number;
+                                name: string;
+                                username: null | string;
+                                username_internal: boolean;
+                                default_group: null | string;
+                                default_friendly: null | string;
+                                default_hostile: null | string;
+                                default_neutral: null | string;
+                                default_unknown: null | string;
+                                skip_resize: boolean;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create Iconset */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        uid: string;
+                        version: number;
+                        /** @description Human readable name */
+                        name: string;
+                        /**
+                         * @description If true, the iconset will not be shown in the UI for selection
+                         * @default false
+                         */
+                        internal: boolean;
+                        scope?: "server" | "user";
+                        default_group?: string;
+                        default_friendly?: string;
+                        default_hostile?: string;
+                        default_neutral?: string;
+                        default_unknown?: string;
+                        skip_resize?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            uid: string;
+                            created: string;
+                            updated: string;
+                            version: number;
+                            name: string;
+                            username: null | string;
+                            username_internal: boolean;
+                            default_group: null | string;
+                            default_friendly: null | string;
+                            default_hostile: null | string;
+                            default_neutral: null | string;
+                            default_unknown: null | string;
+                            skip_resize: boolean;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/iconset/{:iconset}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Iconset */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description No Description */
+                    format?: "json" | "zip";
+                    /** @description No Description */
+                    download?: boolean;
+                    /** @description Resize Images to 32x32px */
+                    resize?: boolean;
+                    /** @description No Description */
+                    token?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            uid: string;
+                            created: string;
+                            updated: string;
+                            version: number;
+                            name: string;
+                            username: null | string;
+                            username_internal: boolean;
+                            default_group: null | string;
+                            default_friendly: null | string;
+                            default_hostile: null | string;
+                            default_neutral: null | string;
+                            default_unknown: null | string;
+                            skip_resize: boolean;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete Iconset */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update Iconset */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        public?: boolean;
+                        default_group?: string;
+                        default_friendly?: string;
+                        default_hostile?: string;
+                        default_neutral?: string;
+                        default_unknown?: string;
+                        skip_resize?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            uid: string;
+                            created: string;
+                            updated: string;
+                            version: number;
+                            name: string;
+                            username: null | string;
+                            username_internal: boolean;
+                            default_group: null | string;
+                            default_friendly: null | string;
+                            default_hostile: null | string;
+                            default_neutral: null | string;
+                            default_unknown: null | string;
+                            skip_resize: boolean;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/iconset/{:iconset}/regen": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Regenerate Iconset Spritesheet */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/iconset/{:iconset}/icon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Icon */
+        post: {
+            parameters: {
+                query: {
+                    /** @description Regenerate Iconset spritesheet after upload */
+                    regen: boolean;
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Human readable name */
+                        name: string;
+                        data: string;
+                        type2525b?: null | string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            created: string;
+                            updated: string;
+                            name: string;
+                            format: string;
+                            iconset: string;
+                            type2525b: string | null;
+                            data: string;
+                            path: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/icon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Icons */
+        get: {
+            parameters: {
+                query: {
+                    /** @description No Description */
+                    scope?: "server" | "user";
+                    /** @description Limit the number of responses returned. Use 0 to return all results without pagination; otherwise the limit is capped at 1000. */
+                    limit: number;
+                    /** @description Iterate through "pages" of items based on the "limit" query param */
+                    page: number;
+                    /** @description Order in which results are returned based on the "sort" query param */
+                    order: "asc" | "desc";
+                    /** @description No Description */
+                    sort?: "id" | "created" | "updated" | "name" | "format" | "iconset" | "type2525b" | "data" | "path" | "enableRLS";
+                    /** @description No Description */
+                    iconset?: string;
+                    /** @description Filter results by a human readable name field */
+                    filter: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            items: {
+                                id: number;
+                                created: string;
+                                updated: string;
+                                name: string;
+                                format: string;
+                                iconset: string;
+                                type2525b: string | null;
+                                data: string;
+                                path: string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/iconset/{:iconset}/icon/{:icon}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Icon Metadata */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                    /** @description No Description */
+                    ":icon": number | string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            created: string;
+                            updated: string;
+                            name: string;
+                            format: string;
+                            iconset: string;
+                            type2525b: string | null;
+                            data: string;
+                            path: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Remove Icon from Iconset */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                    /** @description No Description */
+                    ":icon": number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update Icon in Iconset */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                    /** @description No Description */
+                    ":icon": number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        data?: string;
+                        type2525b?: null | string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: number;
+                            created: string;
+                            updated: string;
+                            name: string;
+                            format: string;
+                            iconset: string;
+                            type2525b: string | null;
+                            data: string;
+                            path: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/iconset/{:iconset}/sprite{:size}.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Spriteset JSON for CoT types */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description No Description */
+                    scope?: "server" | "user";
+                    /** @description No Description */
+                    token?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                    /** @description No Description */
+                    ":size": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+                /** @description Error Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+                /** @description Error Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: number;
+                            message: string;
+                            /** @description Extended error details (ie: TAK Server exception trace) */
+                            details?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/iconset/{:iconset}/sprite{:size}.png": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return a sprite sheet for CoT Types */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description No Description */
+                    token?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description No Description */
+                    ":iconset": string;
+                    /** @description No Description */
+                    ":size": string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
                 /** @description Error Response */
                 400: {

--- a/api/stateless/routes/marti-mission-layers.ts
+++ b/api/stateless/routes/marti-mission-layers.ts
@@ -17,11 +17,11 @@ import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 export default async function router(schema: Schema, config: ConfigStateless) {
     const profileControl = new ProfileControl(config);
 
-    await schema.get('/marti/missions/:name/layer', {
+    await schema.get('/marti/missions/:guid/layer', {
         name: 'List Layers',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Helper API list mission layers',
         res: TAKList(MissionLayer),
@@ -34,10 +34,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const list = await api.MissionLayer.list(
-                req.params.name,
+                req.params.guid,
                 opts,
             );
 
@@ -47,11 +47,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/layer/:layerid', {
+    await schema.get('/marti/missions/:guid/layer/:layerid', {
         name: 'Get Layer',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             layerid: Type.String(),
         }),
         description: 'Helper API to get mission layer',
@@ -65,10 +65,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const layer = await api.MissionLayer.get(
-                req.params.name,
+                req.params.guid,
                 req.params.layerid,
                 opts,
             );
@@ -79,11 +79,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.post('/marti/missions/:name/layer', {
+    await schema.post('/marti/missions/:guid/layer', {
         name: 'Create Layer',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         body: Type.Object({
             name: Default.NameField,
@@ -103,10 +103,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const create = await api.MissionLayer.create(
-                req.params.name,
+                req.params.guid,
                 {
                     ...req.body,
                     creatorUid: user.email,
@@ -120,11 +120,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.put('/marti/missions/:name/layer/:uid/cot', {
+    await schema.put('/marti/missions/:guid/layer/:uid/cot', {
         name: 'Attach Layer CoTs',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             uid: Type.String(),
         }),
         body: Type.Object({
@@ -141,10 +141,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.MissionLayer.attachUids(
-                req.params.name,
+                req.params.guid,
                 req.params.uid,
                 {
                     uids: req.body.uids,
@@ -162,11 +162,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.delete('/marti/missions/:name/layer/:uid/cot/:cotuid', {
+    await schema.delete('/marti/missions/:guid/layer/:uid/cot/:cotuid', {
         name: 'Detach Layer CoT',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             uid: Type.String(),
             cotuid: Type.String(),
         }),
@@ -181,10 +181,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.MissionLayer.setParent(
-                req.params.name,
+                req.params.guid,
                 {
                     layerUids: [req.params.cotuid],
                     creatorUid: user.email,
@@ -201,11 +201,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.patch('/marti/missions/:name/layer/:uid', {
+    await schema.patch('/marti/missions/:guid/layer/:uid', {
         name: 'Update Layer',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             uid: Type.String(),
         }),
         body: Type.Object({
@@ -223,10 +223,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
             if (req.body.name) {
                 const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                     ? { token: String(req.headers['missionauthorization']) }
-                    : await profileControl.subscription(user.email, req.params.name);
+                    : await profileControl.subscription(user.email, req.params.guid);
 
                 await api.MissionLayer.rename(
-                    req.params.name,
+                    req.params.guid,
                     req.params.uid,
                     {
                         name: req.body.name,
@@ -245,11 +245,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.delete('/marti/missions/:name/layer/:uid', {
+    await schema.delete('/marti/missions/:guid/layer/:uid', {
         name: 'Delete Layer',
         group: 'MartiMissionLayer',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             uid: Type.String(),
         }),
         description: 'Helper API to delete mission layers',
@@ -263,10 +263,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.MissionLayer.delete(
-                req.params.name,
+                req.params.guid,
                 {
                     uid: [req.params.uid],
                     creatorUid: user.email,

--- a/api/stateless/routes/marti-mission-logs.ts
+++ b/api/stateless/routes/marti-mission-logs.ts
@@ -15,11 +15,11 @@ import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 export default async function router(schema: Schema, config: ConfigStateless) {
     const profileControl = new ProfileControl(config);
 
-    await schema.get('/marti/missions/:name/log', {
+    await schema.get('/marti/missions/:guid/log', {
         name: 'List Logs',
         group: 'MartiMissionLog',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         query: Type.Object({
             format: Type.String({
@@ -47,10 +47,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const mission = await api.Mission.get(
-                req.params.name,
+                req.params.guid,
                 {
                     logs: true,
                 },
@@ -60,7 +60,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
             if (req.query.format === 'csv') {
                 res.setHeader('Content-Type', 'text/csv');
                 if (req.query.download) {
-                    res.setHeader('Content-Disposition', `attachment; filename="mission-${req.params.name}-logs.csv"`);
+                    res.setHeader('Content-Disposition', `attachment; filename="mission-${mission.name}-logs.csv"`);
                 }
 
                 const headers = ['id', 'dtg', 'creatorUid', 'content', 'keywords'];
@@ -81,7 +81,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                 res.end();
             } else {
                 if (req.query.download) {
-                    res.setHeader('Content-Disposition', `attachment; filename="mission-${req.params.name}-logs.json"`);
+                    res.setHeader('Content-Disposition', `attachment; filename="mission-${mission.name}-logs.json"`);
                 }
 
                 res.json({
@@ -94,11 +94,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.post('/marti/missions/:name/log', {
+    await schema.post('/marti/missions/:guid/log', {
         name: 'Create Log',
         group: 'MartiMissionLog',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Helper API to add a log to a mission',
         body: Type.Object({
@@ -119,10 +119,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const log = await api.MissionLog.create(
-                req.params.name,
+                req.params.guid,
                 {
                     creatorUid: creatorUid,
                     dtg: req.body.dtg ?? new Date().toISOString(),
@@ -138,11 +138,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.patch('/marti/missions/:name/log/:logid', {
+    await schema.patch('/marti/missions/:guid/log/:logid', {
         name: 'Update Log',
         group: 'MartiMissionLog',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             logid: Type.String(),
         }),
         description: 'Helper API to update a log on a mission',
@@ -166,10 +166,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const mission = await api.MissionLog.update(
-                req.params.name,
+                req.params.guid,
                 {
                     id: req.params.logid,
                     dtg: req.body.dtg,
@@ -186,11 +186,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.delete('/marti/missions/:name/log/:log', {
+    await schema.delete('/marti/missions/:guid/log/:log', {
         name: 'Delete Log',
         group: 'MartiMissionLog',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             log: Type.String(),
         }),
         description: 'Helper API to delete a log',
@@ -204,7 +204,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.MissionLog.delete(
                 req.params.log,

--- a/api/stateless/routes/marti-mission.ts
+++ b/api/stateless/routes/marti-mission.ts
@@ -31,11 +31,11 @@ import { TAKAPI, APIAuthCertificate } from '@tak-ps/node-tak';
 export default async function router(schema: Schema, config: ConfigStateless) {
     const profileControl = new ProfileControl(config);
 
-    await schema.get('/marti/missions/:name', {
+    await schema.get('/marti/missions/:guid', {
         name: 'Get Mission',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Helper API to get a single mission',
         query: Type.Object({
@@ -61,10 +61,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const mission = await api.Mission.get(
-                req.params.name,
+                req.params.guid,
                 req.query,
                 opts,
             );
@@ -162,11 +162,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/qr', {
+    await schema.get('/marti/missions/:guid/qr', {
         name: 'Mission QR',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Return an SVG of a QR Code for a mission',
     }, async (req, res) => {
@@ -177,10 +177,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const mission = await api.Mission.get(
-                req.params.name,
+                req.params.guid,
                 {},
                 opts,
             );
@@ -199,11 +199,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/changes', {
+    await schema.get('/marti/missions/:guid/changes', {
         name: 'Mission Changes',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Helper API to get mission changes',
         query: MissionChangesInput,
@@ -216,10 +216,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const changes = await api.Mission.changes(
-                req.params.name,
+                req.params.guid,
                 req.query,
                 opts,
             );
@@ -230,11 +230,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.delete('/marti/missions/:name', {
+    await schema.delete('/marti/missions/:guid', {
         name: 'Mission Delete',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Helper API to delete a single mission',
         query: MissionDeleteInput,
@@ -247,10 +247,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const mission = await api.Mission.delete(
-                req.params.name,
+                req.params.guid,
                 req.query,
                 opts,
             );
@@ -284,12 +284,12 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.patch('/marti/missions/:name', {
+    await schema.patch('/marti/missions/:guid', {
         name: 'Update Mission',
         group: 'MartiMissions',
         description: 'Helper API to create a mission',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         body: Type.Object({
             description: Type.Optional(Type.String()),
@@ -307,12 +307,12 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const { groups, ...rest } = req.body;
 
             const mission = await api.Mission.update(
-                req.params.name,
+                req.params.guid,
                 {
                     ...rest,
                     ...(groups !== undefined ? { group: groups } : {}),
@@ -392,11 +392,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/archive', {
+    await schema.get('/marti/missions/:guid/archive', {
         name: 'Mission Archive',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         query: Type.Object({
             format: Type.String({
@@ -418,15 +418,15 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             if (req.query.download) {
-                res.setHeader('Content-Disposition', `attachment; filename="${req.params.name}.${req.query.format}"`);
+                res.setHeader('Content-Disposition', `attachment; filename="${req.params.guid}.${req.query.format}"`);
             }
 
             if (req.query.format === 'zip') {
                 const archive = await api.Mission.getArchive(
-                    req.params.name,
+                    req.params.guid,
                     opts,
                 );
 
@@ -436,11 +436,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
             } else if (['geojson', 'kml'].includes(req.query.format)) {
                 const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                     ? { token: String(req.headers['missionauthorization']) }
-                    : await profileControl.subscription(user.email, req.params.name);
+                    : await profileControl.subscription(user.email, req.params.guid);
 
                 const fc = {
                     type: 'FeatureCollection',
-                    features: (await api.Mission.latestFeats(req.params.name, opts)).features,
+                    features: (await api.Mission.latestFeats(req.params.guid, opts)).features,
                 };
 
                 if (req.query.format === 'geojson') {
@@ -454,7 +454,7 @@ export default async function router(schema: Schema, config: ConfigStateless) {
                     res.set('Content-Type', 'application/vnd.google-earth.kml+xml');
 
                     const output = Buffer.from(tokml(fc, {
-                        documentName: req.params.name,
+                        documentName: req.params.guid,
                         documentDescription: 'Exported from CloudTAK',
                         simplestyle: true,
                         name: 'callsign',
@@ -473,11 +473,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/role', {
+    await schema.get('/marti/missions/:guid/role', {
         name: 'Mission Role',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Return a role associated with your user',
         res: MissionRole,
@@ -489,10 +489,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const role = await api.Mission.role(
-                req.params.name,
+                req.params.guid,
                 opts,
             );
 
@@ -502,11 +502,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/subscriptions', {
+    await schema.get('/marti/missions/:guid/subscriptions', {
         name: 'Mission Subscriptions',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'List subscriptions associated with a mission',
         res: GenericMartiResponse,
@@ -518,10 +518,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const subs = await api.Mission.subscriptions(
-                req.params.name,
+                req.params.guid,
                 opts,
             );
 
@@ -531,11 +531,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/subscriptions/roles', {
+    await schema.get('/marti/missions/:guid/subscriptions/roles', {
         name: 'Mission Subscriptions',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'List subscriptions associated with a mission',
         res: TAKList(MissionSubscriber),
@@ -547,10 +547,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const roles = await api.Mission.subscriptionRoles(
-                req.params.name,
+                req.params.guid,
                 opts,
             );
 
@@ -560,11 +560,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.put('/marti/missions/:name/role', {
+    await schema.put('/marti/missions/:guid/role', {
         name: 'Set Mission Role',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Change the role of an existing mission subscriber',
         body: Type.Object({
@@ -581,10 +581,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.Mission.setRole(
-                req.params.name,
+                req.params.guid,
                 {
                     clientUid: req.body.clientUid,
                     username: req.body.username,
@@ -602,11 +602,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.get('/marti/missions/:name/contacts', {
+    await schema.get('/marti/missions/:guid/contacts', {
         name: 'Mission Contacts',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'List contacts associated with a mission',
         res: Type.Array(Type.Object({
@@ -626,10 +626,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const missions = await api.Mission.contacts(
-                req.params.name,
+                req.params.guid,
                 opts,
             );
 
@@ -639,11 +639,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.put('/marti/missions/:name/upload', {
+    await schema.put('/marti/missions/:guid/upload', {
         name: 'Mission Attach',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Attach via upload',
         body: Type.Object({
@@ -685,10 +685,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             await api.Mission.attachContents(
-                req.params.name,
+                req.params.guid,
                 {
                     hashes: contents,
                 },
@@ -704,11 +704,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.post('/marti/missions/:name/upload', {
+    await schema.post('/marti/missions/:guid/upload', {
         name: 'Mission Upload',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
         }),
         description: 'Create an upload',
         query: Type.Object({
@@ -741,10 +741,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const missionContent = await api.Mission.attachContents(
-                req.params.name,
+                req.params.guid,
                 {
                     hashes: [content.Hash],
                 },
@@ -757,11 +757,11 @@ export default async function router(schema: Schema, config: ConfigStateless) {
         }
     });
 
-    await schema.delete('/marti/missions/:name/upload/:hash', {
+    await schema.delete('/marti/missions/:guid/upload/:hash', {
         name: 'Mission Upload Delete',
         group: 'MartiMissions',
         params: Type.Object({
-            name: Type.String(),
+            guid: Type.String(),
             hash: Type.String(),
         }),
         description: 'Delete an upload by hash',
@@ -776,10 +776,10 @@ export default async function router(schema: Schema, config: ConfigStateless) {
 
             const opts: Static<typeof MissionOptions> = req.headers['missionauthorization']
                 ? { token: String(req.headers['missionauthorization']) }
-                : await profileControl.subscription(user.email, req.params.name);
+                : await profileControl.subscription(user.email, req.params.guid);
 
             const missionContent = await api.Mission.detachContents(
-                req.params.name,
+                req.params.guid,
                 {
                     hash: req.params.hash,
                 },

--- a/api/test/fixtures/get_schema.json
+++ b/api/test/fixtures/get_schema.json
@@ -844,62 +844,62 @@
         "query": true,
         "res": false
     },
-    "GET /marti/missions/:name/layer": {
+    "GET /marti/missions/:guid/layer": {
         "body": false,
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name/layer/:layerid": {
+    "GET /marti/missions/:guid/layer/:layerid": {
         "body": false,
         "query": false,
         "res": true
     },
-    "POST /marti/missions/:name/layer": {
+    "POST /marti/missions/:guid/layer": {
         "body": true,
         "query": false,
         "res": true
     },
-    "PUT /marti/missions/:name/layer/:uid/cot": {
+    "PUT /marti/missions/:guid/layer/:uid/cot": {
         "body": true,
         "query": false,
         "res": true
     },
-    "DELETE /marti/missions/:name/layer/:uid/cot/:cotuid": {
+    "DELETE /marti/missions/:guid/layer/:uid/cot/:cotuid": {
         "body": false,
         "query": false,
         "res": true
     },
-    "PATCH /marti/missions/:name/layer/:uid": {
+    "PATCH /marti/missions/:guid/layer/:uid": {
         "body": true,
         "query": false,
         "res": true
     },
-    "DELETE /marti/missions/:name/layer/:uid": {
+    "DELETE /marti/missions/:guid/layer/:uid": {
         "body": false,
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name/log": {
+    "GET /marti/missions/:guid/log": {
         "body": false,
         "query": true,
         "res": true
     },
-    "POST /marti/missions/:name/log": {
+    "POST /marti/missions/:guid/log": {
         "body": true,
         "query": false,
         "res": true
     },
-    "PATCH /marti/missions/:name/log/:logid": {
+    "PATCH /marti/missions/:guid/log/:logid": {
         "body": true,
         "query": false,
         "res": true
     },
-    "DELETE /marti/missions/:name/log/:log": {
+    "DELETE /marti/missions/:guid/log/:log": {
         "body": false,
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name": {
+    "GET /marti/missions/:guid": {
         "body": false,
         "query": true,
         "res": true
@@ -914,17 +914,17 @@
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name/qr": {
+    "GET /marti/missions/:guid/qr": {
         "body": false,
         "query": false,
         "res": false
     },
-    "GET /marti/missions/:name/changes": {
+    "GET /marti/missions/:guid/changes": {
         "body": false,
         "query": true,
         "res": true
     },
-    "DELETE /marti/missions/:name": {
+    "DELETE /marti/missions/:guid": {
         "body": false,
         "query": true,
         "res": true
@@ -934,7 +934,7 @@
         "query": false,
         "res": true
     },
-    "PATCH /marti/missions/:name": {
+    "PATCH /marti/missions/:guid": {
         "body": true,
         "query": false,
         "res": true
@@ -944,47 +944,47 @@
         "query": true,
         "res": true
     },
-    "GET /marti/missions/:name/archive": {
+    "GET /marti/missions/:guid/archive": {
         "body": false,
         "query": true,
         "res": false
     },
-    "GET /marti/missions/:name/role": {
+    "GET /marti/missions/:guid/role": {
         "body": false,
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name/subscriptions": {
+    "GET /marti/missions/:guid/subscriptions": {
         "body": false,
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name/subscriptions/roles": {
+    "GET /marti/missions/:guid/subscriptions/roles": {
         "body": false,
         "query": false,
         "res": true
     },
-    "PUT /marti/missions/:name/role": {
+    "PUT /marti/missions/:guid/role": {
         "body": true,
         "query": false,
         "res": true
     },
-    "GET /marti/missions/:name/contacts": {
+    "GET /marti/missions/:guid/contacts": {
         "body": false,
         "query": false,
         "res": true
     },
-    "PUT /marti/missions/:name/upload": {
+    "PUT /marti/missions/:guid/upload": {
         "body": true,
         "query": false,
         "res": true
     },
-    "POST /marti/missions/:name/upload": {
+    "POST /marti/missions/:guid/upload": {
         "body": false,
         "query": true,
         "res": true
     },
-    "DELETE /marti/missions/:name/upload/:hash": {
+    "DELETE /marti/missions/:guid/upload/:hash": {
         "body": false,
         "query": false,
         "res": true

--- a/api/test/marti-mission-layer-cot.srv.test.ts
+++ b/api/test/marti-mission-layer-cot.srv.test.ts
@@ -18,7 +18,7 @@ async function readBody(request: IncomingMessage): Promise<string> {
     return Buffer.concat(chunks).toString();
 }
 
-test('PUT: api/marti/missions/:name/layer/:uid/cot - Attach CoTs to Layer', async () => {
+test('PUT: api/marti/missions/:guid/layer/:uid/cot - Attach CoTs to Layer', async () => {
     let capturedBody: unknown;
     let creatorUid: string | null = null;
 
@@ -69,7 +69,7 @@ test('PUT: api/marti/missions/:name/layer/:uid/cot - Attach CoTs to Layer', asyn
     flight.tak.reset();
 });
 
-test('DELETE: api/marti/missions/:name/layer/:uid/cot/:cotuid - Detach CoT from Layer', async () => {
+test('DELETE: api/marti/missions/:guid/layer/:uid/cot/:cotuid - Detach CoT from Layer', async () => {
     let layerUids: string[] = [];
     let parentUid: string | null = null;
     let creatorUid: string | null = null;

--- a/api/test/marti-mission.srv.test.ts
+++ b/api/test/marti-mission.srv.test.ts
@@ -249,7 +249,7 @@ test('GET: api/marti/mission - Filter Groups', async () => {
     flight.tak.reset();
 });
 
-test('PATCH: api/marti/missions/:name - returns refreshed groups after update', async () => {
+test('PATCH: api/marti/missions/:guid - returns refreshed groups after update', async () => {
     let postedGroups: string[] = [];
     let missionAuthorization: string | undefined;
     let allowGroupChange: string | null = null;
@@ -264,6 +264,7 @@ test('PATCH: api/marti/missions/:name - returns refreshed groups after update', 
             && (
                 url.pathname === '/Marti/api/missions/Test%20Mission'
                 || url.pathname === '/Marti/api/missions/test-mission-guid'
+                || url.pathname === '/Marti/api/missions/guid/9d2b7a6e-3c4f-4e8a-9b1d-2f6a8c0e4b71'
             )
         ) {
             response.setHeader('Content-Type', 'application/json');
@@ -324,7 +325,7 @@ test('PATCH: api/marti/missions/:name - returns refreshed groups after update', 
     });
 
     try {
-        const res = await flight.fetch('/api/marti/missions/Test Mission', {
+        const res = await flight.fetch('/api/marti/missions/9d2b7a6e-3c4f-4e8a-9b1d-2f6a8c0e4b71', {
             method: 'PATCH',
             auth: {
                 bearer: flight.token.admin,

--- a/api/web/src/base/subscription-changes.ts
+++ b/api/web/src/base/subscription-changes.ts
@@ -31,8 +31,8 @@ export default class SubscriptionChanges {
     }
 
     async refresh(): Promise<void> {
-        const { data, error } = await server.GET('/api/marti/missions/{:name}/changes', {
-            params: { path: { ':name': this.guid } },
+        const { data, error } = await server.GET('/api/marti/missions/{:guid}/changes', {
+            params: { path: { ':guid': this.guid } },
             headers: this.headers()
         });
 

--- a/api/web/src/base/subscription-contents.ts
+++ b/api/web/src/base/subscription-contents.ts
@@ -61,8 +61,8 @@ export default class SubscriptionContents {
      * Delete/detach a content entry from the mission and remove it from the local database
      */
     async delete(hash: string): Promise<void> {
-        await server.DELETE('/api/marti/missions/{:name}/upload/{:hash}', {
-            params: { path: { ':name': this.guid, ':hash': hash } },
+        await server.DELETE('/api/marti/missions/{:guid}/upload/{:hash}', {
+            params: { path: { ':guid': this.guid, ':hash': hash } },
             headers: this.headers(),
         });
 

--- a/api/web/src/base/subscription-layer.ts
+++ b/api/web/src/base/subscription-layer.ts
@@ -74,9 +74,9 @@ export default class SubscriptionLayer {
      * in the local Dexie store.
      */
     async refresh(): Promise<void> {
-        const { data, error } = await server.GET('/api/marti/missions/{:name}/layer', {
+        const { data, error } = await server.GET('/api/marti/missions/{:guid}/layer', {
             params: {
-                path: { ':name': this.parent.guid }
+                path: { ':guid': this.parent.guid }
             },
             headers: this.headers()
         });
@@ -136,9 +136,9 @@ export default class SubscriptionLayer {
     async create(
         layer: MissionLayer_Create
     ): Promise<MissionLayer> {
-        const { data, error } = await server.POST('/api/marti/missions/{:name}/layer', {
+        const { data, error } = await server.POST('/api/marti/missions/{:guid}/layer', {
             params: {
-                path: { ':name': this.parent.guid }
+                path: { ':guid': this.parent.guid }
             },
             headers: this.headers(),
             body: layer
@@ -158,9 +158,9 @@ export default class SubscriptionLayer {
         layerid: string,
         layer: MissionLayer_Update
     ): Promise<MissionLayer> {
-        const { data, error } = await server.PATCH('/api/marti/missions/{:name}/layer/{:uid}', {
+        const { data, error } = await server.PATCH('/api/marti/missions/{:guid}/layer/{:uid}', {
             params: {
-                path: { ':name': this.parent.guid, ':uid': layerid }
+                path: { ':guid': this.parent.guid, ':uid': layerid }
             },
             headers: this.headers(),
             body: layer
@@ -202,9 +202,9 @@ export default class SubscriptionLayer {
             }
         });
 
-        const { error } = await server.PUT('/api/marti/missions/{:name}/layer/{:uid}/cot', {
+        const { error } = await server.PUT('/api/marti/missions/{:guid}/layer/{:uid}/cot', {
             params: {
-                path: { ':name': this.parent.guid, ':uid': layeruid }
+                path: { ':guid': this.parent.guid, ':uid': layeruid }
             },
             headers: this.headers(),
             body: { uids }
@@ -233,9 +233,9 @@ export default class SubscriptionLayer {
             }
         });
 
-        const { error } = await server.DELETE('/api/marti/missions/{:name}/layer/{:uid}/cot/{:cotuid}', {
+        const { error } = await server.DELETE('/api/marti/missions/{:guid}/layer/{:uid}/cot/{:cotuid}', {
             params: {
-                path: { ':name': this.parent.guid, ':uid': layeruid, ':cotuid': uid }
+                path: { ':guid': this.parent.guid, ':uid': layeruid, ':cotuid': uid }
             },
             headers: this.headers()
         });
@@ -252,9 +252,9 @@ export default class SubscriptionLayer {
     async delete(
         layeruid: string
     ): Promise<void> {
-        const { error, response } = await server.DELETE('/api/marti/missions/{:name}/layer/{:uid}', {
+        const { error, response } = await server.DELETE('/api/marti/missions/{:guid}/layer/{:uid}', {
             params: {
-                path: { ':name': this.parent.guid, ':uid': layeruid }
+                path: { ':guid': this.parent.guid, ':uid': layeruid }
             },
             headers: this.headers()
         });

--- a/api/web/src/base/subscription-log.ts
+++ b/api/web/src/base/subscription-log.ts
@@ -32,8 +32,8 @@ export default class SubscriptionLog {
     }
 
     async refresh(): Promise<void> {
-        const { data, error } = await server.GET('/api/marti/missions/{:name}/log', {
-            params: { path: { ':name': this.guid }, query: { format: 'json' as const, download: false } },
+        const { data, error } = await server.GET('/api/marti/missions/{:guid}/log', {
+            params: { path: { ':guid': this.guid }, query: { format: 'json' as const, download: false } },
             headers: this.headers()
         });
 
@@ -110,8 +110,8 @@ export default class SubscriptionLog {
             keywords?: Array<string>;
         }
     ): Promise<MissionLog> {
-        const { data, error } = await server.POST('/api/marti/missions/{:name}/log', {
-            params: { path: { ':name': this.guid } },
+        const { data, error } = await server.POST('/api/marti/missions/{:guid}/log', {
+            params: { path: { ':guid': this.guid } },
             headers: this.headers(),
             body: body
         });
@@ -146,8 +146,8 @@ export default class SubscriptionLog {
             keywords?: Array<string>;
         },
     ): Promise<MissionLog> {
-        const { data, error } = await server.PATCH('/api/marti/missions/{:name}/log/{:logid}', {
-            params: { path: { ':name': this.guid, ':logid': logid } },
+        const { data, error } = await server.PATCH('/api/marti/missions/{:guid}/log/{:logid}', {
+            params: { path: { ':guid': this.guid, ':logid': logid } },
             headers: this.headers(),
             body: body
         });
@@ -176,8 +176,8 @@ export default class SubscriptionLog {
     async delete(
         logid: string,
     ): Promise<void> {
-        await server.DELETE('/api/marti/missions/{:name}/log/{:log}', {
-            params: { path: { ':name': this.guid, ':log': logid } },
+        await server.DELETE('/api/marti/missions/{:guid}/log/{:log}', {
+            params: { path: { ':guid': this.guid, ':log': logid } },
             headers: this.headers()
         });
 

--- a/api/web/src/base/subscription.ts
+++ b/api/web/src/base/subscription.ts
@@ -184,9 +184,9 @@ export default class Subscription {
         } else {
             if (!opts.subscribed) opts.subscribed = false;
 
-            const { data: mission, error: missionError } = await server.GET('/api/marti/missions/{:name}', {
+            const { data: mission, error: missionError } = await server.GET('/api/marti/missions/{:guid}', {
                 params: {
-                    path: { ':name': guid },
+                    path: { ':guid': guid },
                     query: { changes: false, logs: false }
                 },
                 headers: Subscription.headers(opts.missiontoken)
@@ -194,9 +194,9 @@ export default class Subscription {
 
             if (missionError || !mission) throw new Error('Failed to load mission');
 
-            const { data: role, error: roleError } = await server.GET('/api/marti/missions/{:name}/role', {
+            const { data: role, error: roleError } = await server.GET('/api/marti/missions/{:guid}/role', {
                 params: {
-                    path: { ':name': guid }
+                    path: { ':guid': guid }
                 },
                 headers: Subscription.headers(opts.missiontoken)
             });
@@ -274,9 +274,9 @@ export default class Subscription {
             if (body.keywords !== undefined) patch.keywords = body.keywords;
             if (body.groups !== undefined) patch.groups = body.groups;
 
-            const { data } = await server.PATCH('/api/marti/missions/{:name}', {
+            const { data } = await server.PATCH('/api/marti/missions/{:guid}', {
                 params: {
-                    path: { ':name': this.guid }
+                    path: { ':guid': this.guid }
                 },
                 headers: Subscription.headers(this.missiontoken),
                 body: patch
@@ -302,9 +302,9 @@ export default class Subscription {
     }
 
     async delete(): Promise<void> {
-        const { data, response } = await server.DELETE('/api/marti/missions/{:name}', {
+        const { data, response } = await server.DELETE('/api/marti/missions/{:guid}', {
             params: {
-                path: { ':name': this.guid }
+                path: { ':guid': this.guid }
             },
             headers: Subscription.headers(this.missiontoken)
         });
@@ -375,9 +375,9 @@ export default class Subscription {
     };
 
     async fetch(): Promise<Mission> {
-        const { data, error } = await server.GET('/api/marti/missions/{:name}', {
+        const { data, error } = await server.GET('/api/marti/missions/{:guid}', {
             params: {
-                path: { ':name': this.guid },
+                path: { ':guid': this.guid },
                 query: { changes: false, logs: false }
             },
             headers: Subscription.headers(this.missiontoken)
@@ -497,9 +497,9 @@ export default class Subscription {
     }
 
     async changeRole(sub: { clientUid: string, username: string }, role: MissionRoleType): Promise<void> {
-        const { error } = await server.PUT('/api/marti/missions/{:name}/role', {
+        const { error } = await server.PUT('/api/marti/missions/{:guid}/role', {
             params: {
-                path: { ':name': this.guid }
+                path: { ':guid': this.guid }
             },
             headers: Subscription.headers(this.missiontoken),
             body: {
@@ -551,9 +551,9 @@ export default class Subscription {
     async subscriptions(): Promise<MissionSubscriptions> {
         if (!navigator.onLine) return [];
 
-        const { data, error } = await server.GET('/api/marti/missions/{:name}/subscriptions/roles', {
+        const { data, error } = await server.GET('/api/marti/missions/{:guid}/subscriptions/roles', {
             params: {
-                path: { ':name': this.guid }
+                path: { ':guid': this.guid }
             },
             headers: Subscription.headers(this.missiontoken)
         });

--- a/api/web/src/components/CloudTAK/Menu/MenuMissions.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuMissions.vue
@@ -536,10 +536,10 @@ async function openMission(mission: Mission, usePassword: boolean) {
 }
 
 async function fetchMission(mission: Mission, password?: string): Promise<Mission> {
-    const { data, error } = await server.GET('/api/marti/missions/{:name}', {
+    const { data, error } = await server.GET('/api/marti/missions/{:guid}', {
         params: {
             path: {
-                ':name': mission.guid
+                ':guid': mission.guid
             },
             query: {
                 password,

--- a/api/web/src/components/CloudTAK/util/ShareToMission.vue
+++ b/api/web/src/components/CloudTAK/util/ShareToMission.vue
@@ -197,10 +197,10 @@ async function share(): Promise<void> {
 
     if (props.assets.length) {
         for (const mission of selected.value) {
-            const res = await server.PUT('/api/marti/missions/{:name}/upload', {
+            const res = await server.PUT('/api/marti/missions/{:guid}/upload', {
                 params: {
                     path: {
-                        ':name': mission.name
+                        ':guid': mission.guid
                     }
                 },
                 body: {

--- a/api/web/src/types.ts
+++ b/api/web/src/types.ts
@@ -82,26 +82,26 @@ export type VideoConnectionFeed = paths["/api/marti/video/{:uid}"]["get"]["respo
 export type VideoConnection_Create = paths["/api/marti/video"]["post"]["requestBody"]["content"]["application/json"];
 export type VideoConnectionList = paths["/api/marti/video"]["get"]["responses"]["200"]["content"]["application/json"];
 
-export type Mission = paths["/api/marti/missions/{:name}"]["get"]["responses"]["200"]["content"]["application/json"];
+export type Mission = paths["/api/marti/missions/{:guid}"]["get"]["responses"]["200"]["content"]["application/json"];
 export type Mission_Create = paths["/api/marti/mission"]["post"]["requestBody"]["content"]["application/json"]
 export type MissionList = paths["/api/marti/mission"]["get"]["responses"]["200"]["content"]["application/json"];
 export type MissionInvite = paths["/api/marti/mission"]["get"]["responses"]["200"]["content"]["application/json"]["invites"][0];
 
-export type MissionRole = paths["/api/marti/missions/{:name}/role"]["get"]["responses"]["200"]["content"]["application/json"];
+export type MissionRole = paths["/api/marti/missions/{:guid}/role"]["get"]["responses"]["200"]["content"]["application/json"];
 export type MissionRoleType = MissionRole["type"];
 
-export type MissionLog = paths["/api/marti/missions/{:name}/log/{:logid}"]["patch"]["responses"]["200"]["content"]["application/json"]["data"];
-export type MissionLogList = paths["/api/marti/missions/{:name}/log"]["get"]["responses"]["200"]["content"]["application/json"];
+export type MissionLog = paths["/api/marti/missions/{:guid}/log/{:logid}"]["patch"]["responses"]["200"]["content"]["application/json"]["data"];
+export type MissionLogList = paths["/api/marti/missions/{:guid}/log"]["get"]["responses"]["200"]["content"]["application/json"];
 
-export type MissionLayer = paths["/api/marti/missions/{:name}/layer/{:layerid}"]["get"]["responses"]["200"]["content"]["application/json"]["data"];
-export type MissionLayer_Create = paths["/api/marti/missions/{:name}/layer"]["post"]["requestBody"]["content"]["application/json"];
-export type MissionLayer_Update = paths["/api/marti/missions/{:name}/layer/{:uid}"]["patch"]["requestBody"]["content"]["application/json"];
-export type MissionLayerList = paths["/api/marti/missions/{:name}/layer"]["get"]["responses"]["200"]["content"]["application/json"];
+export type MissionLayer = paths["/api/marti/missions/{:guid}/layer/{:layerid}"]["get"]["responses"]["200"]["content"]["application/json"]["data"];
+export type MissionLayer_Create = paths["/api/marti/missions/{:guid}/layer"]["post"]["requestBody"]["content"]["application/json"];
+export type MissionLayer_Update = paths["/api/marti/missions/{:guid}/layer/{:uid}"]["patch"]["requestBody"]["content"]["application/json"];
+export type MissionLayerList = paths["/api/marti/missions/{:guid}/layer"]["get"]["responses"]["200"]["content"]["application/json"];
 
-export type MissionChanges = paths["/api/marti/missions/{:name}/changes"]["get"]["responses"]["200"]["content"]["application/json"];
+export type MissionChanges = paths["/api/marti/missions/{:guid}/changes"]["get"]["responses"]["200"]["content"]["application/json"];
 export type MissionChange = MissionChanges["data"][0];
 
-export type MissionSubscriptions = paths["/api/marti/missions/{:name}/subscriptions/roles"]["get"]["responses"]["200"]["content"]["application/json"]["data"];
+export type MissionSubscriptions = paths["/api/marti/missions/{:guid}/subscriptions/roles"]["get"]["responses"]["200"]["content"]["application/json"]["data"];
 
 export type Server_Update = paths["/api/server"]["patch"]["requestBody"]["content"]["application/json"]
 export type Server = paths["/api/server"]["get"]["responses"]["200"]["content"]["application/json"]


### PR DESCRIPTION
### Context

- :rocket: Migrate CloudTAK Mission Sync routes to use a `:guid` parameter instead of `:name`. This is largely a DevRel change and not functional