### PR TITLE
Allow Lasso Select of Mission Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Pending Release
 
+- :tada: Allow Lasso Select to choose a Data Sync in the Layer Selection dropdown and select its features
+
 ### v13.78.1 - 2026-09-03
 
 - :bug: Fix CoT w/ Attachment sharing to Data Sync

--- a/api/web/src/base/overlay.ts
+++ b/api/web/src/base/overlay.ts
@@ -154,7 +154,11 @@ export default class OverlayManager extends BaseInterface {
 
     static queryableOverlayNames(): string[] {
         return this.loaded
-            .filter((overlay) => overlay.actions.feature.includes('query') || overlay.id === -1)
+            .filter((overlay) => {
+                return overlay.id === -1
+                    || (overlay.mode === 'mission' && overlay.mode_id)
+                    || overlay.actions.feature.includes('query');
+            })
             .map((overlay) => overlay.name);
     }
 

--- a/api/web/src/components/CloudTAK/util/SelectFeats.vue
+++ b/api/web/src/components/CloudTAK/util/SelectFeats.vue
@@ -165,7 +165,9 @@ async function deleteFeatures() {
     loading.value = true;
 
     for (const id of props.selected.keys()) {
-        await mapStore.worker.db.remove(id);
+        await mapStore.worker.db.remove(id, {
+            mission: true
+        });
     }
 
     props.selected.clear()

--- a/api/web/src/stores/modules/draw.ts
+++ b/api/web/src/stores/modules/draw.ts
@@ -351,6 +351,18 @@ export default class DrawTool {
                         const ov = OverlayManager.loadedByName(this.lasso.overlay);
                         if (!ov) throw new Error('Could not find overlay');
 
+                        if (ov.mode === 'mission' && ov.mode_id) {
+                            const touching = await this.mapStore.worker.db.touching(feat.geometry as Polygon, {
+                                mission: ov.mode_id
+                            });
+
+                            for (const cot of touching.values()) {
+                                this.mapStore.selected.set(cot.id, cot);
+                            }
+
+                            return;
+                        }
+
                         this.lasso.loading = true;
 
                         try {

--- a/api/web/src/workers/atlas-database.ts
+++ b/api/web/src/workers/atlas-database.ts
@@ -434,9 +434,44 @@ export default class AtlasDatabase {
      * Return CoTs touching a given polygon
      *
      * @param poly - GeoJSON Polygon to test CoTs against
+     * @param opts.mission - If set, test features from the given Mission GUID instead of the CoT store
      */
-    async touching(poly: Polygon): Promise<Set<COT>> {
+    async touching(
+        poly: Polygon,
+        opts: {
+            mission?: string
+        } = {}
+    ): Promise<Set<COT>> {
         const within: Set<COT> = new Set();
+
+        if (opts.mission) {
+            const sub = await db.subscription.get(opts.mission);
+            if (!sub || !sub.subscribed) return within;
+
+            const feats = await db.subscription_feature
+                .where('mission')
+                .equals(opts.mission)
+                .toArray();
+
+            for (const feat of feats) {
+                const feature: Feature = {
+                    id: feat.id,
+                    type: 'Feature',
+                    path: feat.path,
+                    properties: feat.properties,
+                    geometry: feat.geometry,
+                };
+
+                if (booleanWithin(feature, poly)) {
+                    within.add(await COT.load(feature, {
+                        mode: OriginMode.MISSION,
+                        mode_id: opts.mission
+                    }));
+                }
+            }
+
+            return within;
+        }
 
         for (const cot of this.cots.values()) {
             if (booleanWithin(cot.as_feature(), poly)) {


### PR DESCRIPTION
### Context

- :tada: Allow Lasso Select of Mission Sync Overlays
- :bug: Multi Select Panel now allows deletion of Mission Sync features